### PR TITLE
Fix #17, Use real message types in tables

### DIFF
--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -21,105 +21,67 @@
  * @file
  *   CFS Stored Command (SC) sample RTS table 2
  *
- * @note
- * Note 1: The following source code demonstrates how to create a sample
- *         Stored Command RTS table.  The preferred method for creating
- *         flight versions of RTS tables is to use custom ground system
- *         tools that output the binary table files, skipping this step
- *         altogether.
+ * The following source code demonstrates how to create a sample
+ * Stored Command RTS table using the software defined command structures.
+ * It's also possible to create this table via alternative tools
+ * (ground system) and or system agnostic data definitions (XTCE/EDS/JSON).
  *
- * Note 2: This source file creates a sample RTS table that contains only
- *         the following commands that are scheduled as follows:
+ * This source file creates a sample RTS table that contains only
+ * the following commands that are scheduled as follows:
  *
- *         SC NOOP command, execution time relative to start of RTS = 0
- *         SC NOOP command, execution time relative to prev cmd = 5
- *         SC NOOP command, execution time relative to prev cmd = 5
- *
- * Note 3: The byte following the command code in each command packet
- *         secondary header must contain an 8 bit checksum.  Refer to
- *         the SC Users Guide for information on how to calculate this
- *         checksum.
- *
- * Note 4: If the command length (in bytes) is odd, a pad byte must be added
- *         to the RTS command structure (opt data portion) to ensure the next
- *         command starts on a word (uint16) boundary.
+ * SC NOOP command, execution time relative to start of RTS = 0
+ * SC NOOP command, execution time relative to prev cmd = 5
+ * SC NOOP command, execution time relative to prev cmd = 5
  */
 
 #include "cfe.h"
 #include "cfe_tbl_filedef.h"
-#include "cfe_endian.h"
 
+#include "sc_tbldefs.h"      /* defines SC table headers */
 #include "sc_platform_cfg.h" /* defines table buffer size */
 #include "sc_msgdefs.h"      /* defines SC command code values */
 #include "sc_msgids.h"       /* defines SC packet msg ID's */
+#include "sc_msg.h"          /* defines SC message structures */
 
-/*
-** Execution time for each sample command
-*/
-#define CMD1_TIME 0
-#define CMD2_TIME 5
-#define CMD3_TIME 7
+/* Checksum for each sample command */
+#ifndef SC_NOOP_CKSUM
+#define SC_NOOP_CKSUM (0x8F)
+#endif
 
-/*
-** Create execution time as two 16 bit values
-*/
-#define CMD1_TIME_A ((uint16)((uint32)CMD1_TIME >> 16))
-#define CMD2_TIME_A ((uint16)((uint32)CMD2_TIME >> 16))
-#define CMD3_TIME_A ((uint16)((uint32)CMD3_TIME >> 16))
+/* Custom table structure, modify as needed to add desired commands */
+typedef struct
+{
+    SC_RtsEntryHeader_t hdr1;
+    SC_NoArgsCmd_t      cmd1;
+    SC_RtsEntryHeader_t hdr2;
+    SC_NoArgsCmd_t      cmd2;
+    SC_RtsEntryHeader_t hdr3;
+    SC_NoArgsCmd_t      cmd3;
+} SC_RtsStruct002_t;
 
-#define CMD1_TIME_B ((uint16)((uint32)CMD1_TIME))
-#define CMD2_TIME_B ((uint16)((uint32)CMD2_TIME))
-#define CMD3_TIME_B ((uint16)((uint32)CMD3_TIME))
+/* Define the union to size the table correctly */
+typedef union
+{
+    SC_RtsStruct002_t rts;
+    uint16            buf[SC_RTS_BUFF_SIZE];
+} SC_RtsTable002_t;
 
-/*
-** Calculate checksum for each sample command
-*/
-#define CMD1_XSUM 0x008F
-#define CMD2_XSUM 0x008F
-#define CMD3_XSUM 0x008F
+/* Helper macro to get size of structure elements */
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct002_t *)0)->member))
 
-/*
-** Command packet segment flags and sequence counter
-** - 2 bits of segment flags (0xC000 = start and end of packet)
-** - 14 bits of sequence count (unused for command packets)
-*/
-#define PKT_FLAGS 0xC000
+/* Used designated intializers to be verbose, modify as needed/desired */
+SC_RtsTable002_t SC_Rts002 = {
+    /* 1 */
+    .rts.hdr1.TimeTag   = 0,
+    .rts.cmd1.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
-/*
-** Length of cmd pkt data (in bytes minus one) that follows primary header (thus, 0xFFFF = 64k)
-*/
-#define CMD1_LENGTH 1
-#define CMD2_LENGTH 1
-#define CMD3_LENGTH 1
+    /* 2 */
+    .rts.hdr2.TimeTag   = 5,
+    .rts.cmd2.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
-/*
-** Sample cFE Table Header
-*/
-static CFE_TBL_FileDef_t CFE_TBL_FileDef __attribute__((__used__)) = {
-    "RTS_Table002", "SC.RTS_TBL002", "SC Sample RTS_TBL002", "sc_rts002.tbl", (SC_RTS_BUFF_SIZE * sizeof(uint16))};
+    /* 3 */
+    .rts.hdr3.TimeTag   = 5,
+    .rts.cmd3.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM)};
 
-/*
-** Sample RTS Table Data
-*/
-uint16 RTS_Table002[SC_RTS_BUFF_SIZE] = {
-    /*  cmd time,  <---------------------------- cmd pkt primary header ---------------------------->  <----- cmd pkt
-       2nd header ---->   <-- opt data ---> */
-    CMD1_TIME_A,
-    CMD1_TIME_B,
-    CFE_MAKE_BIG16(SC_CMD_MID),
-    CFE_MAKE_BIG16(PKT_FLAGS),
-    CFE_MAKE_BIG16(CMD1_LENGTH),
-    CFE_MAKE_BIG16((SC_NOOP_CC << 8) | CMD1_XSUM),
-    CMD2_TIME_A,
-    CMD2_TIME_B,
-    CFE_MAKE_BIG16(SC_CMD_MID),
-    CFE_MAKE_BIG16(PKT_FLAGS),
-    CFE_MAKE_BIG16(CMD2_LENGTH),
-    CFE_MAKE_BIG16((SC_NOOP_CC << 8) | CMD2_XSUM),
-    CMD3_TIME_A,
-    CMD3_TIME_B,
-    CFE_MAKE_BIG16(SC_CMD_MID),
-    CFE_MAKE_BIG16(PKT_FLAGS),
-    CFE_MAKE_BIG16(CMD3_LENGTH),
-    CFE_MAKE_BIG16((SC_NOOP_CC << 8) | CMD3_XSUM),
-};
+/* Macro for table structure */
+CFE_TBL_FILEDEF(SC_Rts002, SC.RTS_TBL002, SC Example RTS_TBL002, sc_rts002.tbl)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #17

Note so far this is just partial/example, is not backwards compatible with Caelum framework and has a dependency on nasa/cFE#2115.  Marking as draft for now.

**Testing performed**
Ran with the cFE changes, confirmed noops were sent/received using the following cmds:
```
./cmdUtil -ELE -C0 -A0xAA  # SC HK cycle so table wil get started
./cmdUtil -ELE -C0 -A0xAB  # 1 Hz wakeup repeated as needed to trigger RTS manually
```

**Expected behavior changes**
Behavior is the same, just makes table maintenance easier and slightly more portable across different endian systems and w/ different header implementations.

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit/repo and additions to build/run SC as well as the commit that adds the macro header macro

**Additional context**
Depends on cFE update nasa/cFE#2115

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC