### PR TITLE
Fix #56, Remove 'return;' from last line of void functions.

### DIFF
--- a/fsw/platform_inc/sc_msgids.h
+++ b/fsw/platform_inc/sc_msgids.h
@@ -31,7 +31,7 @@
 
 #define SC_CMD_MID        (0x18A9) /**< \brief Msg ID for cmds to SC   */
 #define SC_SEND_HK_MID    (0x18AA) /**< \brief Msg ID to request SC HK */
-#define SC_1HZ_WAKEUP_MID (0x18AB) /**< \brief Msg ID to recieve the 1Hz */
+#define SC_1HZ_WAKEUP_MID (0x18AB) /**< \brief Msg ID to receive the 1Hz */
 
 /**\}*/
 

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -592,9 +592,6 @@ void SC_LoadDefaultTables(void)
     /* Display startup RTS not loaded count */
     CFE_EVS_SendEvent(SC_RTS_LOAD_FAIL_COUNT_INFO_EID, CFE_EVS_EventType_INFORMATION,
                       "RTS table files not loaded at initialization = %d of %d", (int)NotLoadedCount, SC_NUMBER_OF_RTS);
-
-    return;
-
 } /* end SC_LoadDefaultTables() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -644,9 +641,6 @@ void SC_RegisterManageCmds(void)
         CFE_TBL_NotifyByMessage(SC_OperData.RtsTblHandle[i], CFE_SB_ValueToMsgId(SC_CMD_MID), SC_MANAGE_TABLE_CC,
                                 SC_TBL_ID_RTS_0 + i);
     }
-
-    return;
-
 } /* End SC_RegisterManageCmds() */
 
 /************************/

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -770,9 +770,6 @@ void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(SC_TABLE_MANAGE_ID_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Table manage command packet error: table ID = %d", (int)TableID);
     }
-
-    return;
-
 } /* End SC_TableManageCmd() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_events.h
+++ b/fsw/src/sc_events.h
@@ -47,7 +47,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a command is recieved, but it is not of the expected
+ *  This event message is issued when a command is received, but it is not of the expected
  *  length
  */
 #define SC_LEN_ERR_EID 2
@@ -417,7 +417,7 @@
  *  \par Type: DEBUG
  *
  *  \par Cause:
- *  This event message is issued when the #SC_CONTINUE_ATS_ON_FAILURE_CC command was recieved and
+ *  This event message is issued when the #SC_CONTINUE_ATS_ON_FAILURE_CC command was received and
  *  the state was changed successfully
  */
 #define SC_CONT_CMD_DEB_EID 43
@@ -495,7 +495,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when an RTS comand was about to be sent out,
+ *  This event message is issued when an RTS command was about to be sent out,
  *  but the command failed checksum validation
  */
 #define SC_RTS_CHKSUM_ERR_EID 50
@@ -571,7 +571,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when an invalid message Id is recieved in the
+ *  This event message is issued when an invalid message Id is received in the
  *  command pipe
  */
 #define SC_MID_ERR_EID 63
@@ -582,7 +582,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when an invalid command code was recieved in
+ *  This event message is issued when an invalid command code was received in
  *  the command pipe
  */
 #define SC_INVLD_CMD_ERR_EID 64
@@ -670,7 +670,7 @@
  *  \par Type: DEBUG
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTS_CC cmd is recieved and is sucessful
+ *  This event message is issued when a #SC_START_RTS_CC cmd is received and is successful
  */
 #define SC_STARTRTS_CMD_DBG_EID 72
 
@@ -680,7 +680,7 @@
  *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
- *  This event message is issued when an RTS is started sucessfully
+ *  This event message is issued when an RTS is started successfully
  */
 #define SC_RTS_START_INF_EID 73
 
@@ -711,7 +711,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTS_CC command was recieved, but the
+ *  This event message is issued when a #SC_START_RTS_CC command was received, but the
  *  RTS is disabled
  */
 #define SC_STARTRTS_CMD_DISABLED_ERR_EID 76
@@ -722,7 +722,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTS_CC command was recieved, but the
+ *  This event message is issued when a #SC_START_RTS_CC command was received, but the
  *  RTS Id was invalid
  */
 #define SC_STARTRTS_CMD_INVALID_ERR_EID 77
@@ -733,7 +733,7 @@
  *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
- *  This event message is issued when an #SC_STOP_RTS_CC command is received and exexuted sucessfully
+ *  This event message is issued when an #SC_STOP_RTS_CC command is received and exexuted successfully
  */
 #define SC_STOPRTS_CMD_INF_EID 78
 
@@ -754,7 +754,7 @@
  *  \par Type: DEBUG
  *
  *  \par Cause:
- *  This event message is issued when a #SC_DISABLE_RTS_CC command was recieved, and executed sucessfully
+ *  This event message is issued when a #SC_DISABLE_RTS_CC command was received, and executed successfully
  */
 #define SC_DISABLE_RTS_DEB_EID 80
 
@@ -764,7 +764,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_DISABLE_RTS_CC command was recieved,
+ *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
  *  but the RTS Id given was invalid
  */
 #define SC_DISRTS_CMD_ERR_EID 81
@@ -775,7 +775,7 @@
  *  \par Type: DEBUG
  *
  *  \par Cause:
- *  This event message is issued when a #SC_ENABLE_RTS_CC command was recieved, and executed sucessfully
+ *  This event message is issued when a #SC_ENABLE_RTS_CC command was received, and executed successfully
  */
 #define SC_ENABLE_RTS_DEB_EID 82
 
@@ -785,7 +785,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_DISABLE_RTS_CC command was recieved,
+ *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
  *  but the RTS Id given was invalid
  */
 #define SC_ENARTS_CMD_ERR_EID 83
@@ -945,7 +945,7 @@
 #define SC_VERIFY_ATS_EID 103
 
 /**
- * \brief SC ATS Or Append Table Verification Table Entry Comamnd Number Invalid Event ID
+ * \brief SC ATS Or Append Table Verification Table Entry Command Number Invalid Event ID
  *
  *  \par Type: ERROR
  *
@@ -1226,7 +1226,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTSGRP_CC command was recieved, but an
+ *  This event message is issued when a #SC_START_RTSGRP_CC command was received, but an
  *  RTS is marked as #SC_LOADED
  */
 #define SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID 126

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -171,7 +171,7 @@ void SC_LoadAts(uint16 AtsIndex)
 
     /*
      **   Now the commands are parsed through, need to build the tables
-     **   if the load was a sucess, need to build the tables
+     **   if the load was a success, need to build the tables
      */
     /* if the load finished without errors and there was at least one command */
     if ((Result == CFE_SUCCESS) && (SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands > 0))
@@ -599,8 +599,6 @@ void SC_UpdateAppend(void)
     CFE_EVS_SendEvent(SC_UPDATE_APPEND_EID, CFE_EVS_EventType_INFORMATION,
                       "Update Append ATS Table: load count = %d, command count = %d, byte count = %d",
                       SC_OperData.HkPacket.AppendLoadCount, (int)EntryCount, (int)EntryIndex * SC_BYTES_IN_WORD);
-    return;
-
 } /* end SC_UpdateAppend */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -680,9 +678,6 @@ void SC_ProcessAppend(uint16 AtsIndex)
 
     /* notify cFE that we have modified the ats table */
     CFE_TBL_Modified(SC_OperData.AtsTblHandle[AtsIndex]);
-
-    return;
-
 } /* end SC_ProcessAppend */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -260,9 +260,6 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-
-    return;
-
 } /* end SC_StartRtsGrpCmd */
 #endif
 
@@ -356,9 +353,6 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-
-    return;
-
 } /* end SC_StopRtsGrpCmd */
 #endif
 
@@ -452,9 +446,6 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-
-    return;
-
 } /* end SC_DisableRtsGrpCmd */
 #endif
 
@@ -549,9 +540,6 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-
-    return;
-
 } /* end SC_EnableRtsGrpCmd */
 #endif
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #56
Removes all cases of redundant "return;" statements on the last line of void functions.
Corrected a few typos in the comments that were noticed along the way.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 