### PR TITLE
Fix #58, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -128,8 +128,7 @@ void SC_AppMain(void)
 
     /* Let cFE kill the app */
     CFE_ES_ExitApp(RunStatus);
-
-} /* end SC_AppMain() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -225,8 +224,7 @@ int32 SC_AppInit(void)
                       SC_MAJOR_VERSION, SC_MINOR_VERSION, SC_REVISION, SC_MISSION_REV);
 
     return (CFE_SUCCESS);
-
-} /* end SC_AppInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -295,8 +293,7 @@ int32 SC_InitTables(void)
     SC_RegisterManageCmds();
 
     return (CFE_SUCCESS);
-
-} /* end SC_InitTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -321,8 +318,7 @@ int32 SC_RegisterAllTables(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* end SC_RegisterAllTables() */
+}
 
 int32 SC_RegisterDumpOnlyTables(void)
 {
@@ -370,8 +366,7 @@ int32 SC_RegisterDumpOnlyTables(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* end SC_RegisterDumpOnlyTables() */
+}
 
 int32 SC_RegisterLoadableTables(void)
 {
@@ -418,8 +413,7 @@ int32 SC_RegisterLoadableTables(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* end SC_RegisterLoadableTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -464,8 +458,8 @@ int32 SC_GetDumpTablePointers(void)
     }
 
     return (CFE_SUCCESS);
+}
 
-} /* end SC_GetDumpTablePointers() */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Get buffer pointers for loadable tables                         */
@@ -520,8 +514,7 @@ int32 SC_GetLoadTablePointers(void)
     }
 
     return (CFE_SUCCESS);
-
-} /* end SC_GetLoadTablePointers() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -576,7 +569,7 @@ void SC_LoadDefaultTables(void)
     /* Display startup RTS not loaded count */
     CFE_EVS_SendEvent(SC_RTS_LOAD_FAIL_COUNT_INFO_EID, CFE_EVS_EventType_INFORMATION,
                       "RTS table files not loaded at initialization = %d of %d", (int)NotLoadedCount, SC_NUMBER_OF_RTS);
-} /* end SC_LoadDefaultTables() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -616,8 +609,4 @@ void SC_RegisterManageCmds(void)
         CFE_TBL_NotifyByMessage(SC_OperData.RtsTblHandle[i], CFE_SB_ValueToMsgId(SC_CMD_MID), SC_MANAGE_TABLE_CC,
                                 SC_TBL_ID_RTS_0 + i);
     }
-} /* End SC_RegisterManageCmds() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -121,7 +121,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 
         } /* end if */
     }
-} /* end SC_StartAtsCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -170,8 +170,7 @@ void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 
         SC_OperData.HkPacket.CmdCtr++;
     }
-
-} /* end SC_StopAtsCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -238,7 +237,6 @@ bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
      */
     if (TimeIndex == SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands)
     {
-
         CFE_EVS_SendEvent(SC_ATS_SKP_ALL_ERR_EID, CFE_EVS_EventType_ERROR,
                           "All ATS commands were skipped, ATS stopped");
 
@@ -271,8 +269,7 @@ bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
     } /* end if */
 
     return (ReturnCode);
-
-} /* end SC_BeginAts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -281,7 +278,6 @@ bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_KillAts(void)
 {
-
     if (SC_OperData.AtsCtrlBlckAddr->AtpState != SC_IDLE)
     {
         /* Increment the ats use counter */
@@ -294,8 +290,7 @@ void SC_KillAts(void)
 
     /* reset the time of the next ats command */
     SC_AppData.NextCmdTime[SC_ATP] = SC_MAX_TIME;
-
-} /* end SC_KillAts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -304,7 +299,6 @@ void SC_KillAts(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-
     uint16 NewAtsIndex; /* the index of the ats to switch to*/
 
     if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_NoArgsCmd_t)))
@@ -318,7 +312,6 @@ void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
             /* Now check to see if the new ATS has commands in it */
             if (SC_OperData.AtsInfoTblAddr[NewAtsIndex].NumberOfCommands > 0)
             {
-
                 /* set the global switch pend flag */
                 SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
 
@@ -353,7 +346,7 @@ void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
 
         } /* end if */
     }
-} /* end SC_GroundSwitchCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -371,11 +364,9 @@ void SC_ServiceSwitchPend(void)
      */
     if (SC_CompareAbsTime(SC_AppData.NextCmdTime[SC_ATP], SC_AppData.CurrentTime))
     {
-
         /* make sure that an ATS is still running on the ATP */
         if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING)
         {
-
             /* get the ATS number to switch to and from */
             OldAtsIndex = SC_ATS_NUM_TO_INDEX(SC_OperData.AtsCtrlBlckAddr->AtsNumber);
             NewAtsIndex = SC_ToggleAtsIndex();
@@ -383,7 +374,6 @@ void SC_ServiceSwitchPend(void)
             /* Now check to see if the new ATS has commands in it */
             if (SC_OperData.AtsInfoTblAddr[NewAtsIndex].NumberOfCommands > 0)
             {
-
                 /* stop the current ATS */
                 SC_KillAts();
 
@@ -395,7 +385,6 @@ void SC_ServiceSwitchPend(void)
                  */
                 if (SC_BeginAts(NewAtsIndex, 1))
                 {
-
                     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
                     CFE_EVS_SendEvent(SC_ATS_SERVICE_SWTCH_INF_EID, CFE_EVS_EventType_INFORMATION,
@@ -424,8 +413,7 @@ void SC_ServiceSwitchPend(void)
         SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
 
     } /* end if */
-
-} /* end SC_ServiceSwitchPend */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -435,7 +423,6 @@ void SC_ServiceSwitchPend(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool SC_InlineSwitch(void)
 {
-
     uint16 NewAtsIndex; /* the index of the ats to switch to*/
     uint16 OldAtsIndex; /* the index of the ats to switch from*/
     bool   ReturnCode;  /* return code for function */
@@ -497,8 +484,7 @@ bool SC_InlineSwitch(void)
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
 
     return (ReturnCode);
-
-} /* end function */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -627,7 +613,7 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 
         } /* end if */
     }
-} /* end SC_JumpAtsCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -659,7 +645,7 @@ void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr)
                               "Continue-ATS-On-Failure command, State: %d", State);
         }
     }
-} /* end SC_ContinueAtsOnFailureCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -729,8 +715,4 @@ void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                               SC_OperData.HkPacket.AppendEntryCount);
         }
     }
-} /* end SC_AppendAtsCmd */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -280,7 +280,7 @@ void SC_ProcessAtpCmd(void)
         }
 
     } /* end if next ATS command time */
-} /* end SC_ProcessAtpCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -290,7 +290,6 @@ void SC_ProcessAtpCmd(void)
 
 void SC_ProcessRtpCommand(void)
 {
-
     SC_RtsEntry_t *EntryPtr;  /* a pointer to an RTS entry header */
     uint16         RtsIndex;  /* the RTS index for the cmd */
     uint16         CmdOffset; /* the location of the cmd    */
@@ -395,7 +394,7 @@ void SC_ProcessRtpCommand(void)
             SC_KillRts(RtsIndex);
         } /* end if */
     }     /* end if */
-} /* end SC_ProcessRtpCommand */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -444,7 +443,6 @@ void SC_SendHkPacket(void)
      */
     for (i = 0; i < (SC_NUMBER_OF_RTS + (SC_NUMBER_OF_RTS_IN_UINT16 - 1)) / SC_NUMBER_OF_RTS_IN_UINT16; i++)
     {
-
         SC_OperData.HkPacket.RtsExecutingStatus[i] = 0;
         SC_OperData.HkPacket.RtsDisabledStatus[i]  = 0;
 
@@ -452,7 +450,6 @@ void SC_SendHkPacket(void)
 
     for (i = 0; i < SC_NUMBER_OF_RTS; i++)
     {
-
         if (SC_OperData.RtsInfoTblAddr[i].DisabledFlag == true)
         {
             CFE_SET(SC_OperData.HkPacket.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16],
@@ -468,8 +465,7 @@ void SC_SendHkPacket(void)
     /* send the status packet */
     CFE_SB_TimeStampMsg(&SC_OperData.HkPacket.TlmHeader.Msg);
     CFE_SB_TransmitMsg(&SC_OperData.HkPacket.TlmHeader.Msg, true);
-
-} /* end SC_SendHkPacket */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -492,7 +488,7 @@ void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
         SC_OperData.HkPacket.RtsActiveCtr    = 0;
         SC_OperData.HkPacket.RtsActiveErrCtr = 0;
     }
-} /* end SC_ResetCountersCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -507,7 +503,7 @@ void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(SC_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. Version %d.%d.%d.%d",
                           SC_MAJOR_VERSION, SC_MINOR_VERSION, SC_REVISION, SC_MISSION_REV);
     }
-} /* End SC_NoOpCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -537,7 +533,6 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
         case SC_SEND_HK_MID:
             if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_NoArgsCmd_t)))
             {
-
                 /* set during init to power on or processor reset auto-exec RTS */
                 if (SC_AppData.AutoStartRTS != 0)
                 {
@@ -615,7 +610,7 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
             SC_OperData.HkPacket.CmdErrCtr++;
             break;
     } /* end switch */
-} /* end SC_ProcessRequest */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -710,7 +705,7 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             SC_OperData.HkPacket.CmdErrCtr++;
             break;
     } /* end switch */
-} /* end ProcessSequenceRequest */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -770,7 +765,7 @@ void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(SC_TABLE_MANAGE_ID_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Table manage command packet error: table ID = %d", (int)TableID);
     }
-} /* End SC_TableManageCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -789,8 +784,7 @@ void SC_ManageRtsTable(int32 ArrayIndex)
     }
 
     SC_ManageTable(RTS, ArrayIndex);
-
-} /* End SC_ManageRtsTable() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -809,8 +803,7 @@ void SC_ManageAtsTable(int32 ArrayIndex)
     }
 
     SC_ManageTable(ATS, ArrayIndex);
-
-} /* End SC_ManageAtsTable() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -886,9 +879,4 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
                               "ATS Append table manage process error: Result = 0x%X", (unsigned int)Result);
         }
     }
-
-} /* End SC_ManageTable() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -186,8 +186,7 @@ void SC_LoadAts(uint16 AtsIndex)
     { /* there was an error */
         SC_InitAtsTables(AtsIndex);
     } /* end if */
-
-} /* end SC_LoadAts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -222,8 +221,7 @@ void SC_BuildTimeIndexTable(uint16 AtsIndex)
             ListLength++;
         }
     }
-
-} /* end SC_BuildTimeIndexTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -299,7 +297,7 @@ void SC_Insert(uint16 AtsIndex, uint32 NewCmdIndex, uint32 ListLength)
     ** In either case, there is an empty slot next to TimeBufIndex
     */
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][TimeBufIndex + 1] = SC_ATS_CMD_INDEX_TO_NUM(NewCmdIndex);
-} /* end SC_Insert */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -329,8 +327,7 @@ void SC_InitAtsTables(uint16 AtsIndex)
     /* initialize the pointers and counters   */
     SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize          = 0;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 0;
-
-} /* end SC_InitAtsTables */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -359,7 +356,6 @@ void SC_LoadRts(uint16 RtsIndex)
                           "RTS table init error: invalid RTS index %d", RtsIndex);
         return;
     }
-
 } /* SC_LoadRts */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -375,8 +371,7 @@ int32 SC_ValidateAts(void *TableData)
     Result = SC_VerifyAtsTable((uint32 *)TableData, SC_ATS_BUFF_SIZE32);
 
     return (Result);
-
-} /* end SC_ValidateAts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -397,13 +392,11 @@ bool SC_ParseRts(uint32 Buffer32[])
     Done = Error = false;
     while (Error == false && Done == false)
     {
-
         /*
          ** Check to see if a minimum command fits within an RTS
          */
         if (i <= (SC_RTS_BUFF_SIZE32 - SC_RTS_HDR_WORDS))
         {
-
             /*
              ** Cast a header to the RTS buffer current location
              ** and get the size of the packet
@@ -488,8 +481,7 @@ bool SC_ParseRts(uint32 Buffer32[])
 
     /* If Error was true   , then SC_ParseRts must return false    */
     return (!Error);
-
-} /* end SC_ParseRts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -498,7 +490,6 @@ bool SC_ParseRts(uint32 Buffer32[])
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SC_ValidateRts(void *TableData)
 {
-
     uint32 *TableDataPtr;
     int32   Result = CFE_SUCCESS;
 
@@ -515,8 +506,7 @@ int32 SC_ValidateRts(void *TableData)
     }
 
     return (Result);
-
-} /* end SC_ValidateRts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -531,8 +521,7 @@ int32 SC_ValidateAppend(void *TableData)
     Result = SC_VerifyAtsTable((uint32 *)TableData, SC_APPEND_BUFF_SIZE32);
 
     return (Result);
-
-} /* end SC_ValidateAppend */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -599,7 +588,7 @@ void SC_UpdateAppend(void)
     CFE_EVS_SendEvent(SC_UPDATE_APPEND_EID, CFE_EVS_EventType_INFORMATION,
                       "Update Append ATS Table: load count = %d, command count = %d, byte count = %d",
                       SC_OperData.HkPacket.AppendLoadCount, (int)EntryCount, (int)EntryIndex * SC_BYTES_IN_WORD);
-} /* end SC_UpdateAppend */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -678,7 +667,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
 
     /* notify cFE that we have modified the ats table */
     CFE_TBL_Modified(SC_OperData.AtsTblHandle[AtsIndex]);
-} /* end SC_ProcessAppend */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -742,8 +731,7 @@ int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords)
     }
 
     return (Result);
-
-} /* end SC_VerifyAtsTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -851,9 +839,4 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
     }
 
     return (Result);
-
-} /* End of SC_VerifyAtsEntry */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_msg.h
+++ b/fsw/src/sc_msg.h
@@ -101,7 +101,6 @@ typedef struct
      the LSB (bit zero) of uint16 array index zero represents RTS number 1, and bit one of uint16 array
      index zero represents RTS number 2, etc.  If an RTS is ENABLED, then the corresponding bit is zero.
      If an RTS is DISABLED, then the corresponding bit is one. */
-
 } SC_HkTlm_t;
 
 /**\}*/

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -170,8 +170,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     { /* the command length is invalid */
         SC_OperData.HkPacket.RtsActiveErrCtr++;
     }
-
-} /* end SC_StartRts */
+}
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -260,7 +259,7 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-} /* end SC_StartRtsGrpCmd */
+}
 #endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -301,7 +300,7 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 
         } /* end if */
     }
-} /* end SC_StopRtsCmd */
+}
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -353,7 +352,7 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-} /* end SC_StopRtsGrpCmd */
+}
 #endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -393,7 +392,7 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         } /* end if */
     }
-} /* end SC_DisableRTS */
+}
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -446,7 +445,7 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-} /* end SC_DisableRtsGrpCmd */
+}
 #endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -487,7 +486,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 
         } /* end if */
     }
-} /* end SC_EnableRTS */
+}
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -540,7 +539,7 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.CmdErrCtr++;
         }
     }
-} /* end SC_EnableRtsGrpCmd */
+}
 #endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -575,8 +574,7 @@ void SC_KillRts(uint16 RtsIndex)
             SC_OperData.RtsCtrlBlckAddr->NumRtsActive--;
         }
     }
-
-} /* end SC_KillRts */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -614,9 +612,4 @@ void SC_AutoStartRts(uint16 RtsNumber)
         CFE_EVS_SendEvent(SC_AUTOSTART_RTS_INV_ID_ERR_EID, CFE_EVS_EventType_ERROR,
                           "RTS autostart error: invalid RTS ID %d", RtsNumber);
     }
-
-} /* end SC_AutoStartRts */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -57,7 +57,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_GetNextRtsTime(void)
 {
-
     int16           i;        /* loop counter MUST be SIGNED !*/
     uint16          NextRts;  /* the next rts to schedule */
     SC_AbsTimeTag_t NextTime; /* the next time for the RTS */
@@ -93,8 +92,7 @@ void SC_GetNextRtsTime(void)
         SC_OperData.RtsCtrlBlckAddr->RtsNumber = NextRts + 1;
         SC_AppData.NextCmdTime[SC_RTP]         = NextTime;
     } /* end if */
-
-} /* end SC_GetNextRtsTime */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -137,7 +135,7 @@ void SC_UpdateNextTime(void)
             SC_AppData.NextProcNumber = SC_RTP;
         }
     } /* end if */
-} /* end SC_UpdateNextTime */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -303,8 +301,7 @@ void SC_GetNextRtsCommand(void)
         } /* end if the RTS status is EXECUTING */
 
     } /* end if the RTS number is valid */
-
-} /* end SC_GetNextRtsCommand */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -313,7 +310,6 @@ void SC_GetNextRtsCommand(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_GetNextAtsCommand(void)
 {
-
     uint16         AtsIndex;  /* ats array index */
     uint16         TimeIndex; /* a time index pointer */
     uint16         CmdIndex;  /* ats command array index */
@@ -321,7 +317,6 @@ void SC_GetNextAtsCommand(void)
 
     if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING)
     {
-
         /*
          ** Get the information that is needed to find the next command
          */
@@ -333,7 +328,6 @@ void SC_GetNextAtsCommand(void)
          */
         if (TimeIndex < SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands)
         {
-
             /* get the information for the next command in the ATP control block */
             SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr = TimeIndex;
             SC_OperData.AtsCtrlBlckAddr->CmdNumber    = SC_AppData.AtsTimeIndexBuffer[AtsIndex][TimeIndex];
@@ -372,9 +366,4 @@ void SC_GetNextAtsCommand(void)
         SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     } /* end if ATS is EXECUTING*/
-
-} /* end SC_GetNextAtsCommand */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/sc_tbldefs.h
+++ b/fsw/src/sc_tbldefs.h
@@ -63,11 +63,9 @@ typedef uint32 SC_RelTimeTag_t;
  */
 typedef struct
 {
-
     uint16 AtsUseCtr;        /**< \brief How many times it has been used */
     uint16 NumberOfCommands; /**< \brief number of commands in the ATS */
     uint32 AtsSize;          /**< \brief size of the ATS */
-
 } SC_AtsInfoTable_t;
 
 /**
@@ -75,13 +73,11 @@ typedef struct
  */
 typedef struct
 {
-
     uint8  AtpState;       /**< \brief execution state of the ATP */
     uint8  AtsNumber;      /**< \brief current ATS running if any */
     uint32 CmdNumber;      /**< \brief current cmd number to run if any */
     uint16 TimeIndexPtr;   /**< \brief time index pointer for current cmd */
     uint16 SwitchPendFlag; /**< \brief indicates that a buffer switch is waiting */
-
 } SC_AtpControlBlock_t;
 
 /**
@@ -93,10 +89,8 @@ typedef struct
  */
 typedef struct
 {
-
     uint16 NumRtsActive; /**< \brief number of RTSs currently active */
     uint16 RtsNumber;    /**< \brief next RTS number */
-
 } SC_RtpControlBlock_t;
 
 /**
@@ -104,7 +98,6 @@ typedef struct
  */
 typedef struct
 {
-
     uint8           RtsStatus;       /**< \brief status of the RTS */
     bool            DisabledFlag;    /**< \brief disabled/enabled flag */
     uint8           CmdCtr;          /**< \brief Cmds executed in current rts */
@@ -112,7 +105,6 @@ typedef struct
     SC_AbsTimeTag_t NextCommandTime; /**< \brief next command time for RTS */
     uint16          NextCommandPtr;  /**< \brief where next rts cmd is */
     uint16          UseCtr;          /**< \brief how many times RTS is run */
-
 } SC_RtsInfoEntry_t;
 
 #endif

--- a/fsw/src/sc_utils.c
+++ b/fsw/src/sc_utils.c
@@ -61,8 +61,7 @@ void SC_GetCurrentTime(void)
 
     /* We don't care about subseconds */
     SC_AppData.CurrentTime = TempTime.Seconds;
-
-} /* end of SC_GetCurrentTime */
+}
 
 SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
 {
@@ -82,8 +81,7 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
     */
 
     return ((Entry->TimeTag_MS << 16) + Entry->TimeTag_LS);
-
-} /* End of SC_GetAtsEntryTime() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -110,8 +108,7 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
 
     /* We don't need subseconds */
     return (ResultTimeWSubs.Seconds);
-
-} /* end of SC_ComputeAbsTime */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -143,8 +140,7 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
     }
 
     return Status;
-
-} /* end of SC_CompareAbsTime */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -177,7 +173,7 @@ bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
         }
     }
     return (Result);
-} /* End of SC_VerifyCmdLength */
+}
 
 uint16 SC_ToggleAtsIndex(void)
 {
@@ -185,7 +181,3 @@ uint16 SC_ToggleAtsIndex(void)
 
     return (1 - CurrAtsIndex);
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -172,7 +172,3 @@ uint16 ATS_Table1[SC_ATS_BUFF_SIZE] = {
     0,
     0,
     0};
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -122,7 +122,3 @@ uint16 RTS_Table001[SC_RTS_BUFF_SIZE] = {
     CMD3_ARG,
     0x0000,
 };
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -123,7 +123,3 @@ uint16 RTS_Table002[SC_RTS_BUFF_SIZE] = {
     CFE_MAKE_BIG16(CMD3_LENGTH),
     CFE_MAKE_BIG16((SC_NOOP_CC << 8) | CMD3_XSUM),
 };
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -68,7 +68,7 @@ int32 CFE_TBL_RegisterHook1(void *UserObj, int32 StubRetcode, uint32 CallCount, 
     *TblHandle = (CFE_TBL_Handle_t)SC_APP_TEST_CFE_TBL_RegisterHookCount++;
 
     return CFE_SUCCESS;
-} /* end CFE_TBL_RegisterHook1 */
+}
 
 int32 CFE_TBL_GetAddressHookNominal(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
@@ -86,13 +86,13 @@ int32 CFE_TBL_GetAddressHookNominal(void *UserObj, int32 StubRetcode, uint32 Cal
         return CFE_TBL_INFO_UPDATED;
     else
         return CFE_SUCCESS;
-} /* end CFE_TBL_GetAddressHookNominal */
+}
 
 int32 CFE_TBL_GetAddressHookNominal2(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                      const UT_StubContext_t *Context)
 {
     return CFE_TBL_ERR_NEVER_LOADED;
-} /* end CFE_TBL_GetAddressHookNominal2 */
+}
 
 int32 CFE_TBL_GetAddressHookError1(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
@@ -110,7 +110,7 @@ int32 CFE_TBL_GetAddressHookError1(void *UserObj, int32 StubRetcode, uint32 Call
         return -1;
     else
         return CFE_SUCCESS;
-} /* end CFE_TBL_GetAddressHookError1 */
+}
 
 void SC_AppMain_Test_Nominal(void)
 {
@@ -141,8 +141,7 @@ void SC_AppMain_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppMain_Test_Nominal */
+}
 
 void SC_AppMain_Test_AppInitError(void)
 {
@@ -180,8 +179,7 @@ void SC_AppMain_Test_AppInitError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-} /* end SC_AppMain_Test_AppInitError */
+}
 
 void SC_AppMain_Test_RcvMsgError(void)
 {
@@ -223,8 +221,7 @@ void SC_AppMain_Test_RcvMsgError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-} /* end SC_AppMain_Test_RcvMsgError */
+}
 
 void SC_AppInit_Test_NominalPowerOnReset(void)
 {
@@ -309,8 +306,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_NominalPowerOnReset */
+}
 
 void SC_AppInit_Test_Nominal(void)
 {
@@ -395,8 +391,7 @@ void SC_AppInit_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_Nominal */
+}
 
 void SC_AppInit_Test_EVSRegisterError(void)
 {
@@ -424,8 +419,7 @@ void SC_AppInit_Test_EVSRegisterError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-} /* end SC_AppInit_Test_EVSRegisterError */
+}
 
 void SC_AppInit_Test_SBCreatePipeError(void)
 {
@@ -455,8 +449,7 @@ void SC_AppInit_Test_SBCreatePipeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_SBCreatePipeError */
+}
 
 void SC_AppInit_Test_SBSubscribeHKError(void)
 {
@@ -488,8 +481,7 @@ void SC_AppInit_Test_SBSubscribeHKError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_SBSubscribeHKError */
+}
 
 void SC_AppInit_Test_SubscribeTo1HzError(void)
 {
@@ -521,8 +513,7 @@ void SC_AppInit_Test_SubscribeTo1HzError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_SubscribeTo1HzError */
+}
 
 void SC_AppInit_Test_SBSubscribeToCmdError(void)
 {
@@ -554,8 +545,7 @@ void SC_AppInit_Test_SBSubscribeToCmdError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_SBSubscribeToCmdError */
+}
 
 void SC_AppInit_Test_InitTablesError(void)
 {
@@ -586,8 +576,7 @@ void SC_AppInit_Test_InitTablesError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppInit_Test_InitTablesError */
+}
 
 void SC_InitTables_Test_Nominal(void)
 {
@@ -605,7 +594,7 @@ void SC_InitTables_Test_Nominal(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LOAD_FAIL_COUNT_INFO_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_INIT_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-} /* end SC_InitTables_Test_Nominal */
+}
 
 void SC_InitTables_Test_ErrorRegisterAllTables(void)
 {
@@ -636,8 +625,7 @@ void SC_InitTables_Test_ErrorRegisterAllTables(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InitTables_Test_ErrorRegisterAllTables */
+}
 
 void SC_InitTables_Test_ErrorGetDumpTablePointers(void)
 {
@@ -669,8 +657,7 @@ void SC_InitTables_Test_ErrorGetDumpTablePointers(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InitTables_Test_ErrorGetDumpTablePointers */
+}
 
 void SC_InitTables_Test_ErrorGetLoadTablePointers(void)
 {
@@ -711,8 +698,7 @@ void SC_InitTables_Test_ErrorGetLoadTablePointers(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InitTables_Test_ErrorGetLoadTablePointers */
+}
 
 void SC_RegisterAllTables_Test_Nominal(void)
 {
@@ -727,8 +713,7 @@ void SC_RegisterAllTables_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_Nominal */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterRTSInformation(void)
 {
@@ -759,8 +744,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterRTSInformation(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterRTSInformation */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterRTPControl(void)
 {
@@ -791,8 +775,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterRTPControl(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterRTPControl */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterATSInformation(void)
 {
@@ -823,8 +806,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterATSInformation(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterATSInformation */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterATPControl(void)
 {
@@ -855,8 +837,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterATPControl(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterATPControl */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterATSCommandStatus(void)
 {
@@ -888,8 +869,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterATSCommandStatus(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterATSCommandStatus */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterLoadableRTS(void)
 {
@@ -921,8 +901,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterLoadableRTS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterLoadableRTS */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterLoadableATS(void)
 {
@@ -954,8 +933,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterLoadableATS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterLoadableATS */
+}
 
 void SC_RegisterAllTables_Test_ErrorRegisterLoadableAppendATS(void)
 {
@@ -987,8 +965,7 @@ void SC_RegisterAllTables_Test_ErrorRegisterLoadableAppendATS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_RegisterAllTables_Test_ErrorRegisterLoadableAppendATS */
+}
 
 void SC_RegisterDumpOnlyTables_Test_Nominal(void)
 {
@@ -1001,8 +978,7 @@ void SC_RegisterDumpOnlyTables_Test_Nominal(void)
     UtAssert_True(ReturnValue == CFE_SUCCESS, "ReturnValue == CFE_SUCCESS");
     UtAssert_STUB_COUNT(CFE_TBL_Register, 6);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_RegisterDumpOnlyTables_Test_Nominal */
+}
 
 void SC_RegisterLoadableTables_Test_Nominal(void)
 {
@@ -1015,8 +991,7 @@ void SC_RegisterLoadableTables_Test_Nominal(void)
     UtAssert_True(ReturnValue == CFE_SUCCESS, "ReturnValue == CFE_SUCCESS");
     UtAssert_STUB_COUNT(CFE_TBL_Register, 67);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_RegisterLoadableTables_Test_Nominal */
+}
 
 void SC_GetDumpTablePointers_Test_Nominal(void)
 {
@@ -1034,8 +1009,7 @@ void SC_GetDumpTablePointers_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_Nominal */
+}
 
 void SC_GetDumpTablePointers_Test_ErrorGetAddressRTSInformation(void)
 {
@@ -1071,8 +1045,7 @@ void SC_GetDumpTablePointers_Test_ErrorGetAddressRTSInformation(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_ErrorGetAddressRTSInformation */
+}
 
 void SC_GetDumpTablePointers_Test_ErrorGetAddressRTPControl(void)
 {
@@ -1103,8 +1076,7 @@ void SC_GetDumpTablePointers_Test_ErrorGetAddressRTPControl(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_ErrorGetAddressRTPControl */
+}
 
 void SC_GetDumpTablePointers_Test_ErrorGetAddressATSInformation(void)
 {
@@ -1135,8 +1107,7 @@ void SC_GetDumpTablePointers_Test_ErrorGetAddressATSInformation(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_ErrorGetAddressATSInformation */
+}
 
 void SC_GetDumpTablePointers_Test_ErrorGetAddressATPControl(void)
 {
@@ -1167,8 +1138,7 @@ void SC_GetDumpTablePointers_Test_ErrorGetAddressATPControl(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_ErrorGetAddressATPControl */
+}
 
 void SC_GetDumpTablePointers_Test_ErrorGetAddressATSCommandStatus(void)
 {
@@ -1199,8 +1169,7 @@ void SC_GetDumpTablePointers_Test_ErrorGetAddressATSCommandStatus(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetDumpTablePointers_Test_ErrorGetAddressATSCommandStatus */
+}
 
 void SC_GetLoadTablePointers_Test_Nominal(void)
 {
@@ -1218,8 +1187,7 @@ void SC_GetLoadTablePointers_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetLoadTablePointers_Test_Nominal */
+}
 
 void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATS(void)
 {
@@ -1250,8 +1218,7 @@ void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATS */
+}
 
 void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATSAppend(void)
 {
@@ -1285,8 +1252,7 @@ void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATSAppend(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableATSAppend */
+}
 
 void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS(void)
 {
@@ -1321,8 +1287,7 @@ void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS */
+}
 
 void SC_LoadDefaultTables_Test(void)
 {
@@ -1344,7 +1309,7 @@ void SC_LoadDefaultTables_Test(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, SC_RTS_LOAD_FAIL_COUNT_INFO_EID);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
-} /* end SC_LoadDefaultTables_Test */
+}
 
 void UtTest_Setup(void)
 {
@@ -1412,9 +1377,4 @@ void UtTest_Setup(void)
     UtTest_Add(SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS");
     UtTest_Add(SC_LoadDefaultTables_Test, SC_Test_Setup, SC_Test_TearDown, "SC_LoadDefaultTables_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -57,7 +57,7 @@ CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHookAgreaterthanB(void *UserObj, int3
                                                              const UT_StubContext_t *Context)
 {
     return CFE_TIME_A_GT_B;
-} /* end CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHookAgreaterthanB */
+}
 
 uint8              UT_SC_StartAtsRq_CompareHookRunCount;
 CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHook3(void *UserObj, int32 StubRetcode, uint32 CallCount,
@@ -72,7 +72,7 @@ CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHook3(void *UserObj, int32 StubRetcod
     {
         return CFE_TIME_A_LT_B;
     }
-} /* CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHook3 */
+}
 
 void SC_StartAtsCmd_Test_NominalA(void)
 {
@@ -114,8 +114,7 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_NominalA */
+}
 
 void SC_StartAtsCmd_Test_NominalB(void)
 {
@@ -157,8 +156,7 @@ void SC_StartAtsCmd_Test_NominalB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_NominalB */
+}
 
 void SC_StartAtsCmd_Test_CouldNotStart(void)
 {
@@ -205,8 +203,7 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_CouldNotStart */
+}
 
 void SC_StartAtsCmd_Test_NoCommandsA(void)
 {
@@ -247,8 +244,7 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_NoCommandsA */
+}
 
 void SC_StartAtsCmd_Test_NoCommandsB(void)
 {
@@ -289,8 +285,7 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_NoCommandsB */
+}
 
 void SC_StartAtsCmd_Test_InUse(void)
 {
@@ -331,8 +326,7 @@ void SC_StartAtsCmd_Test_InUse(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_InUse */
+}
 
 void SC_StartAtsCmd_Test_InvalidAtsId(void)
 {
@@ -373,8 +367,7 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_InvalidAtsId */
+}
 
 void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
 {
@@ -415,8 +408,7 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_InvalidAtsIdZero */
+}
 
 void SC_StartAtsCmd_Test_InvalidCmdLength(void)
 {
@@ -441,8 +433,7 @@ void SC_StartAtsCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartAtsCmd_Test_InvalidCmdLength */
+}
 
 void SC_StopAtsCmd_Test_NominalA(void)
 {
@@ -482,8 +473,7 @@ void SC_StopAtsCmd_Test_NominalA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopAtsCmd_Test_NominalA */
+}
 
 void SC_StopAtsCmd_Test_NominalB(void)
 {
@@ -523,8 +513,7 @@ void SC_StopAtsCmd_Test_NominalB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopAtsCmd_Test_NominalB */
+}
 
 void SC_StopAtsCmd_Test_NoRunningAts(void)
 {
@@ -564,8 +553,7 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopAtsCmd_Test_NoRunningAts */
+}
 
 void SC_StopAtsCmd_Test_InvalidCmdLength(void)
 {
@@ -592,8 +580,7 @@ void SC_StopAtsCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopAtsCmd_Test_InvalidCmdLength */
+}
 
 void SC_BeginAts_Test_Nominal(void)
 {
@@ -634,8 +621,7 @@ void SC_BeginAts_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_BeginAts_Test_Nominal */
+}
 
 void SC_BeginAts_Test_AllCommandsSkipped(void)
 {
@@ -680,8 +666,7 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_BeginAts_Test_AllCommandsSkipped */
+}
 
 void SC_BeginAts_Test_InvalidAtsIndex(void)
 {
@@ -724,8 +709,7 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_BeginAts_Test_InvalidAtsIndex */
+}
 
 void SC_KillAts_Test(void)
 {
@@ -751,8 +735,7 @@ void SC_KillAts_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_KillAts_Test */
+}
 
 void SC_GroundSwitchCmd_Test_Nominal(void)
 {
@@ -796,8 +779,7 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GroundSwitchCmd_Test_Nominal */
+}
 
 void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
 {
@@ -839,8 +821,7 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded */
+}
 
 void SC_GroundSwitchCmd_Test_AtpIdle(void)
 {
@@ -881,8 +862,7 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GroundSwitchCmd_Test_AtpIdle */
+}
 
 void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
 {
@@ -905,8 +885,7 @@ void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GroundSwitchCmd_Test_InvalidCmdLength */
+}
 
 void SC_ServiceSwitchPend_Test_NominalA(void)
 {
@@ -953,8 +932,7 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ServiceSwitchPend_Test_NominalA */
+}
 
 void SC_ServiceSwitchPend_Test_NominalB(void)
 {
@@ -1001,8 +979,7 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ServiceSwitchPend_Test_NominalB */
+}
 
 void SC_ServiceSwitchPend_Test_AtsEmpty(void)
 {
@@ -1045,8 +1022,7 @@ void SC_ServiceSwitchPend_Test_AtsEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /*  end SC_ServiceSwitchPend_Test_AtsEmpty */
+}
 
 void SC_ServiceSwitchPend_Test_AtpIdle(void)
 {
@@ -1086,8 +1062,7 @@ void SC_ServiceSwitchPend_Test_AtpIdle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ServiceSwitchPend_Test_AtpIdle */
+}
 
 void SC_ServiceSwitchPend_Test_NoSwitch(void)
 {
@@ -1111,8 +1086,7 @@ void SC_ServiceSwitchPend_Test_NoSwitch(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ServiceSwitchPend_Test_NoSwitch */
+}
 
 void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
 {
@@ -1162,8 +1136,7 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ServiceSwitchPend_Test_AtsNotStarted */
+}
 
 void SC_InlineSwitch_Test_NominalA(void)
 {
@@ -1214,8 +1187,7 @@ void SC_InlineSwitch_Test_NominalA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InlineSwitch_Test_NominalA */
+}
 
 void SC_InlineSwitch_Test_NominalB(void)
 {
@@ -1266,8 +1238,7 @@ void SC_InlineSwitch_Test_NominalB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InlineSwitch_Test_NominalB */
+}
 
 void SC_InlineSwitch_Test_AllCommandsSkipped(void)
 {
@@ -1303,8 +1274,7 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InlineSwitch_Test_AllCommandsSkipped */
+}
 
 void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
 {
@@ -1349,8 +1319,7 @@ void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InlineSwitch_Test_DestinationAtsNotLoaded */
+}
 
 void SC_JumpAtsCmd_Test_SkipOneCmd(void)
 {
@@ -1426,8 +1395,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_JumpAtsCmd_Test_SkipOneCmd */
+}
 
 void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
 {
@@ -1479,8 +1447,7 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_JumpAtsCmd_Test_AllCommandsSkipped */
+}
 
 void SC_JumpAtsCmd_Test_NoRunningAts(void)
 {
@@ -1522,8 +1489,7 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_JumpAtsCmd_Test_NoRunningAts */
+}
 
 void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
 {
@@ -1584,8 +1550,7 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_JumpAtsCmd_Test_AtsNotLoaded */
+}
 
 void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
 {
@@ -1614,8 +1579,7 @@ void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_JumpAtsCmd_Test_InvalidCmdLength */
+}
 
 void ContinueAtsOnFailureCmd_Test_Nominal(void)
 {
@@ -1659,8 +1623,7 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end ContinueAtsOnFailureCmd_Test_Nominal */
+}
 
 void ContinueAtsOnFailureCmd_Test_FalseState(void)
 {
@@ -1704,8 +1667,7 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end ContinueAtsOnFailureCmd_Test_FalseState */
+}
 
 void ContinueAtsOnFailureCmd_Test_InvalidState(void)
 {
@@ -1748,8 +1710,7 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end ContinueAtsOnFailureCmd_Test_InvalidState */
+}
 
 void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
 {
@@ -1776,8 +1737,7 @@ void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end ContinueAtsOnFailureCmd_Test_InvalidCmdLength */
+}
 
 void SC_AppendAtsCmd_Test_Nominal(void)
 {
@@ -1830,8 +1790,7 @@ void SC_AppendAtsCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_Nominal */
+}
 
 void SC_AppendAtsCmd_Test_InvalidAtsId(void)
 {
@@ -1874,8 +1833,7 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_InvalidAtsId */
+}
 
 void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
 {
@@ -1918,8 +1876,7 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_InvalidAtsIdZero */
+}
 
 void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
 {
@@ -1964,8 +1921,7 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_AtsTableEmpty */
+}
 
 void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
 {
@@ -2010,8 +1966,7 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_AppendTableEmpty */
+}
 
 void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
 {
@@ -2059,8 +2014,7 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_NoRoomForAppendInAts */
+}
 
 void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
 {
@@ -2087,8 +2041,7 @@ void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AppendAtsCmd_Test_InvalidCmdLength */
+}
 
 void UtTest_Setup(void)
 {
@@ -2163,9 +2116,4 @@ void UtTest_Setup(void)
                "SC_AppendAtsCmd_Test_NoRoomForAppendInAts");
     UtTest_Add(SC_AppendAtsCmd_Test_InvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
                "SC_AppendAtsCmd_Test_InvalidCmdLength");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -49,7 +49,7 @@ CFE_TIME_Compare_t Ut_CFE_TIME_CompareHookAlessthanB(void *UserObj, int32 StubRe
                                                      const UT_StubContext_t *Context)
 {
     return CFE_TIME_A_LT_B;
-} /* end Ut_CFE_TIME_CompareHookAlessthanB */
+}
 
 uint8 SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount;
 int32 Ut_SC_UpdateNextTimeHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
@@ -120,8 +120,7 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_SwitchCmd */
+}
 
 void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 {
@@ -183,8 +182,7 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_NonSwitchCmd */
+}
 
 void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 {
@@ -248,8 +246,7 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_InlineSwitchError */
+}
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 {
@@ -335,8 +332,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_SBErrorAtsA */
+}
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 {
@@ -422,8 +418,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_SBErrorAtsB */
+}
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 {
@@ -511,8 +506,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_ChecksumFailedAtsA */
+}
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 {
@@ -598,8 +592,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_ChecksumFailedAtsB */
+}
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 {
@@ -676,8 +669,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue */
+}
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 {
@@ -747,8 +739,7 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA */
+}
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 {
@@ -818,8 +809,7 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB */
+}
 
 void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 {
@@ -877,8 +867,7 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_CmdNotLoaded */
+}
 
 void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 {
@@ -921,8 +910,7 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_CompareAbsTime */
+}
 
 void SC_ProcessAtpCmd_Test_NextProcNumber(void)
 {
@@ -963,8 +951,7 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_NextProcNumber */
+}
 
 void SC_ProcessAtpCmd_Test_AtpState(void)
 {
@@ -1005,8 +992,7 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_AtpState */
+}
 
 void SC_ProcessAtpCmd_Test_CmdMid(void)
 {
@@ -1067,8 +1053,7 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAtpCmd_Test_CmdMid */
+}
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
 {
@@ -1107,8 +1092,7 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_Nominal */
+}
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
@@ -1164,8 +1148,7 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_BadSoftwareBusReturn */
+}
 
 void SC_ProcessRtpCommand_Test_BadChecksum(void)
 {
@@ -1217,8 +1200,7 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_BadChecksum */
+}
 
 void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 {
@@ -1246,8 +1228,7 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_NextCmdTime */
+}
 
 void SC_ProcessRtpCommand_Test_ProcNumber(void)
 {
@@ -1275,8 +1256,7 @@ void SC_ProcessRtpCommand_Test_ProcNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_ProcNumber */
+}
 
 void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 {
@@ -1303,8 +1283,7 @@ void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_RtsNumberZero */
+}
 
 void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 {
@@ -1332,8 +1311,7 @@ void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_RtsNumberHigh */
+}
 
 void SC_ProcessRtpCommand_Test_RtsStatus(void)
 {
@@ -1361,8 +1339,7 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRtpCommand_Test_RtsStatus */
+}
 
 void SC_SendHkPacket_Test(void)
 {
@@ -1489,8 +1466,7 @@ void SC_SendHkPacket_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_SendHkPacket_Test */
+}
 
 void SC_ProcessRequest_Test_CmdMID(void)
 {
@@ -1529,8 +1505,7 @@ void SC_ProcessRequest_Test_CmdMID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_CmdMID */
+}
 
 void SC_ProcessRequest_Test_HkMID(void)
 {
@@ -1569,8 +1544,7 @@ void SC_ProcessRequest_Test_HkMID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_HkMID */
+}
 
 void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
 {
@@ -1607,8 +1581,7 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength */
+}
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
 {
@@ -1652,8 +1625,7 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_HkMIDAutoStartRts */
+}
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 {
@@ -1698,8 +1670,7 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded */
+}
 
 void SC_ProcessRequest_Test_1HzWakeupNONE(void)
 {
@@ -1745,8 +1716,7 @@ void SC_ProcessRequest_Test_1HzWakeupNONE(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_1HzWakeupNONE */
+}
 
 void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
 {
@@ -1792,8 +1762,7 @@ void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_1HzWakeupNoSwitchPending */
+}
 
 void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
 {
@@ -1840,8 +1809,7 @@ void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime */
+}
 
 void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
 {
@@ -1905,8 +1873,7 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime */
+}
 
 void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
 {
@@ -1961,8 +1928,7 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds */
+}
 
 void SC_ProcessRequest_Test_MIDError(void)
 {
@@ -1996,8 +1962,7 @@ void SC_ProcessRequest_Test_MIDError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessRequest_Test_MIDError */
+}
 
 void SC_ProcessCommand_Test_NoOp(void)
 {
@@ -2039,8 +2004,7 @@ void SC_ProcessCommand_Test_NoOp(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_NoOp */
+}
 
 void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
 {
@@ -2069,8 +2033,7 @@ void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_NoOpNoVerifyCmdLength */
+}
 
 void SC_ProcessCommand_Test_ResetCounters(void)
 {
@@ -2118,8 +2081,7 @@ void SC_ProcessCommand_Test_ResetCounters(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_ResetCounters */
+}
 
 void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
 {
@@ -2145,8 +2107,7 @@ void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength */
+}
 
 void SC_ProcessCommand_Test_StartAts(void)
 {
@@ -2172,8 +2133,7 @@ void SC_ProcessCommand_Test_StartAts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StartAts */
+}
 
 void SC_ProcessCommand_Test_StopAts(void)
 {
@@ -2197,8 +2157,7 @@ void SC_ProcessCommand_Test_StopAts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StopAts */
+}
 
 void SC_ProcessCommand_Test_StartRts(void)
 {
@@ -2222,8 +2181,7 @@ void SC_ProcessCommand_Test_StartRts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StartRts */
+}
 
 void SC_ProcessCommand_Test_StopRts(void)
 {
@@ -2247,8 +2205,7 @@ void SC_ProcessCommand_Test_StopRts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StopRts */
+}
 
 void SC_ProcessCommand_Test_DisableRts(void)
 {
@@ -2272,8 +2229,7 @@ void SC_ProcessCommand_Test_DisableRts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_DisableRts */
+}
 
 void SC_ProcessCommand_Test_EnableRts(void)
 {
@@ -2297,8 +2253,7 @@ void SC_ProcessCommand_Test_EnableRts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_EnableRts */
+}
 
 void SC_ProcessCommand_Test_SwitchAts(void)
 {
@@ -2322,8 +2277,7 @@ void SC_ProcessCommand_Test_SwitchAts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_SwitchAts */
+}
 
 void SC_ProcessCommand_Test_JumpAts(void)
 {
@@ -2347,8 +2301,7 @@ void SC_ProcessCommand_Test_JumpAts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_JumpAts */
+}
 
 void SC_ProcessCommand_Test_ContinueAtsOnFailure(void)
 {
@@ -2372,8 +2325,7 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailure(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_ContinueAtsOnFailure */
+}
 
 void SC_ProcessCommand_Test_AppendAts(void)
 {
@@ -2397,8 +2349,7 @@ void SC_ProcessCommand_Test_AppendAts(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_AppendAts */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTableNominal(void)
 {
@@ -2434,8 +2385,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableNominal(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTableNominal */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 {
@@ -2480,8 +2430,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTableGetAddressError */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTableID(void)
 {
@@ -2518,8 +2467,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableID(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTableID */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex(void)
 {
@@ -2544,8 +2492,7 @@ void SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
 {
@@ -2580,8 +2527,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess(void)
 {
@@ -2616,8 +2562,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess */
+}
 
 void SC_ProcessCommand_Test_TableManageAppendTableNominal(void)
 {
@@ -2653,8 +2598,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableNominal(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAppendTableNominal */
+}
 
 void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
 {
@@ -2699,8 +2643,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageAppendTableGetAddressError */
+}
 
 void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
 {
@@ -2735,8 +2678,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded */
+}
 
 void SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess(void)
 {
@@ -2771,8 +2713,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTableNominal(void)
 {
@@ -2804,8 +2745,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableNominal(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTableNominal */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 {
@@ -2850,8 +2790,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTableGetAddressError */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTableID(void)
 {
@@ -2884,8 +2823,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableID(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTableID */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex(void)
 {
@@ -2910,8 +2848,7 @@ void SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
 {
@@ -2942,8 +2879,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess(void)
 {
@@ -2974,8 +2910,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess */
+}
 
 void SC_ProcessCommand_Test_TableManageRtsInfo(void)
 {
@@ -3001,8 +2936,7 @@ void SC_ProcessCommand_Test_TableManageRtsInfo(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtsInfo */
+}
 
 void SC_ProcessCommand_Test_TableManageRtpCtrl(void)
 {
@@ -3028,8 +2962,7 @@ void SC_ProcessCommand_Test_TableManageRtpCtrl(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageRtpCtrl */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsInfo(void)
 {
@@ -3055,8 +2988,7 @@ void SC_ProcessCommand_Test_TableManageAtsInfo(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsInfo */
+}
 
 void SC_ProcessCommand_Test_TableManageAtpCtrl(void)
 {
@@ -3082,8 +3014,7 @@ void SC_ProcessCommand_Test_TableManageAtpCtrl(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtpCtrl */
+}
 
 void SC_ProcessCommand_Test_TableManageAtsCmdStatus(void)
 {
@@ -3109,8 +3040,7 @@ void SC_ProcessCommand_Test_TableManageAtsCmdStatus(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_TableManageAtsCmdStatus */
+}
 
 void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 {
@@ -3152,8 +3082,7 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_TableManageInvalidTableID */
+}
 
 void SC_ProcessCommand_Test_StartRtsGrp(void)
 {
@@ -3177,8 +3106,7 @@ void SC_ProcessCommand_Test_StartRtsGrp(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StartRtsGrp */
+}
 
 void SC_ProcessCommand_Test_StopRtsGrp(void)
 {
@@ -3202,8 +3130,7 @@ void SC_ProcessCommand_Test_StopRtsGrp(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_StopRtsGrp */
+}
 
 void SC_ProcessCommand_Test_DisableRtsGrp(void)
 {
@@ -3227,8 +3154,7 @@ void SC_ProcessCommand_Test_DisableRtsGrp(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_DisableRtsGrp */
+}
 
 void SC_ProcessCommand_Test_EnableRtsGrp(void)
 {
@@ -3252,8 +3178,7 @@ void SC_ProcessCommand_Test_EnableRtsGrp(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-
-} /* end SC_ProcessCommand_Test_EnableRtsGrp */
+}
 
 void SC_ProcessCommand_Test_InvalidCmdError(void)
 {
@@ -3296,8 +3221,7 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessCommand_Test_InvalidCmdError */
+}
 
 /* Unreachable branches in sc_cmds.c SC_ProcessAtpCmd:236, 274, 310.
    There are only 2 ATS IDs defined, invalid IDs are already handled. */
@@ -3435,9 +3359,4 @@ void UtTest_Setup(void)
                "SC_ProcessCommand_Test_EnableRtsGrp");
     UtTest_Add(SC_ProcessCommand_Test_InvalidCmdError, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_InvalidCmdError");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -61,13 +61,13 @@ int32 SC_LOADS_TEST_CFE_MSG_GetSizeHook1(void *UserObj, int32 StubRetcode, uint3
         SC_OperData.AtsCmdStatusTblAddr[0][1] = SC_LOADED;
 
     return CFE_SUCCESS;
-} /* end SC_LOADS_TEST_CFE_MSG_GetSizeHook1 */
+}
 
 CFE_TIME_Compare_t UT_SC_Insert_CompareHookAgreaterthanB(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                                          const UT_StubContext_t *Context)
 {
     return CFE_TIME_A_GT_B;
-} /* end CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHookAgreaterthanB */
+}
 
 void SC_LoadAts_Test_Nominal(void)
 {
@@ -106,8 +106,7 @@ void SC_LoadAts_Test_Nominal(void)
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_LoadAts_Test_Nominal */
+}
 
 void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
 {
@@ -161,8 +160,7 @@ void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_CmdRunOffEndOfBuffer */
+}
 
 void SC_LoadAts_Test_CmdLengthInvalid(void)
 {
@@ -206,8 +204,7 @@ void SC_LoadAts_Test_CmdLengthInvalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_CmdLengthInvalid */
+}
 
 void SC_LoadAts_Test_CmdLengthZero(void)
 {
@@ -251,8 +248,7 @@ void SC_LoadAts_Test_CmdLengthZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_CmdLengthZero */
+}
 
 void SC_LoadAts_Test_CmdNumberInvalid(void)
 {
@@ -296,8 +292,7 @@ void SC_LoadAts_Test_CmdNumberInvalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_CmdNumberInvalid */
+}
 
 void SC_LoadAts_Test_EndOfLoadReached(void)
 {
@@ -341,8 +336,7 @@ void SC_LoadAts_Test_EndOfLoadReached(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_EndOfLoadReached */
+}
 
 void SC_LoadAts_Test_AtsBufferTooSmall(void)
 {
@@ -411,8 +405,7 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_AtsBufferTooSmall */
+}
 
 void SC_LoadAts_Test_AtsEntryOverflow(void)
 {
@@ -472,8 +465,7 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_AtsEntryOverflow */
+}
 
 void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 {
@@ -523,8 +515,7 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadAts_Test_LoadExactlyBufferLength */
+}
 
 void SC_LoadAts_Test_CmdNotEmpty(void)
 {
@@ -570,8 +561,7 @@ void SC_LoadAts_Test_CmdNotEmpty(void)
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_LoadAts_Test_CmdNotEmpty */
+}
 
 void SC_LoadAts_Test_InvalidIndex(void)
 {
@@ -582,8 +572,7 @@ void SC_LoadAts_Test_InvalidIndex(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LOADATS_INV_INDEX_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end SC_LoadAts_Test_InvalidIndex */
+}
 
 void SC_BuildTimeIndexTable_Test_InvalidIndex(void)
 {
@@ -611,8 +600,7 @@ void SC_BuildTimeIndexTable_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_BuildTimeIndexTable_Test_InvalidIndex */
+}
 
 void SC_Insert_Test(void)
 {
@@ -637,8 +625,7 @@ void SC_Insert_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_Insert_Test */
+}
 
 void SC_Insert_Test_MiddleOfList(void)
 {
@@ -667,8 +654,7 @@ void SC_Insert_Test_MiddleOfList(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_Insert_Test_MiddleOfList */
+}
 
 void SC_Insert_Test_MiddleOfListCompareAbsTimeTrue(void)
 {
@@ -697,8 +683,7 @@ void SC_Insert_Test_MiddleOfListCompareAbsTimeTrue(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_Insert_Test_MiddleOfListCompareAbsTimeTrue */
+}
 
 void SC_Insert_Test_InvalidIndex(void)
 {
@@ -727,8 +712,7 @@ void SC_Insert_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_Insert_Test_InvalidIndex */
+}
 
 void SC_InitAtsTables_Test_InvalidIndex(void)
 {
@@ -753,8 +737,7 @@ void SC_InitAtsTables_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_InitAtsTables_Test_InvalidIndex */
+}
 
 void SC_ValidateAts_Test(void)
 {
@@ -779,8 +762,7 @@ void SC_ValidateAts_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ValidateAts_Test */
+}
 
 void SC_ValidateAppend_Test(void)
 {
@@ -805,8 +787,7 @@ void SC_ValidateAppend_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ValidateAppend_Test */
+}
 
 void SC_ValidateRts_Test(void)
 {
@@ -837,8 +818,7 @@ void SC_ValidateRts_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ValidateRts_Test */
+}
 
 void SC_ValidateRts_Test_ParseRts(void)
 {
@@ -869,8 +849,7 @@ void SC_ValidateRts_Test_ParseRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ValidateRts_Test_ParseRts */
+}
 
 void SC_LoadRts_Test_Nominal(void)
 {
@@ -886,8 +865,7 @@ void SC_LoadRts_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadRts_Test_Nominal */
+}
 
 void SC_LoadRts_Test_InvalidIndex(void)
 {
@@ -912,8 +890,7 @@ void SC_LoadRts_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_LoadRts_Test_InvalidIndex */
+}
 
 void SC_ParseRts_Test_EndOfFile(void)
 {
@@ -944,8 +921,7 @@ void SC_ParseRts_Test_EndOfFile(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_EndOfFile */
+}
 
 void SC_ParseRts_Test_InvalidMsgId(void)
 {
@@ -987,8 +963,7 @@ void SC_ParseRts_Test_InvalidMsgId(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_InvalidMsgId */
+}
 
 void SC_ParseRts_Test_LengthErrorTooShort(void)
 {
@@ -1032,8 +1007,7 @@ void SC_ParseRts_Test_LengthErrorTooShort(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_LengthErrorTooShort */
+}
 
 void SC_ParseRts_Test_LengthErrorTooLong(void)
 {
@@ -1077,8 +1051,7 @@ void SC_ParseRts_Test_LengthErrorTooLong(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_LengthErrorTooLong */
+}
 
 void SC_ParseRts_Test_CmdRunsOffEndOfBuffer(void)
 {
@@ -1126,8 +1099,7 @@ void SC_ParseRts_Test_CmdRunsOffEndOfBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_CmdRunsOffEndOfBuffer */
+}
 
 void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
 {
@@ -1172,8 +1144,7 @@ void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ParseRts_Test_CmdLengthEqualsBufferLength */
+}
 
 void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
 {
@@ -1205,8 +1176,7 @@ void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
     UtAssert_BOOL_TRUE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_ParseRts_Test_CmdDoesNotFitBufferEmpty */
+}
 
 void SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty(void)
 {
@@ -1250,8 +1220,7 @@ void SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty */
+}
 
 void SC_UpdateAppend_Test_Nominal(void)
 {
@@ -1299,8 +1268,7 @@ void SC_UpdateAppend_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_Nominal */
+}
 
 void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
 {
@@ -1353,8 +1321,7 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_CmdDoesNotFitBuffer */
+}
 
 void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
 {
@@ -1399,8 +1366,7 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_InvalidCmdLengthTooLow */
+}
 
 void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
 {
@@ -1445,8 +1411,7 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_InvalidCmdLengthTooHigh */
+}
 
 void SC_UpdateAppend_Test_EndOfBuffer(void)
 {
@@ -1505,8 +1470,7 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_EndOfBuffer */
+}
 
 void SC_UpdateAppend_Test_CmdNumberZero(void)
 {
@@ -1553,8 +1517,7 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_CmdNumberZero */
+}
 
 void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
 {
@@ -1601,8 +1564,7 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateAppend_Test_CmdNumberTooHigh */
+}
 
 void SC_ProcessAppend_Test(void)
 {
@@ -1665,8 +1627,7 @@ void SC_ProcessAppend_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAppend_Test */
+}
 
 void SC_ProcessAppend_Test_CmdLoaded(void)
 {
@@ -1726,8 +1687,7 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAppend_Test_CmdLoaded */
+}
 
 void SC_ProcessAppend_Test_NotExecuting(void)
 {
@@ -1786,8 +1746,7 @@ void SC_ProcessAppend_Test_NotExecuting(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAppend_Test_NotExecuting */
+}
 
 void SC_ProcessAppend_Test_AtsNumber(void)
 {
@@ -1847,8 +1806,7 @@ void SC_ProcessAppend_Test_AtsNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAppend_Test_AtsNumber */
+}
 
 void SC_ProcessAppend_Test_InvalidIndex(void)
 {
@@ -1874,8 +1832,7 @@ void SC_ProcessAppend_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_ProcessAppend_Test_InvalidIndex */
+}
 
 void SC_VerifyAtsTable_Test_Nominal(void)
 {
@@ -1939,8 +1896,7 @@ void SC_VerifyAtsTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsTable_Test_Nominal */
+}
 
 void SC_VerifyAtsTable_Test_InvalidEntry(void)
 {
@@ -1970,8 +1926,7 @@ void SC_VerifyAtsTable_Test_InvalidEntry(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsTable_Test_InvalidEntry */
+}
 
 void SC_VerifyAtsTable_Test_EmptyTable(void)
 {
@@ -2007,8 +1962,7 @@ void SC_VerifyAtsTable_Test_EmptyTable(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsTable_Test_EmptyTable */
+}
 
 void SC_VerifyAtsEntry_Test_Nominal(void)
 {
@@ -2042,8 +1996,7 @@ void SC_VerifyAtsEntry_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_Nominal */
+}
 
 void SC_VerifyAtsEntry_Test_EndOfBuffer(void)
 {
@@ -2062,8 +2015,7 @@ void SC_VerifyAtsEntry_Test_EndOfBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_EndOfBuffer */
+}
 
 void SC_VerifyAtsEntry_Test_InvalidCmdNumber(void)
 {
@@ -2100,8 +2052,7 @@ void SC_VerifyAtsEntry_Test_InvalidCmdNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_InvalidCmdNumber */
+}
 
 void SC_VerifyAtsEntry_Test_BufferFull(void)
 {
@@ -2138,8 +2089,7 @@ void SC_VerifyAtsEntry_Test_BufferFull(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_BufferFull */
+}
 
 void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow(void)
 {
@@ -2182,8 +2132,7 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow */
+}
 
 void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh(void)
 {
@@ -2226,8 +2175,7 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh */
+}
 
 void SC_VerifyAtsEntry_Test_BufferOverflow(void)
 {
@@ -2269,8 +2217,7 @@ void SC_VerifyAtsEntry_Test_BufferOverflow(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_BufferOverflow */
+}
 
 void SC_VerifyAtsEntry_Test_DuplicateCmdNumber(void)
 {
@@ -2314,8 +2261,7 @@ void SC_VerifyAtsEntry_Test_DuplicateCmdNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyAtsEntry_Test_DuplicateCmdNumber */
+}
 
 void UtTest_Setup(void)
 {
@@ -2399,8 +2345,4 @@ void UtTest_Setup(void)
                "SC_VerifyAtsEntry_Test_BufferOverflow");
     UtTest_Add(SC_VerifyAtsEntry_Test_DuplicateCmdNumber, SC_Test_Setup, SC_Test_TearDown,
                "SC_VerifyAtsEntry_Test_DuplicateCmdNumber");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -108,8 +108,7 @@ void SC_StartRtsCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_Nominal */
+}
 
 void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
 {
@@ -177,8 +176,7 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_StartRtsNoEvents */
+}
 
 void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
 {
@@ -229,8 +227,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_InvalidCommandLength1 */
+}
 
 void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
 {
@@ -281,8 +278,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_InvalidCommandLength2 */
+}
 
 void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
 {
@@ -329,8 +325,7 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_RtsNotLoadedOrInUse */
+}
 
 void SC_StartRtsCmd_Test_RtsDisabled(void)
 {
@@ -374,8 +369,7 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_RtsDisabled */
+}
 
 void SC_StartRtsCmd_Test_InvalidRtsId(void)
 {
@@ -406,8 +400,7 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_InvalidRtsId */
+}
 
 void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 {
@@ -438,12 +431,10 @@ void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_InvalidRtsIdZero */
+}
 
 void SC_StartRtsCmd_Test_NoVerifyLength(void)
 {
-
     /* Execute the function being tested */
     SC_StartRtsCmd(&UT_CmdBuf.Buf);
 
@@ -454,8 +445,7 @@ void SC_StartRtsCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsCmd_Test_NoVerifyLength */
+}
 
 void SC_StartRtsGrpCmd_Test_Nominal(void)
 {
@@ -511,8 +501,7 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_Nominal */
+}
 
 void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 {
@@ -545,8 +534,7 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_StartRtsGroupError */
+}
 
 void SC_StartRtsGrpCmd_Test_NoVerifyLength(void)
 {
@@ -558,8 +546,7 @@ void SC_StartRtsGrpCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_NoVerifyLength */
+}
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 {
@@ -593,8 +580,7 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_FirstRtsIndex */
+}
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
@@ -627,8 +613,7 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_FirstRtsIndexZero */
+}
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 {
@@ -662,8 +647,7 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_LastRtsIndex */
+}
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
@@ -696,8 +680,7 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_LastRtsIndexZero */
+}
 
 void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
@@ -731,8 +714,7 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_FirstLastRtsIndex */
+}
 
 void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 {
@@ -802,8 +784,7 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_DisabledFlag */
+}
 
 void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 {
@@ -874,8 +855,7 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StartRtsGrpCmd_Test_RtsStatus */
+}
 
 void SC_StopRtsCmd_Test_Nominal(void)
 {
@@ -907,8 +887,7 @@ void SC_StopRtsCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsCmd_Test_Nominal */
+}
 
 void SC_StopRtsCmd_Test_InvalidRts(void)
 {
@@ -940,8 +919,7 @@ void SC_StopRtsCmd_Test_InvalidRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsCmd_Test_InvalidRts */
+}
 
 void SC_StopRtsCmd_Test_NoVerifyLength(void)
 {
@@ -953,8 +931,7 @@ void SC_StopRtsCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsCmd_Test_NoVerifyLength */
+}
 
 void SC_StopRtsGrpCmd_Test_Nominal(void)
 {
@@ -988,8 +965,7 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_Nominal */
+}
 
 void SC_StopRtsGrpCmd_Test_Error(void)
 {
@@ -1022,8 +998,7 @@ void SC_StopRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_Error */
+}
 
 void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
 {
@@ -1035,8 +1010,7 @@ void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_NoVerifyLength */
+}
 
 void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 {
@@ -1081,8 +1055,7 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_NotExecuting */
+}
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 {
@@ -1115,8 +1088,7 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_FirstRtsIndex */
+}
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
@@ -1149,8 +1121,7 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_FirstRtsIndexZero */
+}
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 {
@@ -1183,8 +1154,7 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_LastRtsIndex */
+}
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
@@ -1217,8 +1187,7 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_LastRtsIndexZero */
+}
 
 void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
@@ -1251,8 +1220,7 @@ void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_StopRtsGrpCmd_Test_FirstLastRtsIndex */
+}
 
 void SC_DisableRtsCmd_Test_Nominal(void)
 {
@@ -1287,8 +1255,7 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsCmd_Test_Nominal */
+}
 
 void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 {
@@ -1320,8 +1287,7 @@ void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsCmd_Test_InvalidRtsID */
+}
 
 void SC_DisableRtsCmd_Test_NoVerifyLength(void)
 {
@@ -1333,8 +1299,7 @@ void SC_DisableRtsCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsCmd_Test_NoVerifyLength */
+}
 
 void SC_DisableRtsGrpCmd_Test_Nominal(void)
 {
@@ -1371,8 +1336,7 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_Nominal */
+}
 
 void SC_DisableRtsGrpCmd_Test_Error(void)
 {
@@ -1406,8 +1370,7 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_Error */
+}
 
 void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
 {
@@ -1419,8 +1382,7 @@ void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_NoVerifyLength */
+}
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
@@ -1454,8 +1416,7 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_FirstRtsIndex */
+}
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
@@ -1489,8 +1450,7 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero */
+}
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 {
@@ -1524,8 +1484,7 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_LastRtsIndex */
+}
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
@@ -1559,8 +1518,7 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_LastRtsIndexZero */
+}
 
 void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
@@ -1594,8 +1552,7 @@ void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex */
+}
 
 void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 {
@@ -1634,8 +1591,7 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_DisableRtsGrpCmd_Test_DisabledFlag */
+}
 
 void SC_EnableRtsCmd_Test_Nominal(void)
 {
@@ -1670,8 +1626,7 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsCmd_Test_Nominal */
+}
 
 void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 {
@@ -1703,8 +1658,7 @@ void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsCmd_Test_InvalidRtsID */
+}
 
 void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 {
@@ -1736,8 +1690,7 @@ void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsCmd_Test_InvalidRtsIDZero */
+}
 
 void SC_EnableRtsCmd_Test_NoVerifyLength(void)
 {
@@ -1749,8 +1702,7 @@ void SC_EnableRtsCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsCmd_Test_NoVerifyLength */
+}
 
 void SC_EnableRtsGrpCmd_Test_Nominal(void)
 {
@@ -1788,8 +1740,7 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_Nominal */
+}
 
 void SC_EnableRtsGrpCmd_Test_Error(void)
 {
@@ -1823,8 +1774,7 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_Error */
+}
 
 void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
 {
@@ -1836,8 +1786,7 @@ void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_NoVerifyLength */
+}
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
@@ -1871,8 +1820,7 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_FirstRtsIndex */
+}
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
@@ -1906,8 +1854,7 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero */
+}
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 {
@@ -1941,8 +1888,7 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_LastRtsIndex */
+}
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
@@ -1976,8 +1922,7 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_LastRtsIndexZero */
+}
 
 void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
@@ -2011,8 +1956,7 @@ void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex */
+}
 
 void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 {
@@ -2051,8 +1995,7 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_EnableRtsGrpCmd_Test_DisabledFlag */
+}
 
 void SC_KillRts_Test(void)
 {
@@ -2084,8 +2027,7 @@ void SC_KillRts_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_KillRts_Test */
+}
 
 void SC_KillRts_Test_NoActiveRts(void)
 {
@@ -2117,8 +2059,7 @@ void SC_KillRts_Test_NoActiveRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_KillRts_Test_NoActiveRts */
+}
 
 void SC_KillRts_Test_InvalidIndex(void)
 {
@@ -2143,8 +2084,7 @@ void SC_KillRts_Test_InvalidIndex(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_KillRts_Test_InvalidIndex */
+}
 
 void SC_AutoStartRts_Test_Nominal(void)
 {
@@ -2158,8 +2098,7 @@ void SC_AutoStartRts_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AutoStartRts_Test_Nominal */
+}
 
 void SC_AutoStartRts_Test_InvalidId(void)
 {
@@ -2184,8 +2123,7 @@ void SC_AutoStartRts_Test_InvalidId(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AutoStart_Test_InvalidId */
+}
 
 void SC_AutoStartRts_Test_InvalidIdZero(void)
 {
@@ -2210,8 +2148,7 @@ void SC_AutoStartRts_Test_InvalidIdZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_AutoStartRts_Test_InvalidIdZero */
+}
 
 void UtTest_Setup(void)
 {
@@ -2318,9 +2255,4 @@ void UtTest_Setup(void)
     UtTest_Add(SC_AutoStartRts_Test_InvalidId, SC_Test_Setup, SC_Test_TearDown, "SC_AutoStartRts_Test_InvalidId");
     UtTest_Add(SC_AutoStartRts_Test_InvalidIdZero, SC_Test_Setup, SC_Test_TearDown,
                "SC_AutoStartRts_Test_InvalidIdZero");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -66,7 +66,7 @@ int32 SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook(void *UserObj, int32 StubRetcod
         return SC_PACKET_MAX_SIZE;
     else
         return SC_PACKET_MAX_SIZE + 100;
-} /* end SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook */
+}
 
 void SC_GetNextRtsTime_Test_Nominal(void)
 {
@@ -95,8 +95,7 @@ void SC_GetNextRtsTime_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsTime_Test_Nominal */
+}
 
 void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
 {
@@ -127,8 +126,7 @@ void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsTime_Test_InvalidRtsNumber */
+}
 
 void SC_GetNextRtsTime_Test_RtsPriority(void)
 {
@@ -160,8 +158,7 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsTime_Test_RtsPriority */
+}
 
 void SC_UpdateNextTime_Test_Atp(void)
 {
@@ -191,8 +188,7 @@ void SC_UpdateNextTime_Test_Atp(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateNextTime_Test_Atp */
+}
 
 void SC_UpdateNextTime_Test_Atp2(void)
 {
@@ -225,8 +221,7 @@ void SC_UpdateNextTime_Test_Atp2(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateNextTime_Test_Atp2 */
+}
 
 void SC_UpdateNextTime_Test_Rtp(void)
 {
@@ -261,8 +256,7 @@ void SC_UpdateNextTime_Test_Rtp(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateNextTime_Test_Rtp */
+}
 
 void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 {
@@ -295,8 +289,7 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_UpdateNextTime_Test_RtpAtpPriority */
+}
 
 void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 {
@@ -353,8 +346,7 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_GetNextCommand */
+}
 
 void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 {
@@ -367,8 +359,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_GetNextRtsCommand_Test_RtsNumberZero */
+}
 
 void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 {
@@ -420,8 +411,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_RtsNumberMax */
+}
 
 void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 {
@@ -472,8 +462,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_RtsNumberOverMax */
+}
 
 void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 {
@@ -525,8 +514,7 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_RtsNotExecuting */
+}
 
 void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 {
@@ -605,8 +593,7 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_RtsLengthError */
+}
 
 void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 {
@@ -685,8 +672,7 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_CommandLengthError */
+}
 
 void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 {
@@ -754,8 +740,7 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_ZeroCommandLength */
+}
 
 void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
 {
@@ -815,8 +800,7 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts */
+}
 
 void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 {
@@ -881,8 +865,7 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_EndOfBuffer */
+}
 
 void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 {
@@ -937,8 +920,7 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextRtsCommand_Test_EndOfBufferLastRts */
+}
 
 void SC_GetNextAtsCommand_Test_Starting(void)
 {
@@ -971,8 +953,7 @@ void SC_GetNextAtsCommand_Test_Starting(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextAtsCommand_Test_Starting */
+}
 
 void SC_GetNextAtsCommand_Test_Idle(void)
 {
@@ -1005,8 +986,7 @@ void SC_GetNextAtsCommand_Test_Idle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextAtsCommand_Test_Idle */
+}
 
 void SC_GetNextAtsCommand_Test_GetNextCommand(void)
 {
@@ -1058,8 +1038,7 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
     UtAssert_INT32_EQ(SC_AppData.NextCmdTime[SC_ATP], 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end SC_GetNextAtsCommand_Test_GetNextCommand */
+}
 
 void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 {
@@ -1119,8 +1098,7 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextAtsCommand_Test_ExecutionACompleted */
+}
 
 void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 {
@@ -1180,8 +1158,7 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_GetNextAtsCommand_Test_ExecutionBCompleted */
+}
 
 /* Unreachable branch in sc_state.c SC_UpdateNextTime:140.
    RtsNumber can never be assigned a value > SC_NUMBER_RTS
@@ -1230,9 +1207,4 @@ void UtTest_Setup(void)
                "SC_GetNextAtsCommand_Test_ExecutionACompleted");
     UtTest_Add(SC_GetNextAtsCommand_Test_ExecutionBCompleted, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextAtsCommand_Test_ExecutionBCompleted");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -40,8 +40,7 @@ void SC_GetCurrentTime_Test(void)
 
     /* Verify results */
     UtAssert_True(SC_AppData.CurrentTime != 0, "SC_AppData.CurrentTime != 0");
-
-} /* end SC_GetCurrentTime_Test */
+}
 
 void SC_GetAtsEntryTime_Test(void)
 {
@@ -56,8 +55,7 @@ void SC_GetAtsEntryTime_Test(void)
 
     /* Verify results */
     UtAssert_True(AbsTimeTag == 10, "AbsTimeTag == 10");
-
-} /* end SC_GetAtsEntryTime_Test */
+}
 
 void SC_ComputeAbsTime_Test(void)
 {
@@ -72,8 +70,7 @@ void SC_ComputeAbsTime_Test(void)
 
     /* The CFE_TIME_Add stub increments when status >= 0 */
     UtAssert_True(AbsTimeTag == 1, "AbsTimeTag == 1");
-
-} /* end SC_ComputeAbsTime_Test */
+}
 
 void SC_CompareAbsTime_Test_True(void)
 {
@@ -89,8 +86,7 @@ void SC_CompareAbsTime_Test_True(void)
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
-
-} /* end SC_CompareAbsTime_Test_True */
+}
 
 void SC_CompareAbsTime_Test_False(void)
 {
@@ -106,8 +102,7 @@ void SC_CompareAbsTime_Test_False(void)
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
-
-} /* end SC_CompareAbsTime_Test_False */
+}
 
 void SC_VerifyCmdLength_Test_Nominal(void)
 {
@@ -134,8 +129,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyCmdLength_Test_Nominal */
+}
 
 void SC_VerifyCmdLength_Test_LenError(void)
 {
@@ -175,8 +169,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyCmdLength_Test_LenError */
+}
 
 void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
 {
@@ -215,8 +208,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end SC_VerifyCmdLength_Test_LenErrorNotMID */
+}
 
 void SC_ToggleAtsIndex_Test(void)
 {
@@ -237,8 +229,7 @@ void SC_ToggleAtsIndex_Test(void)
     Result = SC_ToggleAtsIndex();
 
     UtAssert_True(Result == 0, "Result == 0");
-
-} /* end SC_ToggleAtsIndex_Test */
+}
 
 void UtTest_Setup(void)
 {
@@ -252,9 +243,4 @@ void UtTest_Setup(void)
     UtTest_Add(SC_VerifyCmdLength_Test_LenErrorNotMID, SC_Test_Setup, SC_Test_TearDown,
                "SC_VerifyCmdLength_Test_LenErrorNotMID");
     UtTest_Add(SC_ToggleAtsIndex_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ToggleAtsIndex_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #58
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 