### PR TITLE
Fix #60, Apply consistent Event ID names to common events

### DIFF
--- a/config/default_sc_fcncodes.h
+++ b/config/default_sc_fcncodes.h
@@ -56,7 +56,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - Error specific event message #SC_LEN_ERR_EID
+ *       - Error specific event message #SC_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -87,7 +87,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - Error specific event message #SC_LEN_ERR_EID
+ *       - Error specific event message #SC_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -476,7 +476,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
+ *       - The #SC_CMD_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_STARTRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
  *  \par Criticality
@@ -516,7 +516,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
+ *       - The #SC_CMD_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_STOPRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
  *  \par Criticality
@@ -554,7 +554,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
+ *       - The #SC_CMD_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_DISRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
  *  \par Criticality
@@ -592,7 +592,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
- *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
+ *       - The #SC_CMD_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_ENARTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
  *  \par Criticality

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -50,7 +50,7 @@
  *  This event message is issued when a command is received, but it is not of the expected
  *  length
  */
-#define SC_LEN_ERR_EID 2
+#define SC_CMD_LEN_ERR_EID 2
 
 /**
  * \brief SC Create Pipe Failed Event ID
@@ -61,7 +61,7 @@
  *  This event message is issued when #CFE_SB_CreatePipe returns an
  *  error
  */
-#define SC_INIT_SB_CREATE_ERR_EID 3
+#define SC_CR_PIPE_ERR_EID 3
 
 /**
  * \brief SC Housekeeping Request Subscribe Failed Event ID
@@ -508,7 +508,7 @@
  *  \par Cause:
  *  This event message is issued when the #SC_RESET_COUNTERS_CC command was received
  */
-#define SC_RESET_DEB_EID 51
+#define SC_RESET_INF_EID 51
 
 /**
  * \brief SC No-op Command Event ID
@@ -585,7 +585,7 @@
  *  This event message is issued when an invalid command code was received in
  *  the command pipe
  */
-#define SC_INVLD_CMD_ERR_EID 64
+#define SC_CC_ERR_EID 64
 
 /**
  * \brief SC RTS Info Table Get Address Failed Event ID

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -186,7 +186,7 @@ CFE_Status_t SC_AppInit(void)
     Result = CFE_SB_CreatePipe(&SC_OperData.CmdPipe, SC_PIPE_DEPTH, SC_CMD_PIPE_NAME);
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(SC_INIT_SB_CREATE_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(SC_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Software Bus Create Pipe returned: 0x%08X", (unsigned int)Result);
         return Result;
     }

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -518,7 +518,7 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
 
 void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
 {
-    CFE_EVS_SendEvent(SC_RESET_DEB_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(SC_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
 
     SC_OperData.HkPacket.Payload.CmdCtr          = 0;
     SC_OperData.HkPacket.Payload.CmdErrCtr       = 0;

--- a/fsw/src/sc_dispatch.c
+++ b/fsw/src/sc_dispatch.c
@@ -65,7 +65,7 @@ bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
         CFE_MSG_GetMsgId(Msg, &MessageID);
         CFE_MSG_GetFcnCode(Msg, &CommandCode);
 
-        CFE_EVS_SendEvent(SC_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(SC_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
                           (int)ExpectedLength);
@@ -264,8 +264,7 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             break;
 
         default:
-            CFE_EVS_SendEvent(SC_INVLD_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid Command Code: MID =  0x%08lX CC =  %d",
+            CFE_EVS_SendEvent(SC_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Command Code: MID =  0x%08lX CC =  %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
             SC_OperData.HkPacket.Payload.CmdErrCtr++;
             break;

--- a/fsw/src/sc_dispatch.h
+++ b/fsw/src/sc_dispatch.h
@@ -46,7 +46,7 @@
  *  \retval true  Length matches expected
  *  \retval false Length does not match expected
  *
- *  \sa #SC_LEN_ERR_EID
+ *  \sa #SC_CMD_LEN_ERR_EID
  */
 bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength);
 

--- a/fsw/src/sc_utils.h
+++ b/fsw/src/sc_utils.h
@@ -105,7 +105,7 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2);
  *  \retval 0 When current ATS index is 1
  *  \retval 1 When current ATS index is 0
  *
- *  \sa #SC_LEN_ERR_EID
+ *  \sa #SC_CMD_LEN_ERR_EID
  */
 SC_AtsIndex_t SC_ToggleAtsIndex(void);
 

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -271,14 +271,14 @@ void SC_AppInit_Test_EVSRegisterError(void)
 
 void SC_AppInit_Test_SBCreatePipeError(void)
 {
-    /* Set CFE_SB_CreatePipe to return -1 in order to generate error message SC_INIT_SB_CREATE_ERR_EID */
+    /* Set CFE_SB_CreatePipe to return -1 in order to generate error message SC_CR_PIPE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_CreatePipe), 1, -1);
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_AppInit(), -1);
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_SB_CREATE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CR_PIPE_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -1204,7 +1204,7 @@ void SC_ProcessCommand_Test_ResetCounters(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "RtsActiveCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 0, "RtsActiveErrCtr == 0");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RESET_DEB_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RESET_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -128,7 +128,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -149,7 +149,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -210,7 +210,7 @@ void SC_ProcessRequest_Test_SendHkCmdInvalidLength(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(SC_SendHkCmd, 0);
 }
 
@@ -251,7 +251,7 @@ void SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(SC_OneHzWakeupCmd, 0);
 }
 
@@ -293,7 +293,7 @@ void SC_ProcessCommand_Test_NoopCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(SC_NoopCmd, 0);
 }
 
@@ -314,7 +314,7 @@ void SC_ProcessCommand_Test_ResetCounterCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
     UtAssert_STUB_COUNT(SC_ResetCountersCmd, 0);
 }
 
@@ -335,7 +335,7 @@ void SC_ProcessCommand_Test_StartAtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_StopAtsCmdInvalidLength(void)
@@ -355,7 +355,7 @@ void SC_ProcessCommand_Test_StopAtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_StartRtsCmdInvalidLength(void)
@@ -375,7 +375,7 @@ void SC_ProcessCommand_Test_StartRtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_StopRtsCmdInvalidLength(void)
@@ -395,7 +395,7 @@ void SC_ProcessCommand_Test_StopRtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_DisableRtsCmdInvalidLength(void)
@@ -415,7 +415,7 @@ void SC_ProcessCommand_Test_DisableRtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_EnableRtsCmdInvalidLength(void)
@@ -435,7 +435,7 @@ void SC_ProcessCommand_Test_EnableRtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_SwitchAtsCmdInvalidLength(void)
@@ -455,7 +455,7 @@ void SC_ProcessCommand_Test_SwitchAtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_JumpAtsCmdInvalidLength(void)
@@ -475,7 +475,7 @@ void SC_ProcessCommand_Test_JumpAtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength(void)
@@ -495,7 +495,7 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_AppendAtsCmdInvalidLength(void)
@@ -515,7 +515,7 @@ void SC_ProcessCommand_Test_AppendAtsCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_TableManageCmdInvalidLength(void)
@@ -535,7 +535,7 @@ void SC_ProcessCommand_Test_TableManageCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_StartRtsGrpCmdInvalidLength(void)
@@ -555,7 +555,7 @@ void SC_ProcessCommand_Test_StartRtsGrpCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_StopRtsGrpCmdInvalidLength(void)
@@ -575,7 +575,7 @@ void SC_ProcessCommand_Test_StopRtsGrpCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_DisableRtsGrpCmdInvalidLength(void)
@@ -595,7 +595,7 @@ void SC_ProcessCommand_Test_DisableRtsGrpCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_EnableRtsGrpCmdInvalidLength(void)
@@ -615,7 +615,7 @@ void SC_ProcessCommand_Test_EnableRtsGrpCmdInvalidLength(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
 void SC_ProcessCommand_Test_NoopCmdNominal(void)
@@ -913,7 +913,7 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INVLD_CMD_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CC_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #60
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt