### PR TITLE
Fix #63, Remove initializations causing Cppcheck errors

### DIFF
--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -59,7 +59,7 @@ void SC_ProcessAtpCmd(void)
     int32             EntryIndex; /* ATS entry location in table */
     uint8             AtsIndex;   /* ATS selection index */
     uint32            CmdIndex;   /* ATS command index */
-    char              TempAtsChar = ' ';
+    char              TempAtsChar;
     int32             Result;
     bool              AbortATS = false;
     SC_AtsEntry_t *   EntryPtr;

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -384,9 +384,9 @@ bool SC_ParseRts(uint32 Buffer32[])
     bool           Done;
     bool           Error;
     SC_RtsEntry_t *EntryPtr;
-    CFE_MSG_Size_t CmdSize    = 0;
-    uint16         IndexDelta = 0;
-    CFE_SB_MsgId_t MessageID  = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_Size_t CmdSize = 0;
+    uint16         IndexDelta;
+    CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
 
     i    = 0;
     Done = Error = false;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #63 
Both seem fine to change from initialization at the top of the function to a plain declaration.
`TempAtsChar` is used in only one location, and that is after a mutually exclusive `if`/`else` which assigns it a value in both cases.
`IndexDelta` is used inside just one `if` block, and is assigned a value (on line 409) before any of the 3 references to it are made.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on code behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt