### PR TITLE
Fix #76, Squash static analysis (CodeQL) uninitialized variable warning

### DIFF
--- a/docs/dox_src/cfs_sc.dox
+++ b/docs/dox_src/cfs_sc.dox
@@ -504,7 +504,7 @@
   time tag in the overlap region (including the switch command) this logic 
   does not get used. In either case, the switch can be performed without 
   sending any duplicate commands to be sent out. There are certain conditions 
-  that can cause a ATS switch that is pending to be canceled. If the ATP is 
+  that can cause an ATS switch that is pending to be canceled. If the ATP is 
   stopped by the ground while the ATP is waiting for a "safe" time to switch, 
   then the switch will not occur. Also if the ATP detects the end of the ATS 
   buffer before there is a "safe" time to switch, the switch will be canceled. 

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -439,7 +439,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a ATS command that was about to be sent out
+ *  This event message is issued when an ATS command that was about to be sent out
  *  failed checksum validation, and the Continue-ATS-on_checksum-Failure flag was
  *  set to 'FALSE'
  */

--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -179,11 +179,11 @@ void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
 {
-    SC_AtsEntryHeader_t *Entry;       /* ATS table entry pointer */
-    int32                EntryIndex;  /* ATS entry location in table */
-    SC_AbsTimeTag_t      ListCmdTime; /* list entry execution time */
-    int32                TimeIndex;   /* the current time buffer index */
-    int32                CmdIndex;    /* ATS command index (cmd num - 1) */
+    SC_AtsEntryHeader_t *Entry;           /* ATS table entry pointer */
+    int32                EntryIndex;      /* ATS entry location in table */
+    SC_AbsTimeTag_t      ListCmdTime = 0; /* list entry execution time */
+    int32                TimeIndex;       /* the current time buffer index */
+    int32                CmdIndex;        /* ATS command index (cmd num - 1) */
     bool                 ReturnCode;
     SC_AbsTimeTag_t      TimeToStartAts; /* the REAL time to start the ATS */
     uint16               CmdsSkipped = 0;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #76 
  - Initialize `ListCmdTime` to zero to avoid CodeQL warning/failure.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
CodeQL CI actions now passing without errors.

**Contributor Info**
Avi Weiss @thnkslprpt