### PR TITLE
Fix #78, Split up multiple-variable declaration statements

### DIFF
--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -370,7 +370,8 @@ CFE_Status_t SC_RegisterDumpOnlyTables(void)
 
 CFE_Status_t SC_RegisterLoadableTables(void)
 {
-    int          i, j;
+    int          i;
+    int          j;
     CFE_Status_t Result;
     char         TableName[CFE_MISSION_TBL_MAX_NAME_LENGTH];
 

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -117,7 +117,8 @@ void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
     size_t               MsgSize;
     int                  BufEntrySize;
     int                  MaxBufEntries;
-    int                  i, j;
+    int                  i;
+    int                  j;
 
     memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
 
@@ -348,7 +349,8 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
     size_t               MsgSize2;
     int                  BufEntrySize;
     int                  MaxBufEntries;
-    int                  i, j;
+    int                  i;
+    int                  j;
 
     memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
 
@@ -417,7 +419,8 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     size_t               MsgSize2;
     int                  BufEntrySize;
     int                  MaxBufEntries;
-    int                  i, j;
+    int                  i;
+    int                  j;
 
     memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
     memset(&AtsTable, 0, sizeof(AtsTable));
@@ -477,7 +480,8 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
     size_t               MsgSize2;
     int                  BufEntrySize;
     int                  MaxBufEntries;
-    int                  i, j;
+    int                  i;
+    int                  j;
 
     SC_InitTables();
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #78 
  - Declarations that define multiple variables have been split up into individual declarations.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.
Eases future maintenance.

**Contributor Info**
Avi Weiss @thnkslprpt