### PR TITLE
Fix #5, Remove `OS_OpenCreate` file status check in `SC_LoadDefaultTables`

### DIFF
--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -1209,16 +1209,6 @@
 #define SC_RTS_LOAD_FAIL_DBG_EID 124
 
 /**
- * \brief SC RTS Table Open Failed Event ID
- *
- *  \par Type: DEBUG
- *
- *  \par Cause:
- *  This event message is issued when an RTS file fails to open at startup.
- */
-#define SC_RTS_OPEN_FAIL_DBG_EID 125
-
-/**
  * \brief SC Start RTS Group RTS Not Loaded Or In Use Event ID
  *
  *  \par Type: ERROR

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -537,11 +537,10 @@ CFE_Status_t SC_GetLoadTablePointers(void)
 
 void SC_LoadDefaultTables(void)
 {
-    char      TableName[OS_MAX_PATH_LEN];
-    osal_id_t FileDesc = OS_OBJECT_ID_UNDEFINED;
-    int32     RtsIndex;
-    int32     NotLoadedCount = 0;
-    int32     Status         = OS_SUCCESS;
+    char  TableName[OS_MAX_PATH_LEN];
+    int32 RtsIndex;
+    int32 NotLoadedCount = 0;
+    int32 Status;
 
     /*
     ** Currently, only RTS tables are loaded during initialization.
@@ -552,31 +551,15 @@ void SC_LoadDefaultTables(void)
     {
         /* Example filename: /cf/apps/sc_rts001.tbl */
         snprintf(TableName, sizeof(TableName), "%s%03d.tbl", SC_RTS_FILE_NAME, (int)(RtsIndex + 1));
-        Status = OS_OpenCreate(&FileDesc, TableName, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
-        if (Status == OS_SUCCESS)
-        {
-            OS_close(FileDesc);
-
-            /* Only try to load table files that can be opened */
-            Status = CFE_TBL_Load(SC_OperData.RtsTblHandle[RtsIndex], CFE_TBL_SRC_FILE, TableName);
-            if (Status != CFE_SUCCESS)
-            {
-                NotLoadedCount++;
-
-                /* send an event for each failed load */
-                CFE_EVS_SendEvent(SC_RTS_LOAD_FAIL_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                  "RTS table %d failed to load, returned: 0x%08lX", (int)RtsIndex,
-                                  (unsigned long)Status);
-            }
-        }
-        else
+        Status = CFE_TBL_Load(SC_OperData.RtsTblHandle[RtsIndex], CFE_TBL_SRC_FILE, TableName);
+        if (Status != CFE_SUCCESS)
         {
             NotLoadedCount++;
 
-            /* send an event for each failed open */
-            CFE_EVS_SendEvent(SC_RTS_OPEN_FAIL_DBG_EID, CFE_EVS_EventType_DEBUG,
-                              "RTS table %d file open failed, returned: 0x%08lX", (int)RtsIndex, (unsigned long)Status);
+            /* send an event for each failed load */
+            CFE_EVS_SendEvent(SC_RTS_LOAD_FAIL_DBG_EID, CFE_EVS_EventType_DEBUG,
+                              "RTS table %d failed to load, returned: 0x%08lX", (int)RtsIndex, (unsigned long)Status);
         }
     }
 

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -676,24 +676,17 @@ void SC_GetLoadTablePointers_Test_ErrorGetAddressLoadableRTS(void)
 
 void SC_LoadDefaultTables_Test(void)
 {
-    /* Set OS_open to return 1, in order to enter if-block "if (FileDesc >= 0)" */
-    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_SUCCESS);
-
-    /* Cover branch for - Only try to load table files that can be opened */
+    /* Cover branch for failure of CFE_TBL_Load() */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Load), 1, -1);
-
-    /* Cover branch for - send an event for each failed open */
-    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, -1);
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_LoadDefaultTables());
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LOAD_FAIL_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_RTS_OPEN_FAIL_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, SC_RTS_LOAD_FAIL_COUNT_INFO_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_RTS_LOAD_FAIL_COUNT_INFO_EID);
 
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void UtTest_Setup(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #5 
  - Call to `OS_OpenCreate()` in the `SC_LoadDefaultTables()` function converted to `OS_stat()`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Simplifies function and eases future maintenance.

**Contributor Info**
Avi Weiss @thnkslprpt