### PR TITLE
Fix #85, Remove `CFE_BIT`-related macros

### DIFF
--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -452,13 +452,13 @@ void SC_SendHkPacket(void)
     {
         if (SC_OperData.RtsInfoTblAddr[i].DisabledFlag == true)
         {
-            CFE_SET(SC_OperData.HkPacket.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16],
-                    i % SC_NUMBER_OF_RTS_IN_UINT16);
+            SC_OperData.HkPacket.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
+                (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
         }
         if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_EXECUTING)
         {
-            CFE_SET(SC_OperData.HkPacket.RtsExecutingStatus[i / SC_NUMBER_OF_RTS_IN_UINT16],
-                    i % SC_NUMBER_OF_RTS_IN_UINT16);
+            SC_OperData.HkPacket.RtsExecutingStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
+                (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
         }
     } /* end for */
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #85 
  - Removes the couple instances of the `CFE_BIT`-related macros which are being removed from cFE in https://github.com/nasa/cFE/pull/2294

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss @thnkslprpt