### PR TITLE
Fix #87, Update Command Code underscores for consistency

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,14 +3,14 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with:
-      component-path: apps/sc 
+      component-path: apps/sc
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/sc'
       setup: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_sc.dox
+++ b/docs/dox_src/cfs_sc.dox
@@ -54,8 +54,8 @@
 
   This document provides a complete specification for the commands and telemetry
   associated with the CFS Stored Command (SC) application software. The document
-  is intended primarily for users of the software (operations personal, test
-  engineers, and maintenance personal). The deployment guide section, is
+  is intended primarily for users of the software (operations personnel, test
+  engineers, and maintenance personnel). The deployment guide section, is
   intended for mission developers when deploying and configuring the SC
   application software for a mission flight software build environment. 
 

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -1092,7 +1092,7 @@
  *
  *  \par Cause:
  *  This event message is issued following the successful execution of
- *  a #SC_START_RTSGRP_CC command.
+ *  a #SC_START_RTS_GRP_CC command.
  */
 #define SC_STARTRTSGRP_CMD_INF_EID 115
 
@@ -1102,7 +1102,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTSGRP_CC command was
+ *  This event message is issued when a #SC_START_RTS_GRP_CC command was
  *  rejected because the RTS group definition was invalid:
  *  - First RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
@@ -1117,7 +1117,7 @@
  *
  *  \par Cause:
  *  This event message is issued following the successful execution of
- *  a #SC_STOP_RTSGRP_CC command.
+ *  a #SC_STOP_RTS_GRP_CC command.
  */
 #define SC_STOPRTSGRP_CMD_INF_EID 117
 
@@ -1127,7 +1127,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_STOP_RTSGRP_CC command was
+ *  This event message is issued when a #SC_STOP_RTS_GRP_CC command was
  *  rejected because the RTS group definition was invalid:
  *  - First RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
@@ -1142,7 +1142,7 @@
  *
  *  \par Cause:
  *  This event message is issued following the successful execution of
- *  a #SC_DISABLE_RTSGRP_CC command.
+ *  a #SC_DISABLE_RTS_GRP_CC command.
  */
 #define SC_DISRTSGRP_CMD_INF_EID 119
 
@@ -1152,7 +1152,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_DISABLE_RTSGRP_CC command was
+ *  This event message is issued when a #SC_DISABLE_RTS_GRP_CC command was
  *  rejected because the RTS group definition was invalid:
  *  - First RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
@@ -1167,7 +1167,7 @@
  *
  *  \par Cause:
  *  This event message is issued following the successful execution of
- *  a #SC_ENABLE_RTSGRP_CC command.
+ *  a #SC_ENABLE_RTS_GRP_CC command.
  */
 #define SC_ENARTSGRP_CMD_INF_EID 121
 
@@ -1177,7 +1177,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_ENABLE_RTSGRP_CC command was
+ *  This event message is issued when a #SC_ENABLE_RTS_GRP_CC command was
  *  rejected because the RTS group definition was invalid:
  *  - First RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
@@ -1226,7 +1226,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTSGRP_CC command was received, but an
+ *  This event message is issued when a #SC_START_RTS_GRP_CC command was received, but an
  *  RTS is marked as #SC_LOADED
  */
 #define SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID 126
@@ -1237,7 +1237,7 @@
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when a #SC_START_RTSGRP_CC command was received, but an
+ *  This event message is issued when a #SC_START_RTS_GRP_CC command was received, but an
  *  RTS is disabled
  */
 #define SC_STARTRTSGRP_CMD_DISABLED_ERR_EID 127

--- a/fsw/inc/sc_msg.h
+++ b/fsw/inc/sc_msg.h
@@ -190,7 +190,7 @@ typedef struct
 /**
  *  \brief RTS Group Command
  *
- *  For command details see #SC_START_RTSGRP_CC, #SC_STOP_RTSGRP_CC, #SC_DISABLE_RTSGRP_CC, #SC_ENABLE_RTSGRP_CC
+ *  For command details see #SC_START_RTS_GRP_CC, #SC_STOP_RTS_GRP_CC, #SC_DISABLE_RTS_GRP_CC, #SC_ENABLE_RTS_GRP_CC
  */
 typedef struct
 {

--- a/fsw/inc/sc_msgdefs.h
+++ b/fsw/inc/sc_msgdefs.h
@@ -543,9 +543,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #SC_STOP_RTSGRP_CC
+ *  \sa #SC_STOP_RTS_GRP_CC
  */
-#define SC_START_RTSGRP_CC 13
+#define SC_START_RTS_GRP_CC 13
 
 /**
  * \brief STOP a group of RTS
@@ -583,9 +583,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #SC_START_RTSGRP_CC
+ *  \sa #SC_START_RTS_GRP_CC
  */
-#define SC_STOP_RTSGRP_CC 14
+#define SC_STOP_RTS_GRP_CC 14
 
 /**
  * \brief DISABLE a group of RTS
@@ -621,9 +621,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #SC_ENABLE_RTSGRP_CC
+ *  \sa #SC_ENABLE_RTS_GRP_CC
  */
-#define SC_DISABLE_RTSGRP_CC 15
+#define SC_DISABLE_RTS_GRP_CC 15
 
 /**
  * \brief ENABLE a group of RTS
@@ -659,12 +659,19 @@
  *  \par Criticality
  *       None
  *
- *  \sa #SC_DISABLE_RTSGRP_CC
+ *  \sa #SC_DISABLE_RTS_GRP_CC
  */
-#define SC_ENABLE_RTSGRP_CC 16
+#define SC_ENABLE_RTS_GRP_CC 16
 
 #endif
 
 /**\}*/
+
+#ifndef SC_OMIT_DEPRECATED
+#define SC_START_RTSGRP_CC   SC_START_RTS_GRP_CC
+#define SC_STOP_RTSGRP_CC    SC_STOP_RTS_GRP_CC
+#define SC_DISABLE_RTSGRP_CC SC_DISABLE_RTS_GRP_CC
+#define SC_ENABLE_RTSGRP_CC  SC_ENABLE_RTS_GRP_CC
+#endif
 
 #endif

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -681,19 +681,19 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
 
-        case SC_START_RTSGRP_CC:
+        case SC_START_RTS_GRP_CC:
             SC_StartRtsGrpCmd(BufPtr);
             break;
 
-        case SC_STOP_RTSGRP_CC:
+        case SC_STOP_RTS_GRP_CC:
             SC_StopRtsGrpCmd(BufPtr);
             break;
 
-        case SC_DISABLE_RTSGRP_CC:
+        case SC_DISABLE_RTS_GRP_CC:
             SC_DisableRtsGrpCmd(BufPtr);
             break;
 
-        case SC_ENABLE_RTSGRP_CC:
+        case SC_ENABLE_RTS_GRP_CC:
             SC_EnableRtsGrpCmd(BufPtr);
             break;
 #endif

--- a/fsw/src/sc_rtsrq.h
+++ b/fsw/src/sc_rtsrq.h
@@ -56,7 +56,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *
  *  \param [in]         CmdPacket      Pointer to Software Bus buffer
  *
- *  \sa #SC_START_RTSGRP_CC
+ *  \sa #SC_START_RTS_GRP_CC
  */
 void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
 #endif
@@ -155,7 +155,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *
  *  \param [in]         CmdPacket      Pointer to Software Bus buffer
  *
- *  \sa #SC_ENABLE_RTSGRP_CC
+ *  \sa #SC_ENABLE_RTS_GRP_CC
  */
 void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
 #endif

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -3095,7 +3095,7 @@ void SC_ProcessCommand_Test_StartRtsGrp(void)
      **/
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTSGRP_CC;
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_GRP_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -3119,7 +3119,7 @@ void SC_ProcessCommand_Test_StopRtsGrp(void)
      **/
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTSGRP_CC;
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_GRP_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -3143,7 +3143,7 @@ void SC_ProcessCommand_Test_DisableRtsGrp(void)
      **/
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTSGRP_CC;
+    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_GRP_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -3167,7 +3167,7 @@ void SC_ProcessCommand_Test_EnableRtsGrp(void)
      **/
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTSGRP_CC;
+    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_GRP_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #87 
  - A few command codes with inconsistent underscores separating words were updated to better fit the cFS/cFE naming conventions

**Testing performed**
GitHub CI actions all passing successfully (incl. Unit Tests and Build + Run).

**Expected behavior changes**
No change to behavior.
Improved consistency and clarity.

Note: there are similar issues with some of the SC EIDs lacking underscores between words: e.g. `SC_ENARTSGRP_CMD_INF_EID`

**Contributor Info**
Avi Weiss @thnkslprpt