### PR TITLE
Fix #52, UT fix to support SC_LAST_RTS_WITH_EVENTS == SC_NUMBER_OF_RTS

### DIFF
--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -117,10 +117,6 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     SC_RtpControlBlock_t RtsCtrlBlck;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS #%%d command");
 
     SC_InitTables();
 
@@ -165,17 +161,19 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 1, "SC_OperData.HkPacket.RtsActiveCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    /* Handle if SC_LAST_RTS_WITH_EVENTS is the same as SC_NUM_OF_RTS */
+    if (UT_CmdBuf.RtsCmd.RtsId > SC_LAST_RTS_WITH_EVENTS)
+    {
+        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DBG_EID);
+        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    }
+    else
+    {
+        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_START_INF_EID);
+        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    }
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidCommandLength1(void)

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -1192,12 +1192,18 @@ void UtTest_Setup(void)
                "SC_GetNextRtsCommand_Test_CommandLengthError");
     UtTest_Add(SC_GetNextRtsCommand_Test_ZeroCommandLength, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextRtsCommand_Test_ZeroCommandLength");
-    UtTest_Add(SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts, SC_Test_Setup, SC_Test_TearDown,
-               "SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts");
+
+    /* Only run if SC_LAST_RTS_WITH_EVENTS < SC_NUMBER_OF_RTS */
+    if (SC_LAST_RTS_WITH_EVENTS < SC_NUMBER_OF_RTS)
+    {
+        UtTest_Add(SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts, SC_Test_Setup, SC_Test_TearDown,
+                   "SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts");
+        UtTest_Add(SC_GetNextRtsCommand_Test_EndOfBufferLastRts, SC_Test_Setup, SC_Test_TearDown,
+                   "SC_GetNextRtsCommand_Test_EndOfBufferLastRts");
+    }
+
     UtTest_Add(SC_GetNextRtsCommand_Test_EndOfBuffer, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextRtsCommand_Test_EndOfBuffer");
-    UtTest_Add(SC_GetNextRtsCommand_Test_EndOfBufferLastRts, SC_Test_Setup, SC_Test_TearDown,
-               "SC_GetNextRtsCommand_Test_EndOfBufferLastRts");
     UtTest_Add(SC_GetNextAtsCommand_Test_Starting, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextAtsCommand_Test_Starting");
     UtTest_Add(SC_GetNextAtsCommand_Test_Idle, SC_Test_Setup, SC_Test_TearDown, "SC_GetNextAtsCommand_Test_Idle");


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #52

**Testing performed**
CI and tested with SC_LAST_RTS_WITH_EVENTS == SC_NUMBER_OF_RTS

**Expected behavior changes**
None

**System(s) tested on**
 - Ubuntu 20.04

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC