### PR TITLE
Fix #18, Make compiler-added padding in `SC_AtpControlBlock_t` explicit

### DIFF
--- a/fsw/inc/sc_tbldefs.h
+++ b/fsw/inc/sc_tbldefs.h
@@ -81,6 +81,7 @@ typedef struct
 {
     uint8  AtpState;       /**< \brief execution state of the ATP */
     uint8  AtsNumber;      /**< \brief current ATS running if any */
+    uint16 Padding;        /**< \brief Structure padding to align to 32-bit boundaries */
     uint32 CmdNumber;      /**< \brief current cmd number to run if any */
     uint16 TimeIndexPtr;   /**< \brief time index pointer for current cmd */
     uint16 SwitchPendFlag; /**< \brief indicates that a buffer switch is waiting */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #18
  - Implicit padding was being added in `SC_AtpControlBlock_t` - this PR makes it explicit

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss @thnkslprpt