### PR TITLE
Fix #80, Unit tests read past array bounds and general cleanup

### DIFF
--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -41,7 +41,6 @@
 #include "utstubs.h"
 
 /* sc_atsrq_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
 
 SC_AtsInfoTable_t SC_ATSRQ_TEST_GlobalAtsInfoTable[2];
 
@@ -110,10 +109,8 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StartAtsCmd_Test_NominalB(void)
@@ -152,10 +149,8 @@ void SC_StartAtsCmd_Test_NominalB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StartAtsCmd_Test_CouldNotStart(void)
@@ -199,10 +194,8 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_NoCommandsA(void)
@@ -240,10 +233,8 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_NoCommandsB(void)
@@ -281,10 +272,8 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_InUse(void)
@@ -322,10 +311,8 @@ void SC_StartAtsCmd_Test_InUse(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_InvalidAtsId(void)
@@ -363,10 +350,8 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
@@ -404,10 +389,8 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartAtsCmd_Test_InvalidCmdLength(void)
@@ -429,10 +412,8 @@ void SC_StartAtsCmd_Test_InvalidCmdLength(void)
     SC_StartAtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StopAtsCmd_Test_NominalA(void)
@@ -469,10 +450,8 @@ void SC_StopAtsCmd_Test_NominalA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopAtsCmd_Test_NominalB(void)
@@ -509,10 +488,8 @@ void SC_StopAtsCmd_Test_NominalB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopAtsCmd_Test_NoRunningAts(void)
@@ -549,10 +526,8 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopAtsCmd_Test_InvalidCmdLength(void)
@@ -576,10 +551,8 @@ void SC_StopAtsCmd_Test_InvalidCmdLength(void)
     SC_StopAtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_BeginAts_Test_Nominal(void)
@@ -617,10 +590,8 @@ void SC_BeginAts_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_BeginAts_Test_AllCommandsSkipped(void)
@@ -662,10 +633,8 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_BeginAts_Test_InvalidAtsIndex(void)
@@ -705,10 +674,8 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_KillAts_Test(void)
@@ -731,10 +698,8 @@ void SC_KillAts_Test(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE");
     UtAssert_True(SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GroundSwitchCmd_Test_Nominal(void)
@@ -775,10 +740,8 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
@@ -817,10 +780,8 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GroundSwitchCmd_Test_AtpIdle(void)
@@ -858,10 +819,8 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
@@ -881,10 +840,8 @@ void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
     SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ServiceSwitchPend_Test_NominalA(void)
@@ -928,10 +885,8 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ServiceSwitchPend_Test_NominalB(void)
@@ -975,10 +930,8 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ServiceSwitchPend_Test_AtsEmpty(void)
@@ -1018,10 +971,8 @@ void SC_ServiceSwitchPend_Test_AtsEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ServiceSwitchPend_Test_AtpIdle(void)
@@ -1058,10 +1009,8 @@ void SC_ServiceSwitchPend_Test_AtpIdle(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ServiceSwitchPend_Test_NoSwitch(void)
@@ -1082,10 +1031,8 @@ void SC_ServiceSwitchPend_Test_NoSwitch(void)
 
     /* Verify results */
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
@@ -1132,10 +1079,8 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_InlineSwitch_Test_NominalA(void)
@@ -1183,10 +1128,8 @@ void SC_InlineSwitch_Test_NominalA(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
     /* Generates 1 event message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_InlineSwitch_Test_NominalB(void)
@@ -1234,10 +1177,8 @@ void SC_InlineSwitch_Test_NominalB(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
     /* Generates 1 event message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_InlineSwitch_Test_AllCommandsSkipped(void)
@@ -1270,10 +1211,8 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
@@ -1315,10 +1254,8 @@ void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_JumpAtsCmd_Test_SkipOneCmd(void)
@@ -1391,10 +1328,8 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[2].Spec);
 
     /* Generates 1 event message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
 void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
@@ -1443,10 +1378,8 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_JumpAtsCmd_Test_NoRunningAts(void)
@@ -1485,10 +1418,8 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
@@ -1546,10 +1477,8 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
@@ -1575,10 +1504,8 @@ void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
     SC_JumpAtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void ContinueAtsOnFailureCmd_Test_Nominal(void)
@@ -1619,10 +1546,8 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void ContinueAtsOnFailureCmd_Test_FalseState(void)
@@ -1663,10 +1588,8 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void ContinueAtsOnFailureCmd_Test_InvalidState(void)
@@ -1706,10 +1629,8 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
@@ -1733,10 +1654,8 @@ void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
     SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_AppendAtsCmd_Test_Nominal(void)
@@ -1786,10 +1705,8 @@ void SC_AppendAtsCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_InvalidAtsId(void)
@@ -1829,10 +1746,8 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
@@ -1872,10 +1787,8 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
@@ -1917,10 +1830,8 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
@@ -1962,10 +1873,8 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
@@ -2010,10 +1919,8 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
@@ -2037,10 +1944,8 @@ void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
     SC_AppendAtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void UtTest_Setup(void)

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -68,10 +68,6 @@ CFE_TIME_Compare_t UT_SC_StartAtsRq_CompareHook3(void *UserObj, int32 StubRetcod
 void SC_StartAtsCmd_Test_NominalA(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Started");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -82,7 +78,7 @@ void SC_StartAtsCmd_Test_NominalA(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -90,23 +86,12 @@ void SC_StartAtsCmd_Test_NominalA(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StartAtsCmd_Test_NominalB(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Started");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -117,7 +102,7 @@ void SC_StartAtsCmd_Test_NominalB(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -125,13 +110,6 @@ void SC_StartAtsCmd_Test_NominalB(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -139,10 +117,6 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "All ATS commands were skipped, ATS stopped");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -158,19 +132,12 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ALL_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -178,10 +145,6 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start ATS Rejected: ATS %%c Not Loaded");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -193,19 +156,12 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -213,10 +169,6 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start ATS Rejected: ATS %%c Not Loaded");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -228,19 +180,12 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -248,10 +193,6 @@ void SC_StartAtsCmd_Test_InUse(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start ATS Rejected: ATP is not Idle");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -262,19 +203,12 @@ void SC_StartAtsCmd_Test_InUse(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_IDLE_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -282,10 +216,6 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start ATS %%d Rejected: Invalid ATS ID");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -296,19 +226,12 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_INVLD_ID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -316,10 +239,6 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start ATS %%d Rejected: Invalid ATS ID");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -330,19 +249,12 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_INVLD_ID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -357,10 +269,9 @@ void SC_StartAtsCmd_Test_InvalidCmdLength(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
 
     /* Execute the function being tested */
-    SC_StartAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -368,10 +279,6 @@ void SC_StopAtsCmd_Test_NominalA(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c stopped");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -381,19 +288,12 @@ void SC_StopAtsCmd_Test_NominalA(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
 
     /* Execute the function being tested */
-    SC_StopAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -401,10 +301,6 @@ void SC_StopAtsCmd_Test_NominalB(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c stopped");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -414,19 +310,12 @@ void SC_StopAtsCmd_Test_NominalB(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
 
     /* Execute the function being tested */
-    SC_StopAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -434,10 +323,6 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "There is no ATS running to stop");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -447,19 +332,12 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 99;
 
     /* Execute the function being tested */
-    SC_StopAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_NO_ATS_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -476,30 +354,23 @@ void SC_StopAtsCmd_Test_InvalidCmdLength(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 99;
 
     /* Execute the function being tested */
-    SC_StopAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_BeginAts_Test_Nominal(void)
 {
-    bool   Result;
     uint16 AtsIndex   = 0;
     uint16 TimeOffset = 0;
-    int32  strCmpResult;
-    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS started, skipped %%d commands");
 
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    Result = SC_BeginAts(AtsIndex, TimeOffset);
+    UtAssert_BOOL_TRUE(SC_BeginAts(AtsIndex, TimeOffset));
 
     /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtsNumber == 1, "SC_OperData.AtsCtrlBlckAddr->AtsNumber == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0],
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
@@ -507,25 +378,13 @@ void SC_BeginAts_Test_Nominal(void)
     UtAssert_True(SC_AppData.NextCmdTime[SC_ATP] == 0, "SC_AppData.NextCmdTime[SC_ATP] == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_ERR_SKP_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_BeginAts_Test_AllCommandsSkipped(void)
 {
-    bool   Result;
     uint16 AtsIndex   = 0;
     uint16 TimeOffset = 0;
-    int32  strCmpResult;
-    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "All ATS commands were skipped, ATS stopped");
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
@@ -536,33 +395,20 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
     /* Execute the function being tested */
-    Result = SC_BeginAts(AtsIndex, TimeOffset);
+    UtAssert_BOOL_FALSE(SC_BeginAts(AtsIndex, TimeOffset));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ALL_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_BeginAts_Test_InvalidAtsIndex(void)
 {
-    bool   Result;
     uint16 AtsIndex   = SC_NUMBER_OF_ATS;
     uint16 TimeOffset = 0;
-    int32  strCmpResult;
-    char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Begin ATS error: invalid ATS index %%d");
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
@@ -573,19 +419,10 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
     /* Execute the function being tested */
-    Result = SC_BeginAts(AtsIndex, TimeOffset);
+    UtAssert_BOOL_FALSE(SC_BeginAts(AtsIndex, TimeOffset));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_BEGINATS_INVLD_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -595,13 +432,12 @@ void SC_KillAts_Test(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState  = 99;
 
     /* Execute the function being tested */
-    SC_KillAts();
+    UtAssert_VOIDCALL(SC_KillAts());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[0].AtsUseCtr == 1, "SC_OperData.AtsInfoTblAddr[0].AtsUseCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE");
     UtAssert_True(SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -609,10 +445,6 @@ void SC_KillAts_Test(void)
 void SC_GroundSwitchCmd_Test_Nominal(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS is Pending");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -625,7 +457,7 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
 
     /* Execute the function being tested */
-    SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == true,
@@ -633,23 +465,12 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Failure: Destination ATS Not Loaded");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -660,7 +481,7 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -668,23 +489,12 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GroundSwitchCmd_Test_AtpIdle(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Rejected: ATP is idle");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -694,7 +504,7 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState  = 99;
 
     /* Execute the function being tested */
-    SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -702,13 +512,6 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_IDLE_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -724,17 +527,11 @@ void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
     SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ServiceSwitchPend_Test_NominalA(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
@@ -749,7 +546,7 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
 
     /* Execute the function being tested */
-    SC_ServiceSwitchPend();
+    UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -758,23 +555,11 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_SERVICE_SWTCH_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ServiceSwitchPend_Test_NominalB(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
@@ -789,7 +574,7 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 0);
 
     /* Execute the function being tested */
-    SC_ServiceSwitchPend();
+    UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -798,23 +583,11 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_SERVICE_SWTCH_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ServiceSwitchPend_Test_AtsEmpty(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Failure: Destination ATS is empty");
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
@@ -827,30 +600,18 @@ void SC_ServiceSwitchPend_Test_AtsEmpty(void)
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    SC_ServiceSwitchPend();
+    UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SERVICE_SWITCH_ATS_CMD_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ServiceSwitchPend_Test_AtpIdle(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Rejected: ATP is idle");
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
@@ -860,20 +621,13 @@ void SC_ServiceSwitchPend_Test_AtpIdle(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = 99;
 
     /* Execute the function being tested */
-    SC_ServiceSwitchPend();
+    UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SERVICE_SWITCH_IDLE_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -889,18 +643,11 @@ void SC_ServiceSwitchPend_Test_NoSwitch(void)
     SC_ServiceSwitchPend();
 
     /* Verify results */
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "All ATS commands were skipped, ATS stopped");
-
     /* Set to cause SC_BeginAts to return false, in order to reach block starting with "could not start the ats" */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
@@ -917,7 +664,7 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    SC_ServiceSwitchPend();
+    UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE");
@@ -925,24 +672,11 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ALL_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_InlineSwitch_Test_NominalA(void)
 {
-    bool  Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -954,10 +688,9 @@ void SC_InlineSwitch_Test_NominalA(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
 
     /* Execute the function being tested */
-    Result = SC_InlineSwitch();
+    UtAssert_BOOL_TRUE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
 
@@ -966,25 +699,11 @@ void SC_InlineSwitch_Test_NominalA(void)
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_INLINE_SWTCH_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-    /* Generates 1 event message we don't care about in this test */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_InlineSwitch_Test_NominalB(void)
 {
-    bool  Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -996,10 +715,9 @@ void SC_InlineSwitch_Test_NominalB(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 0);
 
     /* Execute the function being tested */
-    Result = SC_InlineSwitch();
+    UtAssert_BOOL_TRUE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
 
@@ -1008,21 +726,11 @@ void SC_InlineSwitch_Test_NominalB(void)
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_INLINE_SWTCH_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-    /* Generates 1 event message we don't care about in this test */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_InlineSwitch_Test_AllCommandsSkipped(void)
 {
-    bool Result;
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to cause all commnds to be skipped, to reach block starting with comment "all of the commands in the new ats
@@ -1034,26 +742,18 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    Result = SC_InlineSwitch();
+    UtAssert_BOOL_FALSE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
 {
-    bool  Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Failure: Destination ATS Not Loaded");
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
@@ -1062,23 +762,14 @@ void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
 
     /* Execute the function being tested */
-    Result = SC_InlineSwitch();
+    UtAssert_BOOL_FALSE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_INLINE_SWTCH_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1087,13 +778,6 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Next ATS command time in the ATP was set to %%s");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Jump Cmd: Skipped %%d ATS commands");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1115,7 +799,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
     /* Execute the function being tested */
-    SC_JumpAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
@@ -1129,23 +813,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, SC_JUMP_ATS_SKIPPED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[2].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[2].Spec);
-
-    /* Generates 1 event message we don't care about in this test */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
@@ -1154,11 +822,6 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Jump Cmd: All ATS commands were skipped, ATS stopped");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1176,19 +839,12 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    SC_JumpAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_JUMPATS_CMD_STOPPED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1196,10 +852,6 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Jump Failed: No active ATS");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1209,19 +861,12 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_JumpAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_JUMPATS_CMD_NOT_ACT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1230,11 +875,6 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Next ATS command time in the ATP was set to %%s");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1253,7 +893,7 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
     /* Execute the function being tested */
-    SC_JumpAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
@@ -1267,13 +907,6 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -1290,10 +923,9 @@ void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
 
     /* Execute the function being tested */
-    SC_JumpAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1301,10 +933,6 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Continue-ATS-On-Failure command, State: %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1314,7 +942,7 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = true;
 
     /* Execute the function being tested */
-    SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.ContinueAtsOnFailureFlag == true,
@@ -1322,13 +950,6 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1336,10 +957,6 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Continue-ATS-On-Failure command, State: %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1349,7 +966,7 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = false;
 
     /* Execute the function being tested */
-    SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.ContinueAtsOnFailureFlag == false,
@@ -1357,13 +974,6 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1371,11 +981,6 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Continue ATS On Failure command  failed, invalid state: %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1385,19 +990,12 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
     UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = 99;
 
     /* Execute the function being tested */
-    SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1412,10 +1010,9 @@ void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
 
     /* Execute the function being tested */
-    SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1423,21 +1020,14 @@ void SC_AppendAtsCmd_Test_Nominal(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_APPEND_ATS_CC;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Append ATS %%c command: %%d ATS entries appended");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -1446,20 +1036,13 @@ void SC_AppendAtsCmd_Test_Nominal(void)
     SC_OperData.HkPacket.AppendEntryCount                 = 1;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendCmdArg == 1, "SC_OperData.HkPacket.AppendCmdArg == 1");
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1467,10 +1050,6 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS error: invalid ATS ID = %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1481,19 +1060,12 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
     SC_OperData.HkPacket.AppendEntryCount = 1;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_ARG_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1501,10 +1073,6 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS error: invalid ATS ID = %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1515,19 +1083,12 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
     SC_OperData.HkPacket.AppendEntryCount = 1;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_ARG_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1536,10 +1097,6 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS %%c error: ATS table is empty");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1551,19 +1108,12 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_TGT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1572,10 +1122,6 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS %%c error: Append table is empty");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1587,19 +1133,12 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_SRC_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1608,11 +1147,6 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     uint8             AtsIndex  = 0;
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Append ATS %%c error: ATS size = %%d, Append size = %%d, ATS buffer = %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1626,19 +1160,12 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     SC_AppData.AppendWordCount                            = SC_ATS_BUFF_SIZE;
 
     /* Execute the function being tested */
-    SC_AppendAtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_FIT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1656,7 +1183,6 @@ void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
     SC_AppendAtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -40,14 +40,6 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-/* sc_atsrq_tests globals */
-
-SC_AtsInfoTable_t SC_ATSRQ_TEST_GlobalAtsInfoTable[2];
-
-SC_AtpControlBlock_t SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-uint32 SC_ATSRQ_TEST_GlobalAtsCmdStatus[SC_NUMBER_OF_ATS];
-
 /*
  * Function Definitions
  */
@@ -85,11 +77,6 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
@@ -124,11 +111,6 @@ void SC_StartAtsCmd_Test_NominalB(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
 
     UT_CmdBuf.StartAtsCmd.AtsId                    = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
@@ -168,12 +150,6 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
@@ -212,13 +188,9 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
     SC_StartAtsCmd(&UT_CmdBuf.Buf);
@@ -251,13 +223,9 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId                    = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
     SC_StartAtsCmd(&UT_CmdBuf.Buf);
@@ -289,11 +257,6 @@ void SC_StartAtsCmd_Test_InUse(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
 
     UT_CmdBuf.StartAtsCmd.AtsId           = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
@@ -329,11 +292,6 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId           = 99;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
@@ -368,11 +326,6 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId           = 0;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
@@ -403,11 +356,6 @@ void SC_StartAtsCmd_Test_InvalidCmdLength(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_StartAtsCmd(&UT_CmdBuf.Buf);
 
@@ -429,11 +377,6 @@ void SC_StopAtsCmd_Test_NominalA(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
 
@@ -468,11 +411,6 @@ void SC_StopAtsCmd_Test_NominalB(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
 
     /* Execute the function being tested */
@@ -506,11 +444,6 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 99;
 
     /* Execute the function being tested */
@@ -540,11 +473,6 @@ void SC_StopAtsCmd_Test_InvalidCmdLength(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
 
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 99;
 
     /* Execute the function being tested */
@@ -564,11 +492,6 @@ void SC_BeginAts_Test_Nominal(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS started, skipped %%d commands");
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_InitTables();
 
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
@@ -606,13 +529,7 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_OperData.AtsInfoTblAddr          = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr         = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0]  = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
     SC_AppData.AtsTimeIndexBuffer[0][0] = 1;
-
-    SC_InitTables();
-
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Set to cause all commnds to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
@@ -649,13 +566,7 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_OperData.AtsInfoTblAddr          = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr         = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0]  = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
     SC_AppData.AtsTimeIndexBuffer[0][0] = 1;
-
-    SC_InitTables();
-
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Set to cause all commnds to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
@@ -680,13 +591,6 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
 
 void SC_KillAts_Test(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsInfoTable));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = 99;
 
@@ -713,11 +617,6 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
@@ -756,11 +655,6 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
@@ -796,11 +690,6 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = 99;
 
@@ -831,11 +720,6 @@ void SC_GroundSwitchCmd_Test_InvalidCmdLength(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Execute the function being tested */
     SC_GroundSwitchCmd(&UT_CmdBuf.Buf);
 
@@ -852,11 +736,6 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
-
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
@@ -898,11 +777,6 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -943,11 +817,6 @@ void SC_ServiceSwitchPend_Test_AtsEmpty(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -984,11 +853,6 @@ void SC_ServiceSwitchPend_Test_AtpIdle(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -1017,11 +881,6 @@ void SC_ServiceSwitchPend_Test_NoSwitch(void)
 {
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, false);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -1048,11 +907,6 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -1061,8 +915,6 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
-    SC_OperData.AtsCmdStatusTblAddr[0]             = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1]             = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
 
     /* Execute the function being tested */
     SC_ServiceSwitchPend();
@@ -1090,13 +942,6 @@ void SC_InlineSwitch_Test_NominalA(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
-
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
 
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
@@ -1140,13 +985,6 @@ void SC_InlineSwitch_Test_NominalB(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Switched from %%c to %%c");
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
     /* Set to satisfy first if-statement, while not affecting later calls to CFE_TIME_Compare */
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
@@ -1185,13 +1023,6 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
 {
     bool Result;
 
-    SC_InitTables();
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Set to cause all commnds to be skipped, to reach block starting with comment "all of the commands in the new ats
@@ -1222,13 +1053,6 @@ void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Switch ATS Failure: Destination ATS Not Loaded");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
@@ -1270,13 +1094,6 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
              "Next ATS command time in the ATP was set to %%s");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Jump Cmd: Skipped %%d ATS commands");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1343,13 +1160,6 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Jump Cmd: All ATS commands were skipped, ATS stopped");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1391,13 +1201,6 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS Jump Failed: No active ATS");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1432,13 +1235,6 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Next ATS command time in the ATP was set to %%s");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1486,13 +1282,6 @@ void SC_JumpAtsCmd_Test_InvalidCmdLength(void)
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1516,13 +1305,6 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Continue-ATS-On-Failure command, State: %%d");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1558,13 +1340,6 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Continue-ATS-On-Failure command, State: %%d");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1602,13 +1377,6 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Continue ATS On Failure command  failed, invalid state: %%d");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1638,13 +1406,6 @@ void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1670,13 +1431,6 @@ void SC_AppendAtsCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Append ATS %%c command: %%d ATS entries appended");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1718,13 +1472,6 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS error: invalid ATS ID = %%d");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1758,13 +1505,6 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS error: invalid ATS ID = %%d");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1801,13 +1541,6 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS %%c error: ATS table is empty");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1843,13 +1576,6 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
     char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Append ATS %%c error: Append table is empty");
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1888,13 +1614,6 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Append ATS %%c error: ATS size = %%d, Append size = %%d, ATS buffer = %%d");
 
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
@@ -1927,13 +1646,6 @@ void SC_AppendAtsCmd_Test_InvalidCmdLength(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-
-    SC_OperData.AtsInfoTblAddr         = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -388,7 +388,7 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_AppData.AtsTimeIndexBuffer[0][0] = 1;
+    SC_AppData.AtsTimeIndexBuffer[0][0]            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Set to cause all commnds to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
@@ -412,7 +412,7 @@ void SC_BeginAts_Test_InvalidAtsIndex(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_AppData.AtsTimeIndexBuffer[0][0] = 1;
+    SC_AppData.AtsTimeIndexBuffer[0][0]            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Set to cause all commnds to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
@@ -1019,7 +1019,7 @@ void ContinueAtsOnFailureCmd_Test_InvalidCmdLength(void)
 void SC_AppendAtsCmd_Test_Nominal(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint8                AtsIndex = 0;
+    uint8                AtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_APPEND_ATS_CC;
 
@@ -1028,8 +1028,8 @@ void SC_AppendAtsCmd_Test_Nominal(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     UT_CmdBuf.AppendAtsCmd.AtsId                          = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -677,7 +677,7 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
 {
-    bool                 ChecksumValid;
+    bool ChecksumValid;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -704,7 +704,7 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
-    bool                 ChecksumValid;
+    bool ChecksumValid;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -737,7 +737,7 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 
 void SC_ProcessRtpCommand_Test_BadChecksum(void)
 {
-    bool                 ChecksumValid;
+    bool ChecksumValid;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -841,8 +841,8 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
 
 void SC_SendHkPacket_Test(void)
 {
-    uint8                i;
-    int32                LastRtsHkIndex = 0;
+    uint8 i;
+    int32 LastRtsHkIndex = 0;
 
     SC_OperData.HkPacket.CmdErrCtr                = 1;
     SC_OperData.HkPacket.CmdCtr                   = 2;
@@ -973,7 +973,7 @@ void SC_ProcessRequest_Test_HkMID(void)
      **  Test case: SC_SEND_HK_MID
      **/
 
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -992,7 +992,7 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
      **  Test case: SC_SEND_HK_MID
      **/
 
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1009,7 +1009,7 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
      **  Test case: SC_SEND_HK_MID
      **/
 
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
 
     SC_AppData.AutoStartRTS = 1;
 
@@ -1033,7 +1033,7 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
      **  Test case: SC_SEND_HK_MID
      **/
 
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
 
     SC_AppData.AutoStartRTS                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS - 1].RtsStatus = SC_LOADED;
@@ -1057,7 +1057,7 @@ void SC_ProcessRequest_Test_1HzWakeupNONE(void)
     /**
      **  Test case: SC_1HZ_WAKEUP_MID with SC_AppData.NextProcNumber == SC_NONE
      **/
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1083,7 +1083,7 @@ void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
     /**
      **  Test case: SC_1HZ_WAKEUP_MID with SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false
      **/
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1109,7 +1109,7 @@ void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
     /**
      **  Test case: SC_1HZ_WAKEUP_MID with a pending ATP command that should not execute yet
      **/
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1147,8 +1147,8 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
     SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount = 0;
     UT_SetHookFunction(UT_KEY(SC_UpdateNextTime), Ut_SC_UpdateNextTimeHook, NULL);
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
-    Entry->CmdNumber          = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
+    Entry->CmdNumber = 1;
 
     SC_AppData.NextProcNumber             = SC_RTP;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING; /* Causes switch to ATP */
@@ -1176,7 +1176,7 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
      **  Test case: SC_1HZ_WAKEUP_MID with a pending RTP command that needs to execute immediately, but too many
      *commands are being sent at once
      **/
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -62,21 +62,9 @@ int32 Ut_SC_UpdateNextTimeHook(void *UserObj, int32 StubRetcode, uint32 CallCoun
 void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -122,21 +110,9 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
     bool                 ChecksumValid;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -182,21 +158,9 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -244,10 +208,6 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
     bool                 ChecksumValid;
@@ -258,14 +218,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
              "ATS Command Distribution Failed, Cmd Number: %%d, SB returned: 0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -328,10 +280,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
     bool                 ChecksumValid;
@@ -342,14 +290,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
              "ATS Command Distribution Failed, Cmd Number: %%d, SB returned: 0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[1]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
@@ -412,10 +352,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
@@ -426,16 +362,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
              "ATS Command Failed Checksum: Command #%%d Skipped");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    memset(&AtsCmdStatusTbl, 0, sizeof(AtsCmdStatusTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -498,10 +424,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
@@ -512,14 +434,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
              "ATS Command Failed Checksum: Command #%%d Skipped");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[1]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
@@ -582,10 +496,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
@@ -594,16 +504,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "ATS Command Failed Checksum: Command #%%d Skipped");
-
-    memset(&AtsCmdStatusTbl, 0, sizeof(AtsCmdStatusTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -657,10 +557,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     int32                strCmpResult;
     char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -668,14 +564,6 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
              "ATS Command Number Mismatch: Command Skipped, expected: %%d received: %%d");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 3;
@@ -725,10 +613,6 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     int32                strCmpResult;
     char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -736,14 +620,6 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
              "ATS Command Number Mismatch: Command Skipped, expected: %%d received: %%d");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[1]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 3;
@@ -793,25 +669,11 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    memset(AtsCmdStatusTbl, 0, sizeof(AtsCmdStatusTbl));
-
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid ATS Command Status: Command Skipped, Status: %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -849,18 +711,6 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -890,18 +740,6 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 void SC_ProcessAtpCmd_Test_NextProcNumber(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -929,18 +767,6 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
 void SC_ProcessAtpCmd_Test_AtpState(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -968,21 +794,9 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
 void SC_ProcessAtpCmd_Test_CmdMid(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -1026,16 +840,7 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     bool                 ChecksumValid;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -1063,21 +868,12 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     bool                 ChecksumValid;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "RTS %%03d Command Distribution Failed: RTS Stopped. SB returned 0x%%08X");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -1117,20 +913,11 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 
 void SC_ProcessRtpCommand_Test_BadChecksum(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     bool                 ChecksumValid;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Command Failed Checksum: RTS Stopped");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -1167,16 +954,6 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
 void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 1;
     SC_AppData.CurrentTime                                                           = 0;
     SC_AppData.NextProcNumber                                                        = SC_RTP;
@@ -1193,16 +970,6 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 
 void SC_ProcessRtpCommand_Test_ProcNumber(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
     SC_AppData.NextProcNumber                                                        = SC_NONE;
@@ -1219,16 +986,6 @@ void SC_ProcessRtpCommand_Test_ProcNumber(void)
 
 void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
     SC_AppData.NextCmdTime[SC_RTP]         = 0;
     SC_AppData.CurrentTime                 = 1;
     SC_AppData.NextProcNumber              = SC_RTP;
@@ -1244,16 +1001,6 @@ void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 
 void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
     SC_AppData.NextProcNumber                                                        = SC_RTP;
@@ -1270,16 +1017,6 @@ void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 
 void SC_ProcessRtpCommand_Test_RtsStatus(void)
 {
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
     SC_AppData.NextProcNumber                                                        = SC_RTP;
@@ -1297,29 +1034,7 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
 void SC_SendHkPacket_Test(void)
 {
     uint8                i;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                LastRtsHkIndex = 0;
-
-    memset(&AtsCmdStatusTbl, 0, sizeof(AtsCmdStatusTbl));
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
-    SC_InitTables();
 
     SC_OperData.HkPacket.CmdErrCtr                = 1;
     SC_OperData.HkPacket.CmdCtr                   = 2;
@@ -1463,23 +1178,6 @@ void SC_ProcessRequest_Test_HkMID(void)
      **/
 
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1500,23 +1198,6 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
      **/
 
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1535,25 +1216,8 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
      **/
 
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     SC_AppData.AutoStartRTS = 1;
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1577,26 +1241,9 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
      **/
 
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     SC_AppData.AutoStartRTS                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS - 1].RtsStatus = SC_LOADED;
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1619,28 +1266,11 @@ void SC_ProcessRequest_Test_1HzWakeupNONE(void)
      **  Test case: SC_1HZ_WAKEUP_MID with SC_AppData.NextProcNumber == SC_NONE
      **/
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_InitTables();
 
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
     SC_AppData.NextProcNumber                   = SC_NONE;
@@ -1663,28 +1293,11 @@ void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
      **  Test case: SC_1HZ_WAKEUP_MID with SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false
      **/
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_InitTables();
 
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
     SC_AppData.NextProcNumber                   = SC_NONE;
@@ -1707,30 +1320,11 @@ void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
      **  Test case: SC_1HZ_WAKEUP_MID with a pending ATP command that should not execute yet
      **/
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    memset(&AtsCtrlBlck, 0, sizeof(AtsCtrlBlck));
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_InitTables();
 
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
     SC_AppData.NextProcNumber                   = SC_ATP;
@@ -1752,24 +1346,7 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
      **  Test case: SC_1HZ_WAKEUP_MID with a pending RTP command that needs to execute immediately
      **/
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    memset(&AtsCtrlBlck, 0, sizeof(AtsCtrlBlck));
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
+    SC_AtsEntryHeader_t *Entry;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1781,11 +1358,6 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
     SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount = 0;
     UT_SetHookFunction(UT_KEY(SC_UpdateNextTime), Ut_SC_UpdateNextTimeHook, NULL);
 
-    SC_AtsEntryHeader_t *Entry;
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber          = 1;
 
@@ -1817,24 +1389,6 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
      *commands are being sent at once
      **/
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtpControlBlock_t AtsCtrlBlck;
-    uint32               AtsCmdStatusTbl[SC_NUMBER_OF_ATS];
-    SC_AtsInfoTable_t    AtsInfoTbl[SC_NUMBER_OF_ATS];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    memset(&AtsCtrlBlck, 0, sizeof(AtsCtrlBlck));
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.AtsTblAddr[0]          = &AtsTable[0];
-    SC_OperData.AtsCtrlBlckAddr        = &AtsCtrlBlck;
-    SC_OperData.AtsCmdStatusTblAddr[0] = &AtsCmdStatusTbl[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &AtsCmdStatusTbl[1];
-    SC_OperData.AtsInfoTblAddr         = &AtsInfoTbl[0];
-
-    SC_OperData.RtsTblAddr[0]   = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlck;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -1842,8 +1396,6 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    SC_InitTables();
 
     SC_AppData.NextProcNumber             = SC_RTP;
     SC_AppData.NextCmdTime[SC_RTP]        = 0;
@@ -2046,8 +1598,6 @@ void SC_ProcessCommand_Test_StartAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.StartAtsCmd.AtsId = 1;
 
     /* Execute the function being tested */
@@ -2072,8 +1622,6 @@ void SC_ProcessCommand_Test_StopAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -2095,8 +1643,6 @@ void SC_ProcessCommand_Test_StartRts(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -2120,8 +1666,6 @@ void SC_ProcessCommand_Test_StopRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -2143,8 +1687,6 @@ void SC_ProcessCommand_Test_DisableRts(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -2168,8 +1710,6 @@ void SC_ProcessCommand_Test_EnableRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -2191,8 +1731,6 @@ void SC_ProcessCommand_Test_SwitchAts(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -2216,8 +1754,6 @@ void SC_ProcessCommand_Test_JumpAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -2239,8 +1775,6 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailure(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -2264,8 +1798,6 @@ void SC_ProcessCommand_Test_AppendAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -2283,16 +1815,11 @@ void SC_ProcessCommand_Test_TableManageAtsTableNominal(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
@@ -2329,8 +1856,6 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
 
     /* Set to generate error message SC_TABLE_MANAGE_ATS_ERR_EID */
@@ -2362,16 +1887,11 @@ void SC_ProcessCommand_Test_TableManageAtsTableID(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
@@ -2422,16 +1942,11 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
@@ -2457,16 +1972,11 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
@@ -2492,16 +2002,11 @@ void SC_ProcessCommand_Test_TableManageAppendTableNominal(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
@@ -2538,8 +2043,6 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_APPEND;
 
     /* Set to generate error message SC_TABLE_MANAGE_APPEND_ERR_EID */
@@ -2571,16 +2074,11 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
@@ -2606,16 +2104,11 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
@@ -2640,16 +2133,11 @@ void SC_ProcessCommand_Test_TableManageRtsTableNominal(void)
      **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
      **/
 
-    uint32            RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
@@ -2683,8 +2171,6 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
     /* Set to generate error message SC_TABLE_MANAGE_RTS_ERR_EID */
@@ -2715,16 +2201,11 @@ void SC_ProcessCommand_Test_TableManageRtsTableID(void)
      **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
      **/
 
-    uint32            RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     /* test TableID >= SC_TBL_ID_RTS_0 */
     UT_CmdBuf.NotifyCmd.Payload.Parameter = 0;
@@ -2771,16 +2252,11 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
      **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
      **/
 
-    uint32            RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
@@ -2802,16 +2278,11 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess(void)
      **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
      **/
 
-    uint32            RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
@@ -2839,8 +2310,6 @@ void SC_ProcessCommand_Test_TableManageRtsInfo(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_INFO;
 
     /* Execute the function being tested */
@@ -2864,8 +2333,6 @@ void SC_ProcessCommand_Test_TableManageRtpCtrl(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTP_CTRL;
 
@@ -2891,8 +2358,6 @@ void SC_ProcessCommand_Test_TableManageAtsInfo(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_INFO;
 
     /* Execute the function being tested */
@@ -2917,8 +2382,6 @@ void SC_ProcessCommand_Test_TableManageAtpCtrl(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATP_CTRL;
 
     /* Execute the function being tested */
@@ -2942,8 +2405,6 @@ void SC_ProcessCommand_Test_TableManageAtsCmdStatus(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_CMD_0;
 
@@ -2973,8 +2434,6 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     UT_CmdBuf.NotifyCmd.Payload.Parameter = 999;
 
@@ -3009,8 +2468,6 @@ void SC_ProcessCommand_Test_StartRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -3032,8 +2489,6 @@ void SC_ProcessCommand_Test_StopRtsGrp(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -3057,8 +2512,6 @@ void SC_ProcessCommand_Test_DisableRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_InitTables();
-
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
@@ -3080,8 +2533,6 @@ void SC_ProcessCommand_Test_EnableRtsGrp(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);
@@ -3109,8 +2560,6 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_ProcessCommand(&UT_CmdBuf.Buf);

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -94,7 +94,7 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
@@ -102,7 +102,6 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -142,7 +141,7 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
@@ -150,7 +149,6 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -190,7 +188,7 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, false);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -201,7 +199,6 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == 1, "SC_OperData.HkPacket.LastAtsErrSeq == 1");
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -211,13 +208,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Distribution Failed, Cmd Number: %%d, SB returned: 0x%%08X");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -246,7 +236,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -258,22 +248,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -283,13 +258,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Distribution Failed, Cmd Number: %%d, SB returned: 0x%%08X");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
@@ -318,7 +286,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -330,22 +298,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -355,13 +308,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Failed Checksum: Command #%%d Skipped");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -391,7 +337,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -402,22 +348,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -427,13 +358,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Failed Checksum: Command #%%d Skipped");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
@@ -463,7 +387,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -474,22 +398,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
@@ -499,11 +408,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Failed Checksum: Command #%%d Skipped");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -533,7 +437,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -544,26 +448,12 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Number Mismatch: Command Skipped, expected: %%d received: %%d");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 3;
@@ -580,7 +470,7 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -591,35 +481,13 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_MSMTCH_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Command Number Mismatch: Command Skipped, expected: %%d received: %%d");
-
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Aborted");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 3;
@@ -636,7 +504,7 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -647,33 +515,13 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_MSMTCH_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid ATS Command Status: Command Skipped, Status: %%d");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -689,7 +537,7 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
@@ -698,13 +546,6 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -728,11 +569,10 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -755,11 +595,10 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -782,11 +621,10 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -826,14 +664,13 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     UT_SetDeferredRetcode(UT_KEY(SC_InlineSwitch), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAtpCmd();
+    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -853,7 +690,7 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 1, "SC_OperData.HkPacket.RtsCmdCtr == 1");
@@ -862,18 +699,12 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0");
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "RTS %%03d Command Distribution Failed: RTS Stopped. SB returned 0x%%08X");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -889,7 +720,7 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 0, "SC_OperData.HkPacket.RtsCmdCtr == 0");
@@ -901,23 +732,12 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
     UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd == 0, "SC_OperData.HkPacket.LastRtsErrCmd == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_DIST_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessRtpCommand_Test_BadChecksum(void)
 {
     bool                 ChecksumValid;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Command Failed Checksum: RTS Stopped");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -930,7 +750,7 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 0, "SC_OperData.HkPacket.RtsCmdCtr == 0");
@@ -942,13 +762,6 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd == 0, "SC_OperData.HkPacket.LastRtsErrCmd == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_CHKSUM_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -961,10 +774,9 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -977,10 +789,9 @@ void SC_ProcessRtpCommand_Test_ProcNumber(void)
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -992,10 +803,9 @@ void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 0;
 
     /* RtsNumber > 0 will be false so nothing should happen, branch coverage */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1008,10 +818,9 @@ void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1024,10 +833,9 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EMPTY;
 
     /* Execute the function being tested */
-    SC_ProcessRtpCommand();
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1077,7 +885,7 @@ void SC_SendHkPacket_Test(void)
         sizeof(SC_OperData.HkPacket.RtsExecutingStatus) / sizeof(SC_OperData.HkPacket.RtsExecutingStatus[0]) - 1;
 
     /* Execute the function being tested */
-    SC_SendHkPacket();
+    UtAssert_VOIDCALL(SC_SendHkPacket());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
@@ -1130,7 +938,6 @@ void SC_SendHkPacket_Test(void)
     UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsExecutingStatus[LastRtsHkIndex], 32767);
     UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsDisabledStatus[LastRtsHkIndex], 32767);
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1142,10 +949,6 @@ void SC_ProcessRequest_Test_CmdMID(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "No-op command. Version %%d.%%d.%%d.%%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1154,20 +957,13 @@ void SC_ProcessRequest_Test_CmdMID(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_NOOP_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1184,10 +980,9 @@ void SC_ProcessRequest_Test_HkMID(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1202,10 +997,9 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1224,12 +1018,11 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1250,12 +1043,11 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1278,11 +1070,10 @@ void SC_ProcessRequest_Test_1HzWakeupNONE(void)
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1305,11 +1096,10 @@ void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1331,11 +1121,10 @@ void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
     SC_AppData.NextCmdTime[SC_ATP]              = 1000;
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1373,10 +1162,9 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1404,11 +1192,10 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1420,28 +1207,17 @@ void SC_ProcessRequest_Test_MIDError(void)
      **/
 
     CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Invalid command pipe message ID: 0x%%08lX");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     /* Execute the function being tested */
-    SC_ProcessRequest(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_MID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1457,10 +1233,6 @@ void SC_ProcessCommand_Test_NoOp(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "No-op command. Version %%d.%%d.%%d.%%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1468,20 +1240,13 @@ void SC_ProcessCommand_Test_NoOp(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_NOOP_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1502,12 +1267,11 @@ void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1524,10 +1288,6 @@ void SC_ProcessCommand_Test_ResetCounters(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_RESET_COUNTERS_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset counters command");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1535,7 +1295,7 @@ void SC_ProcessCommand_Test_ResetCounters(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
@@ -1548,13 +1308,6 @@ void SC_ProcessCommand_Test_ResetCounters(void)
     UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 0, "RtsActiveErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RESET_DEB_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1575,10 +1328,9 @@ void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1601,7 +1353,7 @@ void SC_ProcessCommand_Test_StartAts(void)
     UT_CmdBuf.StartAtsCmd.AtsId = 1;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1623,7 +1375,7 @@ void SC_ProcessCommand_Test_StopAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1645,7 +1397,7 @@ void SC_ProcessCommand_Test_StartRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1667,7 +1419,7 @@ void SC_ProcessCommand_Test_StopRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1689,7 +1441,7 @@ void SC_ProcessCommand_Test_DisableRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1711,7 +1463,7 @@ void SC_ProcessCommand_Test_EnableRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1733,7 +1485,7 @@ void SC_ProcessCommand_Test_SwitchAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1755,7 +1507,7 @@ void SC_ProcessCommand_Test_JumpAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1777,7 +1529,7 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailure(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1799,7 +1551,7 @@ void SC_ProcessCommand_Test_AppendAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1830,7 +1582,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableNominal(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1847,11 +1599,6 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS table manage process error: ATS = %%d, Result = 0x%%X");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1862,17 +1609,10 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_ATS_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1903,7 +1643,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableID(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1911,23 +1651,12 @@ void SC_ProcessCommand_Test_TableManageAtsTableID(void)
 void SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex(void)
 {
     uint8 AtsIndex = SC_NUMBER_OF_ATS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS table manage error: invalid ATS index %%d");
 
     /* Execute the function being tested */
-    SC_ManageAtsTable(AtsIndex);
+    UtAssert_VOIDCALL(SC_ManageAtsTable(AtsIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_ATS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1956,7 +1685,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1986,7 +1715,7 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2017,7 +1746,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableNominal(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2034,11 +1763,6 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS Append table manage process error: Result = 0x%%X");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2049,17 +1773,10 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_APPEND_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -2088,7 +1805,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2118,7 +1835,7 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2145,7 +1862,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableNominal(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2162,11 +1879,6 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "RTS table manage process error: RTS = %%d, Result = 0x%%X");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2177,17 +1889,10 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_RTS_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -2214,7 +1919,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableID(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2222,23 +1927,12 @@ void SC_ProcessCommand_Test_TableManageRtsTableID(void)
 void SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex(void)
 {
     uint8 RtsIndex = SC_NUMBER_OF_RTS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS table manage error: invalid RTS index %%d");
 
     /* Execute the function being tested */
-    SC_ManageRtsTable(RtsIndex);
+    UtAssert_VOIDCALL(SC_ManageRtsTable(RtsIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_RTS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -2263,7 +1957,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2289,7 +1983,7 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2313,7 +2007,7 @@ void SC_ProcessCommand_Test_TableManageRtsInfo(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_INFO;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2337,7 +2031,7 @@ void SC_ProcessCommand_Test_TableManageRtpCtrl(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTP_CTRL;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2361,7 +2055,7 @@ void SC_ProcessCommand_Test_TableManageAtsInfo(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_INFO;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2385,7 +2079,7 @@ void SC_ProcessCommand_Test_TableManageAtpCtrl(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATP_CTRL;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2409,7 +2103,7 @@ void SC_ProcessCommand_Test_TableManageAtsCmdStatus(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_CMD_0;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2426,11 +2120,6 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Table manage command packet error: table ID = %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2438,17 +2127,10 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
     UT_CmdBuf.NotifyCmd.Payload.Parameter = 999;
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_ID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -2469,7 +2151,7 @@ void SC_ProcessCommand_Test_StartRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2491,7 +2173,7 @@ void SC_ProcessCommand_Test_StopRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2513,7 +2195,7 @@ void SC_ProcessCommand_Test_DisableRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2535,7 +2217,7 @@ void SC_ProcessCommand_Test_EnableRtsGrp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -2552,30 +2234,18 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
 
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = 99;
-    int32             strCmpResult;
-    char              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid Command Code: MID =  0x%%08lX CC =  %%d");
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INVLD_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -39,7 +39,6 @@
 #include "utstubs.h"
 
 /* sc_cmds_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
 
 /*
  * Function Definitions
@@ -116,10 +115,8 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
@@ -178,10 +175,8 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
@@ -242,10 +237,8 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == 1, "SC_OperData.HkPacket.LastAtsErrSeq == 1");
     UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
@@ -328,10 +321,8 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
@@ -414,10 +405,8 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
@@ -502,10 +491,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
@@ -588,10 +575,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
@@ -665,10 +650,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
@@ -735,10 +718,8 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
@@ -805,10 +786,8 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
@@ -863,10 +842,8 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
@@ -906,10 +883,8 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_NextProcNumber(void)
@@ -947,10 +922,8 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_AtpState(void)
@@ -988,10 +961,8 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAtpCmd_Test_CmdMid(void)
@@ -1049,10 +1020,8 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
@@ -1088,10 +1057,8 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
@@ -1144,10 +1111,8 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessRtpCommand_Test_BadChecksum(void)
@@ -1196,10 +1161,8 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessRtpCommand_Test_NextCmdTime(void)
@@ -1224,10 +1187,8 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
     SC_ProcessRtpCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_ProcNumber(void)
@@ -1252,10 +1213,8 @@ void SC_ProcessRtpCommand_Test_ProcNumber(void)
     SC_ProcessRtpCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
@@ -1279,10 +1238,8 @@ void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
     SC_ProcessRtpCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
@@ -1307,10 +1264,8 @@ void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
     SC_ProcessRtpCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_RtsStatus(void)
@@ -1335,10 +1290,8 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
     SC_ProcessRtpCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_SendHkPacket_Test(void)
@@ -1462,10 +1415,8 @@ void SC_SendHkPacket_Test(void)
     UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsExecutingStatus[LastRtsHkIndex], 32767);
     UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsDisabledStatus[LastRtsHkIndex], 32767);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_CmdMID(void)
@@ -1501,10 +1452,8 @@ void SC_ProcessRequest_Test_CmdMID(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessRequest_Test_HkMID(void)
@@ -1540,10 +1489,8 @@ void SC_ProcessRequest_Test_HkMID(void)
     SC_ProcessRequest(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
@@ -1577,10 +1524,8 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
     SC_ProcessRequest(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
@@ -1621,10 +1566,8 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
     UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
@@ -1666,10 +1609,8 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
     UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_1HzWakeupNONE(void)
@@ -1712,10 +1653,8 @@ void SC_ProcessRequest_Test_1HzWakeupNONE(void)
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
@@ -1758,10 +1697,8 @@ void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
@@ -1805,10 +1742,8 @@ void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
@@ -1869,10 +1804,8 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
     SC_ProcessRequest(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
@@ -1924,10 +1857,8 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
     /* Verify results */
     UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_MIDError(void)
@@ -1958,10 +1889,8 @@ void SC_ProcessRequest_Test_MIDError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_NoOp(void)
@@ -2000,10 +1929,8 @@ void SC_ProcessCommand_Test_NoOp(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
@@ -2029,10 +1956,8 @@ void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessCommand_Test_ResetCounters(void)
@@ -2077,10 +2002,8 @@ void SC_ProcessCommand_Test_ResetCounters(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
@@ -2103,10 +2026,8 @@ void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessCommand_Test_StartAts(void)
@@ -2426,10 +2347,8 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_TableManageAtsTableID(void)
@@ -2488,10 +2407,8 @@ void SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
@@ -2639,10 +2556,8 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
@@ -2786,10 +2701,8 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_TableManageRtsTableID(void)
@@ -2844,10 +2757,8 @@ void SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
@@ -3078,10 +2989,8 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessCommand_Test_StartRtsGrp(void)
@@ -3217,10 +3126,8 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 /* Unreachable branches in sc_cmds.c SC_ProcessAtpCmd:236, 274, 310.

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -264,14 +264,14 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
 
     for (i = 0, j = 0; i < MaxBufEntries; i++, j += BufEntrySize)
     {
-        Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-        Entry->CmdNumber                             = i + 1;
+        Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+        Entry->CmdNumber = i + 1;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
-    Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-    Entry->CmdNumber                             = i++ + 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+    Entry->CmdNumber = i++ + 1;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = (SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_WORDS - j) * SC_BYTES_IN_WORD;
@@ -316,14 +316,14 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
 
     for (i = 0, j = 0; i < MaxBufEntries; i++, j += BufEntrySize)
     {
-        Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-        Entry->CmdNumber                             = i + 1;
+        Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+        Entry->CmdNumber = i + 1;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
-    Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-    Entry->CmdNumber                             = i++ + 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+    Entry->CmdNumber = i++ + 1;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = (SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_WORDS + 4 - j) * SC_BYTES_IN_WORD;
@@ -360,14 +360,14 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 
     for (i = 0, j = 0; i < MaxBufEntries; i++, j += BufEntrySize)
     {
-        Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-        Entry->CmdNumber                             = i + 1;
+        Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+        Entry->CmdNumber = i + 1;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
-    Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
-    Entry->CmdNumber                             = i++ + 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
+    Entry->CmdNumber = i++ + 1;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = ((SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_NOPKT_WORDS - j) * SC_BYTES_IN_WORD);
@@ -536,8 +536,8 @@ void SC_ValidateAts_Test(void)
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 0;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 0;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_ValidateAts((uint16 *)(SC_OperData.AtsTblAddr[AtsIndex])), SC_ERROR);
@@ -552,8 +552,8 @@ void SC_ValidateAppend_Test(void)
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 0;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 0;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_ValidateAppend((SC_OperData.AtsTblAddr[AtsIndex])), SC_ERROR);
@@ -566,12 +566,12 @@ void SC_ValidateAppend_Test(void)
 void SC_ValidateRts_Test(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     /* The MsgId and MsgSize are here to satisfy TSF */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -588,12 +588,12 @@ void SC_ValidateRts_Test(void)
 void SC_ValidateRts_Test_ParseRts(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 0;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 0;
 
     /* The MsgId and MsgSize are here to satisfy TSF */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -632,12 +632,12 @@ void SC_LoadRts_Test_InvalidIndex(void)
 void SC_ParseRts_Test_EndOfFile(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 0;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 0;
 
     /* Set these to satisfy if-statement to reach line with comment "assumed end of file" */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -653,12 +653,12 @@ void SC_ParseRts_Test_EndOfFile(void)
 void SC_ParseRts_Test_InvalidMsgId(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     /* Set to generate error message SC_RTS_INVLD_MID_ERR_EID */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -675,12 +675,12 @@ void SC_ParseRts_Test_InvalidMsgId(void)
 void SC_ParseRts_Test_LengthErrorTooShort(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize   = 0;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     /* Set to generate error message SC_RTS_INVLD_MID_ERR_EID */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -698,12 +698,12 @@ void SC_ParseRts_Test_LengthErrorTooShort(void)
 void SC_ParseRts_Test_LengthErrorTooLong(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize   = SC_PACKET_MAX_SIZE + 1;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     /* Set to generate error message SC_RTS_LEN_ERR_EID as a result of length being too long */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -721,13 +721,13 @@ void SC_ParseRts_Test_LengthErrorTooLong(void)
 void SC_ParseRts_Test_CmdRunsOffEndOfBuffer(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize;
     int32                BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     while (BufUnused > 0)
     {
@@ -766,13 +766,13 @@ void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
     /* Also tests the case where CmdLength is less than the buffer length */
 
     SC_RtsEntryHeader_t *Entry;
-    uint8                RtsIndex = 0;
+    uint8                RtsIndex  = 0;
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize;
     size_t               BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
-    Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
-    Entry->TimeTag                   = 1;
+    Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
+    Entry->TimeTag = 1;
 
     /* Fill buffer with packets */
     while (BufUnused != 0)
@@ -808,7 +808,7 @@ void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
 
 void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
 {
-    uint8          RtsIndex = 0;
+    uint8          RtsIndex  = 0;
     CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
     size_t         MsgSize;
     size_t         BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
@@ -845,7 +845,7 @@ void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
 
 void SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty(void)
 {
-    uint8          RtsIndex = 0;
+    uint8          RtsIndex  = 0;
     CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
     size_t         MsgSize;
     size_t         BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
@@ -892,8 +892,8 @@ void SC_UpdateAppend_Test_Nominal(void)
     uint8                EntryIndex = 0;
     size_t               MsgSize;
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
-    Entry->CmdNumber          = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
+    Entry->CmdNumber = 1;
 
     /* Set to reach code block starting with comment "Compute buffer index for next Append ATS table entry" */
     MsgSize = 50;
@@ -952,8 +952,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     uint8                EntryIndex = 0;
     size_t               MsgSize;
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
-    Entry->CmdNumber          = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
+    Entry->CmdNumber = 1;
 
     /* Set to satisfy condition "(CommandBytes < SC_PACKET_MIN_SIZE)" */
     MsgSize = SC_PACKET_MIN_SIZE - 1;
@@ -978,8 +978,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     uint8                EntryIndex = 0;
     size_t               MsgSize;
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
-    Entry->CmdNumber          = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
+    Entry->CmdNumber = 1;
 
     /* Set to satisfy condition "(CommandBytes > SC_PACKET_MAX_SIZE)" */
     MsgSize = SC_PACKET_MAX_SIZE * 2;
@@ -1045,8 +1045,8 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     uint8                EntryIndex = 0;
     size_t               MsgSize;
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
-    Entry->CmdNumber          = 0;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
+    Entry->CmdNumber = 0;
 
     /* Cause condition to be met: "(Entry->CmdNumber == 0)" */
     MsgSize = 50;
@@ -1073,8 +1073,8 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     uint8                EntryIndex = 0;
     size_t               MsgSize;
 
-    Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
-    Entry->CmdNumber          = SC_MAX_ATS_CMDS + 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
+    Entry->CmdNumber = SC_MAX_ATS_CMDS + 1;
 
     /* Cause condition to be met: "(Entry->CmdNumber > SC_MAX_ATS_CMDS)" */
     MsgSize = 50;
@@ -1340,8 +1340,8 @@ void SC_VerifyAtsTable_Test_EmptyTable(void)
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 0;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 0;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE), SC_ERROR);
@@ -1357,8 +1357,8 @@ void SC_VerifyAtsEntry_Test_Nominal(void)
     uint8                AtsIndex = 0;
     size_t               MsgSize;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     SC_OperData.AtsDupTestArray[0] = SC_DUP_TEST_UNUSED;
 
@@ -1392,8 +1392,8 @@ void SC_VerifyAtsEntry_Test_InvalidCmdNumber(void)
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 5000;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 5000;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE), SC_ERROR);
@@ -1408,8 +1408,8 @@ void SC_VerifyAtsEntry_Test_BufferFull(void)
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, 2), SC_ERROR);
@@ -1425,8 +1425,8 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow(void)
     uint8                AtsIndex = 0;
     size_t               MsgSize;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     /* Set to generate error message SC_VERIFY_ATS_PKT_ERR_EID by satisfying condition "(CommandBytes <
      * SC_PACKET_MIN_SIZE)" */
@@ -1447,8 +1447,8 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh(void)
     uint8                AtsIndex = 0;
     size_t               MsgSize;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     /* Set to generate error message SC_VERIFY_ATS_PKT_ERR_EID by satisfying condition "(CommandBytes <
      * SC_PACKET_MIN_SIZE)" */
@@ -1469,8 +1469,8 @@ void SC_VerifyAtsEntry_Test_BufferOverflow(void)
     uint8                AtsIndex = 0;
     size_t               MsgSize;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     /* Set to generate error message SC_VERIFY_ATS_BUF_ERR_EID */
     MsgSize = SC_PACKET_MAX_SIZE;
@@ -1490,8 +1490,8 @@ void SC_VerifyAtsEntry_Test_DuplicateCmdNumber(void)
     uint8                AtsIndex = 0;
     size_t               MsgSize;
 
-    Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
-    Entry->CmdNumber                 = 1;
+    Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
+    Entry->CmdNumber = 1;
 
     /* Set to generate error message SC_VERIFY_ATS_DUP_ERR_EID */
     MsgSize = SC_PACKET_MAX_SIZE;

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -40,13 +40,6 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-/* sc_loads_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
-
-uint32 SC_APP_TEST_GlobalAtsCmdStatusTbl[SC_NUMBER_OF_ATS * SC_MAX_ATS_CMDS];
-
-SC_AtpControlBlock_t SC_APP_TEST_GlobalAtsCtrlBlck;
-
 /*
  * Function Definitions
  */
@@ -74,18 +67,7 @@ void SC_LoadAts_Test_Nominal(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     size_t               MsgSize   = sizeof(SC_NoArgsCmd_t);
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-    memset(&AtsTable, 0, sizeof(AtsTable));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
@@ -111,22 +93,12 @@ void SC_LoadAts_Test_Nominal(void)
 void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
     size_t               MsgSize;
     int                  BufEntrySize;
     int                  MaxBufEntries;
     int                  i;
     int                  j;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     /* Causes CFE_MSG_GetSize to satisfy the conditions of if-statement below comment "if the length of the command is
      * valid", but NOT the if-statement immediately after */
@@ -138,8 +110,6 @@ void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
     {
         Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
         Entry->CmdNumber = i + 1;
-
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
 
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
     }
@@ -157,32 +127,17 @@ void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_CmdLengthInvalid(void)
 {
     size_t               MsgSize;
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_EMPTY;
 
     /* Set to make the if-statement below comment "if the length of the command is valid" fail */
     MsgSize = SC_PACKET_MAX_SIZE + 1;
@@ -201,32 +156,17 @@ void SC_LoadAts_Test_CmdLengthInvalid(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_CmdLengthZero(void)
 {
     size_t               MsgSize;
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_EMPTY;
 
     /* Set to make the if-statement below comment "if the length of the command is valid" fail */
     MsgSize = 0;
@@ -245,32 +185,17 @@ void SC_LoadAts_Test_CmdLengthZero(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_CmdNumberInvalid(void)
 {
     size_t               MsgSize;
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = SC_MAX_ATS_CMDS * 2;
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_EMPTY;
 
     /* Set to make the if-statement below comment "if the length of the command is valid" fail */
     MsgSize = SC_PACKET_MAX_SIZE + 1;
@@ -289,32 +214,17 @@ void SC_LoadAts_Test_CmdNumberInvalid(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_EndOfLoadReached(void)
 {
     size_t               MsgSize;
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 0;
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_EMPTY;
 
     /* Set to make the if-statement below comment "if the length of the command is valid" fail */
     MsgSize = SC_PACKET_MAX_SIZE + 1;
@@ -333,17 +243,12 @@ void SC_LoadAts_Test_EndOfLoadReached(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_AtsBufferTooSmall(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
     size_t               MsgSize1;
     size_t               MsgSize2;
@@ -351,14 +256,6 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
     int                  MaxBufEntries;
     int                  i;
     int                  j;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     /* Set to reach block of code starting with comment "even the smallest command will not fit in the buffer" */
     MsgSize1      = SC_PACKET_MAX_SIZE;
@@ -369,14 +266,12 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
     {
         Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
         Entry->CmdNumber                             = i + 1;
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
     Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
     Entry->CmdNumber                             = i++ + 1;
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = (SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_WORDS - j) * SC_BYTES_IN_WORD;
@@ -388,8 +283,6 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
     Entry->CmdNumber = i + 1;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
-
     /* Execute the function being tested */
     SC_LoadAts(AtsIndex);
 
@@ -403,17 +296,12 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0,
                   "SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_AtsEntryOverflow(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
     size_t               MsgSize1;
     size_t               MsgSize2;
@@ -421,15 +309,6 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     int                  MaxBufEntries;
     int                  i;
     int                  j;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-    memset(&AtsTable, 0, sizeof(AtsTable));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     MsgSize1      = SC_PACKET_MAX_SIZE;
     BufEntrySize  = ((MsgSize1 + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD) + SC_ATS_HDR_NOPKT_WORDS;
@@ -439,14 +318,12 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     {
         Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
         Entry->CmdNumber                             = i + 1;
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
     Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
     Entry->CmdNumber                             = i++ + 1;
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = (SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_WORDS + 4 - j) * SC_BYTES_IN_WORD;
@@ -458,23 +335,16 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     Entry->CmdNumber = i + 1;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
-
     /* Execute the function being tested */
     SC_LoadAts(AtsIndex);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
     size_t               MsgSize1;
     size_t               MsgSize2;
@@ -482,12 +352,6 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
     int                  MaxBufEntries;
     int                  i;
     int                  j;
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     /* Set to reach block of code starting with comment "we encountered a load exactly as long as the buffer" */
     MsgSize1      = SC_PACKET_MAX_SIZE;
@@ -498,14 +362,12 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
     {
         Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
         Entry->CmdNumber                             = i + 1;
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
         UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize1, sizeof(MsgSize1), false);
     }
 
     /* Next entry should not leave enough buffer space for an ATS command header */
     Entry                                        = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][j];
     Entry->CmdNumber                             = i++ + 1;
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][j] = SC_EMPTY;
 
     /* Use the remaining buffer space to calculate the final message size */
     MsgSize2 = ((SC_ATS_BUFF_SIZE32 - SC_ATS_HDR_NOPKT_WORDS - j) * SC_BYTES_IN_WORD);
@@ -515,10 +377,7 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
     SC_LoadAts(AtsIndex);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadAts_Test_CmdNotEmpty(void)
@@ -526,19 +385,8 @@ void SC_LoadAts_Test_CmdNotEmpty(void)
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     size_t               MsgSize   = sizeof(SC_NoArgsCmd_t);
     SC_AtsEntryHeader_t *Entry;
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     uint8                AtsIndex = 0;
     uint8                EntryLoc;
-
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-    memset(&AtsTable, 0, sizeof(AtsTable));
-
-    SC_InitTables();
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
@@ -574,36 +422,19 @@ void SC_LoadAts_Test_InvalidIndex(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LOADATS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_BuildTimeIndexTable_Test_InvalidIndex(void)
 {
     uint8 AtsIndex = SC_NUMBER_OF_ATS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Build time index table error: invalid ATS index %%d");
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_BuildTimeIndexTable(AtsIndex);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_BUILD_TIME_IDXTBL_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_Insert_Test(void)
@@ -611,8 +442,6 @@ void SC_Insert_Test(void)
     uint8 AtsIndex    = 0;
     uint8 ListLength  = 1;
     uint8 NewCmdIndex = 0;
-
-    SC_InitTables();
 
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][0] = 1;
 
@@ -625,10 +454,7 @@ void SC_Insert_Test(void)
     UtAssert_True(SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex + 1,
                   "SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_Insert_Test_MiddleOfList(void)
@@ -641,8 +467,6 @@ void SC_Insert_Test_MiddleOfList(void)
       "new cmd will execute at same time or after this list entry" */
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, false);
 
-    SC_InitTables();
-
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][0] = 1;
 
     /* Execute the function being tested */
@@ -654,10 +478,7 @@ void SC_Insert_Test_MiddleOfList(void)
     UtAssert_True(SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex + 1,
                   "SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex+1");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_Insert_Test_MiddleOfListCompareAbsTimeTrue(void)
@@ -670,8 +491,6 @@ void SC_Insert_Test_MiddleOfListCompareAbsTimeTrue(void)
       "new cmd will execute at same time or after this list entry" */
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    SC_InitTables();
-
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][0] = 1;
 
     /* Execute the function being tested */
@@ -683,10 +502,7 @@ void SC_Insert_Test_MiddleOfListCompareAbsTimeTrue(void)
     UtAssert_True(SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex + 1,
                   "SC_AppData.AtsTimeIndexBuffer[AtsIndex][1] == NewCmdIndex+1");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_Insert_Test_InvalidIndex(void)
@@ -694,117 +510,66 @@ void SC_Insert_Test_InvalidIndex(void)
     uint8 AtsIndex    = SC_NUMBER_OF_ATS;
     uint8 ListLength  = 1;
     uint8 NewCmdIndex = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS insert error: invalid ATS index %%d");
-
-    SC_InitTables();
 
     /* Execute the function being tested */
     SC_Insert(AtsIndex, NewCmdIndex, ListLength);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INSERTATS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_InitAtsTables_Test_InvalidIndex(void)
 {
     uint8 AtsIndex = SC_NUMBER_OF_ATS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS table init error: invalid ATS index %%d");
 
     /* Execute the function being tested */
     SC_InitAtsTables(AtsIndex);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_ATSTBL_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ValidateAts_Test(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
 
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 0;
 
     /* Execute the function being tested */
-    Result = SC_ValidateAts((uint16 *)(SC_OperData.AtsTblAddr[AtsIndex]));
+    UtAssert_INT32_EQ(SC_ValidateAts((uint16 *)(SC_OperData.AtsTblAddr[AtsIndex])), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_MPT_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ValidateAppend_Test(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
 
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 0;
 
     /* Execute the function being tested */
-    Result = SC_ValidateAppend((SC_OperData.AtsTblAddr[AtsIndex]));
+    UtAssert_INT32_EQ(SC_ValidateAppend((SC_OperData.AtsTblAddr[AtsIndex])), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_MPT_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ValidateRts_Test(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -813,29 +578,20 @@ void SC_ValidateRts_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ValidateRts((uint16 *)(SC_OperData.RtsTblAddr[RtsIndex]));
+    UtAssert_INT32_EQ(SC_ValidateRts((uint16 *)(SC_OperData.RtsTblAddr[RtsIndex])), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_INVLD_MID_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ValidateRts_Test_ParseRts(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 0;
 
@@ -844,70 +600,42 @@ void SC_ValidateRts_Test_ParseRts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ValidateRts((uint16 *)(SC_OperData.RtsTblAddr[RtsIndex]));
+    UtAssert_INT32_EQ(SC_ValidateRts((uint16 *)(SC_OperData.RtsTblAddr[RtsIndex])), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadRts_Test_Nominal(void)
 {
     uint8 AtsIndex = 0;
 
-    SC_InitTables();
-
     /* Execute the function being tested */
-    SC_LoadRts(AtsIndex);
+    UtAssert_VOIDCALL(SC_LoadRts(AtsIndex));
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_LoadRts_Test_InvalidIndex(void)
 {
     uint8 RtsIndex = SC_NUMBER_OF_RTS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS table init error: invalid RTS index %%d");
 
     /* Execute the function being tested */
-    SC_LoadRts(RtsIndex);
+    UtAssert_VOIDCALL(SC_LoadRts(RtsIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LOADRTS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ParseRts_Test_EndOfFile(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
 
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 0;
 
@@ -916,33 +644,19 @@ void SC_ParseRts_Test_EndOfFile(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_TRUE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ParseRts_Test_InvalidMsgId(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     size_t               MsgSize   = SC_PACKET_MIN_SIZE;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS cmd loaded with invalid MID at %%d");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -951,41 +665,20 @@ void SC_ParseRts_Test_InvalidMsgId(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_FALSE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_INVLD_MID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ParseRts_Test_LengthErrorTooShort(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize   = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "RTS cmd loaded with invalid length at %%d, len: %%d");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -995,41 +688,20 @@ void SC_ParseRts_Test_LengthErrorTooShort(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_FALSE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ParseRts_Test_LengthErrorTooLong(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize   = SC_PACKET_MAX_SIZE + 1;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "RTS cmd loaded with invalid length at %%d, len: %%d");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -1039,43 +711,21 @@ void SC_ParseRts_Test_LengthErrorTooLong(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_FALSE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ParseRts_Test_CmdRunsOffEndOfBuffer(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32                BufUnused = sizeof(RtsTable);
+    int32                BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS cmd at %%d runs off end of buffer");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -1104,22 +754,11 @@ void SC_ParseRts_Test_CmdRunsOffEndOfBuffer(void)
     }
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_FALSE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LEN_BUFFER_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
@@ -1128,17 +767,10 @@ void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
 
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int16                Result;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t       TestMsgId = SC_UT_MID_1;
     size_t               MsgSize;
-    size_t               BufUnused = sizeof(RtsTable);
+    size_t               BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
     Entry                            = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag                   = 1;
 
@@ -1168,30 +800,18 @@ void SC_ParseRts_Test_CmdLengthEqualsBufferLength(void)
     }
 
     /* Execute the function being tested */
-    Result = SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]);
+    UtAssert_BOOL_TRUE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
     /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
 {
     uint8          RtsIndex = 0;
-    uint32         RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
     size_t         MsgSize;
-    size_t         BufUnused = sizeof(RtsTable);
-
-    SC_InitTables();
-
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
+    size_t         BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
     /* Fill buffer with packets */
     while (BufUnused > SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE)
@@ -1226,21 +846,12 @@ void SC_ParseRts_Test_CmdDoesNotFitBufferEmpty(void)
 void SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty(void)
 {
     uint8          RtsIndex = 0;
-    uint32         RtsTable[SC_RTS_BUFF_SIZE32];
     CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
     size_t         MsgSize;
-    size_t         BufUnused = sizeof(RtsTable);
-    int32          strCmpResult;
-    char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    size_t         BufUnused = SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD;
 
     /* Filling the table so it is considered used wherever checked */
-    memset(&RtsTable, 0xff, sizeof(RtsTable));
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS cmd loaded won't fit in buffer at %%d");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
+    memset(SC_OperData.RtsTblAddr[RtsIndex], 0xff, SC_RTS_BUFF_SIZE32 * SC_BYTES_IN_WORD);
 
     /* Fill buffer with packets */
     while (BufUnused > SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE)
@@ -1269,14 +880,8 @@ void SC_ParseRts_Test_CmdDoesNotFitBufferNotEmpty(void)
     /* Execute the function being tested */
     UtAssert_BOOL_FALSE(SC_ParseRts(SC_OperData.RtsTblAddr[RtsIndex]));
 
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LEN_TOO_LONG_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_Nominal(void)
@@ -1285,18 +890,8 @@ void SC_UpdateAppend_Test_Nominal(void)
 
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
     Entry->CmdNumber          = 1;
 
@@ -1307,7 +902,7 @@ void SC_UpdateAppend_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1315,37 +910,17 @@ void SC_UpdateAppend_Test_Nominal(void)
     UtAssert_True(SC_AppData.AppendWordCount == 15, "SC_AppData.AppendWordCount == 15");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
     int                  BufEntrySize;
     int                  MaxBufEntries;
     int                  j;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
 
     /* Set to reach code block starting with comment "Compute buffer index for next Append ATS table entry" */
     MsgSize       = SC_PACKET_MAX_SIZE;
@@ -1360,7 +935,7 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
     }
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1368,34 +943,15 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
     UtAssert_True(SC_AppData.AppendWordCount == 1980, "SC_AppData.AppendWordCount == 1980");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
     Entry->CmdNumber          = 1;
 
@@ -1405,7 +961,7 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1413,34 +969,15 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
     Entry->CmdNumber          = 1;
 
@@ -1450,7 +987,7 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1458,38 +995,18 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_EndOfBuffer(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize1;
     size_t               MsgSize2;
     int                  BufEntrySize;
     int                  MaxBufEntries;
     int                  j;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
 
     /* Cause condition to be met: "(EntryIndex >= SC_APPEND_BUFF_SIZE)" */
     MsgSize1      = SC_PACKET_MAX_SIZE;
@@ -1509,7 +1026,7 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     }
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1517,16 +1034,7 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     UtAssert_True(SC_AppData.AppendWordCount == 2000, "SC_AppData.AppendWordCount == 2000");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_CmdNumberZero(void)
@@ -1535,18 +1043,8 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
 
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
     Entry->CmdNumber          = 0;
 
@@ -1556,7 +1054,7 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1564,16 +1062,7 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
@@ -1582,18 +1071,8 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
 
     SC_AtsEntryHeader_t *Entry;
     uint8                EntryIndex = 0;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Update Append ATS Table: load count = %%d, command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    SC_OperData.AppendTblAddr = &AtsAppendTable[0];
     Entry                     = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[EntryIndex];
     Entry->CmdNumber          = SC_MAX_ATS_CMDS + 1;
 
@@ -1603,7 +1082,7 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_UpdateAppend();
+    UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
@@ -1611,38 +1090,14 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_ProcessAppend_Test(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&AtsTable, 0, sizeof(AtsTable));
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
-    SC_OperData.AtsCtrlBlckAddr               = &SC_APP_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AppendTblAddr                 = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[AtsIndex];
     Entry->CmdNumber = 1;
@@ -1667,7 +1122,7 @@ void SC_ProcessAppend_Test(void)
     UT_SetDeferredRetcode(UT_KEY(SC_BeginAts), 1, true);
 
     /* Execute the function being tested */
-    SC_ProcessAppend(AtsIndex);
+    UtAssert_VOIDCALL(SC_ProcessAppend(AtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 1,
@@ -1680,32 +1135,14 @@ void SC_ProcessAppend_Test(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAppend_Test_CmdLoaded(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&AtsTable, 0, sizeof(AtsTable));
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
-    SC_OperData.AtsCtrlBlckAddr               = &SC_APP_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AppendTblAddr                 = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[AtsIndex];
     Entry->CmdNumber = 1;
@@ -1727,7 +1164,7 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_ProcessAppend(AtsIndex);
+    UtAssert_VOIDCALL(SC_ProcessAppend(AtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 1,
@@ -1740,32 +1177,14 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAppend_Test_NotExecuting(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&AtsTable, 0, sizeof(AtsTable));
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
-    SC_OperData.AtsCtrlBlckAddr               = &SC_APP_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AppendTblAddr                 = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[AtsIndex];
     Entry->CmdNumber = 1;
@@ -1787,7 +1206,7 @@ void SC_ProcessAppend_Test_NotExecuting(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_ProcessAppend(AtsIndex);
+    UtAssert_VOIDCALL(SC_ProcessAppend(AtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 1,
@@ -1799,32 +1218,14 @@ void SC_ProcessAppend_Test_NotExecuting(void)
                   "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_LOADED");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAppend_Test_AtsNumber(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsAppendTable[SC_APPEND_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&AtsTable, 0, sizeof(AtsTable));
-    memset(&AtsAppendTable, 0, sizeof(AtsAppendTable));
-    memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
-    SC_OperData.AtsCtrlBlckAddr               = &SC_APP_TEST_GlobalAtsCtrlBlck;
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
-    SC_OperData.AppendTblAddr                 = &AtsAppendTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr[AtsIndex];
     Entry->CmdNumber = 1;
@@ -1846,7 +1247,7 @@ void SC_ProcessAppend_Test_AtsNumber(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    SC_ProcessAppend(AtsIndex);
+    UtAssert_VOIDCALL(SC_ProcessAppend(AtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize == 1,
@@ -1859,36 +1260,19 @@ void SC_ProcessAppend_Test_AtsNumber(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessAppend_Test_InvalidIndex(void)
 {
     uint8 AtsIndex = SC_NUMBER_OF_ATS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "ATS process append error: invalid ATS index %%d");
 
     /* Execute the function being tested */
-    SC_ProcessAppend(AtsIndex);
+    UtAssert_VOIDCALL(SC_ProcessAppend(AtsIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_PROCESS_APPEND_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsTable_Test_Nominal(void)
@@ -1896,20 +1280,7 @@ void SC_VerifyAtsTable_Test_Nominal(void)
     SC_AtsEntryHeader_t *Entry1;
     SC_AtsEntryHeader_t *Entry2;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    memset(&AtsTable, 0, sizeof(AtsTable));
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table: command count = %%d, byte count = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
 
     Entry1            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry1->CmdNumber = 1;
@@ -1923,7 +1294,7 @@ void SC_VerifyAtsTable_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE), CFE_SUCCESS);
 
     /* Verify results */
 
@@ -1940,19 +1311,8 @@ void SC_VerifyAtsTable_Test_Nominal(void)
     UtAssert_True(SC_OperData.AtsDupTestArray[SC_MAX_ATS_CMDS - 1] == SC_DUP_TEST_UNUSED,
                   "SC_OperData.AtsDupTestArray[SC_MAX_ATS_CMDS - 1] == SC_DUP_TEST_UNUSED");
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsTable_Test_InvalidEntry(void)
@@ -1960,12 +1320,6 @@ void SC_VerifyAtsTable_Test_InvalidEntry(void)
     SC_AtsEntryHeader_t *Entry1;
     SC_AtsEntryHeader_t *Entry2;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
 
     Entry1            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry1->CmdNumber = 5000;
@@ -1974,64 +1328,35 @@ void SC_VerifyAtsTable_Test_InvalidEntry(void)
     Entry2->CmdNumber = 0;
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_NUM_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsTable_Test_EmptyTable(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Verify ATS Table error: table is empty");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 0;
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsTable((SC_OperData.AtsTblAddr[AtsIndex]), SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_MPT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_Nominal(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
 
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -2042,128 +1367,64 @@ void SC_VerifyAtsEntry_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE),
+                      SC_ATS_HDR_NOPKT_WORDS + ((SC_PACKET_MAX_SIZE + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD));
 
     /* Verify results */
-    UtAssert_True(Result == SC_ATS_HDR_NOPKT_WORDS + ((SC_PACKET_MAX_SIZE + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD),
-                  "Result == SC_ATS_HDR_NOPKT_WORDS + (SC_PACKET_MAX_SIZE + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD");
     UtAssert_True(SC_OperData.AtsDupTestArray[0] == 0, "SC_OperData.AtsDupTestArray[0] == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_VerifyAtsEntry_Test_EndOfBuffer(void)
 {
     uint16 AtsIndex = 10000;
-    int16  Result;
-
-    SC_InitTables();
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[0]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[0]), AtsIndex, SC_ATS_BUFF_SIZE), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_VerifyAtsEntry_Test_InvalidCmdNumber(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: invalid command number: buf index = %%d, cmd num = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 5000;
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_NUM_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_BufferFull(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: buffer full: buf index = %%d, cmd num = %%d, buf words = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, 2);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, 2), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_END_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: invalid length: buf index = %%d, cmd num = %%d, pkt len = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -2173,40 +1434,19 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_PKT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: invalid length: buf index = %%d, cmd num = %%d, pkt len = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -2216,40 +1456,19 @@ void SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_PKT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_BufferOverflow(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: buffer overflow: buf index = %%d, cmd num = %%d, pkt len = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -2258,40 +1477,19 @@ void SC_VerifyAtsEntry_Test_BufferOverflow(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, 20);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, 20), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_BUF_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_VerifyAtsEntry_Test_DuplicateCmdNumber(void)
 {
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
-    int16                Result;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Verify ATS Table error: dup cmd number: buf index = %%d, cmd num = %%d, dup index = %%d");
-
-    SC_InitTables();
-
-    SC_OperData.AtsTblAddr[AtsIndex] = &AtsTable[0];
     Entry                            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber                 = 1;
 
@@ -2302,22 +1500,11 @@ void SC_VerifyAtsEntry_Test_DuplicateCmdNumber(void)
     SC_OperData.AtsDupTestArray[0] = 99;
 
     /* Execute the function being tested */
-    Result = SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE);
+    UtAssert_INT32_EQ(SC_VerifyAtsEntry((SC_OperData.AtsTblAddr[AtsIndex]), AtsIndex, SC_ATS_BUFF_SIZE), SC_ERROR);
 
     /* Verify results */
-    UtAssert_True(Result == SC_ERROR, "Result == SC_ERROR");
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_VERIFY_ATS_DUP_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void UtTest_Setup(void)

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -40,8 +40,6 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-/* sc_rtsrq_tests globals */
-
 /*
  * Function Definitions
  */
@@ -51,9 +49,6 @@ void SC_StartRtsCmd_Test_Nominal(void)
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS Number %%03d Started");
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -71,7 +66,7 @@ void SC_StartRtsCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -88,13 +83,6 @@ void SC_StartRtsCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_START_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -123,7 +111,7 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -143,12 +131,10 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     if (UT_CmdBuf.RtsCmd.RtsId > SC_LAST_RTS_WITH_EVENTS)
     {
         UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DBG_EID);
-        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     }
     else
     {
         UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_START_INF_EID);
-        UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     }
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -159,10 +145,6 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS %%03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %%d");
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -180,17 +162,10 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVLD_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -199,10 +174,6 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS %%03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %%d");
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -220,17 +191,10 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVLD_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -238,10 +202,6 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS %%03d Rejected: RTS Not Loaded or In Use, Status: %%d");
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -256,17 +216,10 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -274,9 +227,6 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: RTS Disabled");
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -291,26 +241,15 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DISABLED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidRtsId(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
@@ -318,26 +257,15 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVALID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = 0;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
@@ -345,24 +273,17 @@ void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVALID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_StartRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.RtsActiveErrCtr == 1");
@@ -373,10 +294,6 @@ void SC_StartRtsCmd_Test_NoVerifyLength(void)
 void SC_StartRtsGrpCmd_Test_Nominal(void)
 {
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
@@ -388,7 +305,7 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -405,22 +322,11 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -428,39 +334,26 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -468,28 +361,17 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -497,29 +379,17 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -527,28 +397,17 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -556,29 +415,17 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -586,31 +433,18 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 {
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS group error: rejected RTS ID %%03d, RTS Disabled");
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag   = true;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
@@ -625,7 +459,7 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
@@ -641,34 +475,13 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_DISABLED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 {
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS group error: rejected RTS ID %%03d, RTS Not Loaded or In Use, Status: %%d");
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr         = 0;
@@ -682,7 +495,7 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -700,98 +513,55 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StopRtsCmd_Test_Nominal(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Aborted");
-
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTS_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsCmd_Test_InvalidRts(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS %%03d rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTS_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_StopRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StopRtsGrpCmd_Test_Nominal(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Stop RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -799,28 +569,17 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_Error(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -828,26 +587,19 @@ void SC_StopRtsGrpCmd_Test_Error(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -856,10 +608,6 @@ void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
 void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 {
     uint8                RtsIndex = 0;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Stop RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
 
@@ -870,28 +618,17 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -899,28 +636,17 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -928,28 +654,17 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -957,28 +672,17 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -986,28 +690,17 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1015,28 +708,18 @@ void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Disabled RTS %%03d");
 
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
@@ -1044,7 +727,7 @@ void SC_DisableRtsCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -1052,48 +735,30 @@ void SC_DisableRtsCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISABLE_RTS_DEB_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Disable RTS %%03d Rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTS_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_DisableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1102,10 +767,6 @@ void SC_DisableRtsCmd_Test_NoVerifyLength(void)
 void SC_DisableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1114,7 +775,7 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -1122,23 +783,11 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_Error(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -1146,26 +795,19 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1173,11 +815,6 @@ void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1185,29 +822,17 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1215,29 +840,17 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -1245,29 +858,17 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -1275,29 +876,17 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1305,29 +894,18 @@ void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
 
@@ -1338,7 +916,7 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -1346,22 +924,12 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enabled RTS %%03d");
 
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
@@ -1369,7 +937,7 @@ void SC_EnableRtsCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
@@ -1377,76 +945,47 @@ void SC_EnableRtsCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENABLE_RTS_DEB_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enable RTS %%03d Rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTS_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enable RTS %%03d Rejected: Invalid RTS ID");
-
     UT_CmdBuf.RtsCmd.RtsId = 0;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTS_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_EnableRtsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1455,11 +994,6 @@ void SC_EnableRtsCmd_Test_NoVerifyLength(void)
 void SC_EnableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1468,7 +1002,7 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
@@ -1476,23 +1010,11 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_Error(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -1500,26 +1022,19 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
 {
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1527,11 +1042,6 @@ void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1539,29 +1049,17 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1569,29 +1067,17 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -1599,29 +1085,17 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -1629,29 +1103,17 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1659,29 +1121,18 @@ void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[1].DisabledFlag        = true;
@@ -1692,7 +1143,7 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
@@ -1700,13 +1151,6 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
     UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1718,7 +1162,7 @@ void SC_KillRts_Test(void)
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 1;
 
     /* Execute the function being tested */
-    SC_KillRts(RtsIndex);
+    UtAssert_VOIDCALL(SC_KillRts(RtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED,
@@ -1726,7 +1170,6 @@ void SC_KillRts_Test(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1739,7 +1182,7 @@ void SC_KillRts_Test_NoActiveRts(void)
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 0;
 
     /* Execute the function being tested */
-    SC_KillRts(RtsIndex);
+    UtAssert_VOIDCALL(SC_KillRts(RtsIndex));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED,
@@ -1748,30 +1191,18 @@ void SC_KillRts_Test_NoActiveRts(void)
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_KillRts_Test_InvalidIndex(void)
 {
     uint8 RtsIndex = SC_NUMBER_OF_RTS;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS kill error: invalid RTS index %%d");
 
     /* Execute the function being tested */
-    SC_KillRts(RtsIndex);
+    UtAssert_VOIDCALL(SC_KillRts(RtsIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_KILLRTS_INV_INDEX_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -1780,7 +1211,7 @@ void SC_AutoStartRts_Test_Nominal(void)
     uint8 RtsId = 1;
 
     /* Execute the function being tested */
-    SC_AutoStartRts(RtsId);
+    UtAssert_VOIDCALL(SC_AutoStartRts(RtsId));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1789,46 +1220,24 @@ void SC_AutoStartRts_Test_Nominal(void)
 void SC_AutoStartRts_Test_InvalidId(void)
 {
     uint8 RtsId = SC_NUMBER_OF_RTS + 1;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS autostart error: invalid RTS ID %%d");
 
     /* Execute the function being tested */
-    SC_AutoStartRts(RtsId);
+    UtAssert_VOIDCALL(SC_AutoStartRts(RtsId));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_AUTOSTART_RTS_INV_ID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AutoStartRts_Test_InvalidIdZero(void)
 {
     uint8 RtsId = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS autostart error: invalid RTS ID %%d");
 
     /* Execute the function being tested */
-    SC_AutoStartRts(RtsId);
+    UtAssert_VOIDCALL(SC_AutoStartRts(RtsId));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_AUTOSTART_RTS_INV_ID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -293,7 +293,7 @@ void SC_StartRtsCmd_Test_NoVerifyLength(void)
 
 void SC_StartRtsGrpCmd_Test_Nominal(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
@@ -444,7 +444,7 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
 void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag   = true;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
@@ -481,7 +481,7 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 
 void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr         = 0;
@@ -607,7 +607,7 @@ void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
 
 void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
 
@@ -1156,7 +1156,7 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 
 void SC_KillRts_Test(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 1;
@@ -1176,7 +1176,7 @@ void SC_KillRts_Test(void)
 
 void SC_KillRts_Test_NoActiveRts(void)
 {
-    uint8                RtsIndex = 0;
+    uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 0;

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -50,19 +50,10 @@ void SC_StartRtsCmd_Test_Nominal(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     size_t               MsgSize;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS Number %%03d Started");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -111,21 +102,11 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     size_t               MsgSize;
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS;
 
     RtsIndex = UT_CmdBuf.RtsCmd.RtsId - 1;
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -177,20 +158,11 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     size_t               MsgSize;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS %%03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %%d");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -226,20 +198,11 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     size_t               MsgSize;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS %%03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %%d");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -275,19 +238,10 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS %%03d Rejected: RTS Not Loaded or In Use, Status: %%d");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -320,16 +274,9 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 {
     SC_RtsEntryHeader_t *Entry;
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: RTS Disabled");
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -364,8 +311,6 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: Invalid RTS ID");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
@@ -392,8 +337,6 @@ void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS %%03d Rejected: Invalid RTS ID");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsCmd.RtsId = 0;
 
@@ -424,27 +367,17 @@ void SC_StartRtsCmd_Test_NoVerifyLength(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.RtsActiveErrCtr == 1");
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StartRtsGrpCmd_Test_Nominal(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_OperData.RtsTblAddr[RtsIndex]               = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr                    = &RtsCtrlBlck;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
 
@@ -488,8 +421,6 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -530,8 +461,6 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -560,8 +489,6 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -593,8 +520,6 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -623,8 +548,6 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
@@ -656,8 +579,6 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Start RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -684,22 +605,12 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS group error: rejected RTS ID %%03d, RTS Disabled");
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag   = true;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
@@ -752,22 +663,12 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS group error: rejected RTS ID %%03d, RTS Not Loaded or In Use, Status: %%d");
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Start RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-    memset(&RtsTable, 0, sizeof(RtsTable));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr         = 0;
@@ -824,8 +725,6 @@ void SC_StopRtsCmd_Test_Nominal(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Aborted");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
@@ -853,8 +752,6 @@ void SC_StopRtsCmd_Test_InvalidRts(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS %%03d rejected: Invalid RTS ID");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
@@ -895,8 +792,6 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Stop RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -925,8 +820,6 @@ void SC_StopRtsGrpCmd_Test_Error(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
@@ -957,27 +850,16 @@ void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
     SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Stop RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    memset(&RtsTable, 0, sizeof(RtsTable));
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_InitTables();
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
 
@@ -1010,8 +892,6 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1040,8 +920,6 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1072,8 +950,6 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
@@ -1103,8 +979,6 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -1133,8 +1007,6 @@ void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Stop RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1166,8 +1038,6 @@ void SC_DisableRtsCmd_Test_Nominal(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Disabled RTS %%03d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
@@ -1198,8 +1068,6 @@ void SC_DisableRtsCmd_Test_InvalidRtsID(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Disable RTS %%03d Rejected: Invalid RTS ID");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
@@ -1228,7 +1096,6 @@ void SC_DisableRtsCmd_Test_NoVerifyLength(void)
     SC_DisableRtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1239,8 +1106,6 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1274,8 +1139,6 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -1305,7 +1168,6 @@ void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
     SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1315,8 +1177,6 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1348,8 +1208,6 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1379,8 +1237,6 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
@@ -1412,8 +1268,6 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -1443,8 +1297,6 @@ void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1476,8 +1328,6 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    SC_InitTables();
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
 
@@ -1513,8 +1363,6 @@ void SC_EnableRtsCmd_Test_Nominal(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enabled RTS %%03d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = 1;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
@@ -1545,8 +1393,6 @@ void SC_EnableRtsCmd_Test_InvalidRtsID(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enable RTS %%03d Rejected: Invalid RTS ID");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Set message size so SC_VerifyCmdLength will return true, to satisfy first if-statement */
@@ -1574,8 +1420,6 @@ void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Enable RTS %%03d Rejected: Invalid RTS ID");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsCmd.RtsId = 0;
 
@@ -1605,7 +1449,6 @@ void SC_EnableRtsCmd_Test_NoVerifyLength(void)
     SC_EnableRtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1617,8 +1460,6 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1652,8 +1493,6 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
@@ -1683,7 +1522,6 @@ void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
     SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -1693,8 +1531,6 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1726,8 +1562,6 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
 
@@ -1757,8 +1591,6 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
@@ -1790,8 +1622,6 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
 
-    SC_InitTables();
-
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
 
@@ -1821,8 +1651,6 @@ void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group error: FirstID=%%d, LastID=%%d");
-
-    SC_InitTables();
 
     UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
     UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
@@ -1855,8 +1683,6 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable RTS group: FirstID=%%d, LastID=%%d, Modified=%%d");
 
-    SC_InitTables();
-
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[1].DisabledFlag        = true;
     UT_CmdBuf.RtsGrpCmd.FirstRtsId                    = 1;
@@ -1887,15 +1713,6 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 void SC_KillRts_Test(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 1;
@@ -1917,15 +1734,6 @@ void SC_KillRts_Test(void)
 void SC_KillRts_Test_NoActiveRts(void)
 {
     uint8                RtsIndex = 0;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
-    SC_RtpControlBlock_t RtsCtrlBlck;
-
-    SC_InitTables();
-
-    memset(&RtsCtrlBlck, 0, sizeof(RtsCtrlBlck));
-
-    SC_OperData.RtsTblAddr[RtsIndex] = &RtsTable[0];
-    SC_OperData.RtsCtrlBlckAddr      = &RtsCtrlBlck;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 0;
@@ -1975,7 +1783,6 @@ void SC_AutoStartRts_Test_Nominal(void)
     SC_AutoStartRts(RtsId);
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -41,7 +41,6 @@
 #include "utstubs.h"
 
 /* sc_rtsrq_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
 
 /*
  * Function Definitions
@@ -104,10 +103,8 @@ void SC_StartRtsCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
@@ -221,10 +218,8 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
@@ -272,10 +267,8 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
@@ -319,10 +312,8 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_RtsDisabled(void)
@@ -363,10 +354,8 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidRtsId(void)
@@ -394,10 +383,8 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
@@ -425,10 +412,8 @@ void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsCmd_Test_NoVerifyLength(void)
@@ -439,10 +424,8 @@ void SC_StartRtsCmd_Test_NoVerifyLength(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.RtsActiveErrCtr == 1");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StartRtsGrpCmd_Test_Nominal(void)
@@ -495,10 +478,8 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
@@ -528,10 +509,8 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_NoVerifyLength(void)
@@ -540,10 +519,8 @@ void SC_StartRtsGrpCmd_Test_NoVerifyLength(void)
     SC_StartRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
@@ -574,10 +551,8 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
@@ -607,10 +582,8 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
@@ -641,10 +614,8 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
@@ -674,10 +645,8 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
@@ -708,10 +677,8 @@ void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
@@ -778,10 +745,8 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StartRtsGrpCmd_Test_RtsStatus(void)
@@ -849,10 +814,8 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
 void SC_StopRtsCmd_Test_Nominal(void)
@@ -881,10 +844,8 @@ void SC_StopRtsCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsCmd_Test_InvalidRts(void)
@@ -913,10 +874,8 @@ void SC_StopRtsCmd_Test_InvalidRts(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsCmd_Test_NoVerifyLength(void)
@@ -925,10 +884,8 @@ void SC_StopRtsCmd_Test_NoVerifyLength(void)
     SC_StopRtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StopRtsGrpCmd_Test_Nominal(void)
@@ -959,10 +916,8 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_Error(void)
@@ -992,10 +947,8 @@ void SC_StopRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
@@ -1004,10 +957,8 @@ void SC_StopRtsGrpCmd_Test_NoVerifyLength(void)
     SC_StopRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_StopRtsGrpCmd_Test_NotExecuting(void)
@@ -1049,10 +1000,8 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
@@ -1082,10 +1031,8 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
@@ -1115,10 +1062,8 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
@@ -1148,10 +1093,8 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
@@ -1181,10 +1124,8 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
@@ -1214,10 +1155,8 @@ void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_Nominal(void)
@@ -1249,10 +1188,8 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_InvalidRtsID(void)
@@ -1281,10 +1218,8 @@ void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsCmd_Test_NoVerifyLength(void)
@@ -1293,10 +1228,8 @@ void SC_DisableRtsCmd_Test_NoVerifyLength(void)
     SC_DisableRtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_DisableRtsGrpCmd_Test_Nominal(void)
@@ -1330,10 +1263,8 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_Error(void)
@@ -1364,10 +1295,8 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
@@ -1376,10 +1305,8 @@ void SC_DisableRtsGrpCmd_Test_NoVerifyLength(void)
     SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
@@ -1410,10 +1337,8 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
@@ -1444,10 +1369,8 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
@@ -1478,10 +1401,8 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
@@ -1512,10 +1433,8 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
@@ -1546,10 +1465,8 @@ void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
@@ -1585,10 +1502,8 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_Nominal(void)
@@ -1620,10 +1535,8 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_InvalidRtsID(void)
@@ -1652,10 +1565,8 @@ void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
@@ -1684,10 +1595,8 @@ void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsCmd_Test_NoVerifyLength(void)
@@ -1696,10 +1605,8 @@ void SC_EnableRtsCmd_Test_NoVerifyLength(void)
     SC_EnableRtsCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_EnableRtsGrpCmd_Test_Nominal(void)
@@ -1734,10 +1641,8 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_Error(void)
@@ -1768,10 +1673,8 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
@@ -1780,10 +1683,8 @@ void SC_EnableRtsGrpCmd_Test_NoVerifyLength(void)
     SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
@@ -1814,10 +1715,8 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
@@ -1848,10 +1747,8 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
@@ -1882,10 +1779,8 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
@@ -1916,10 +1811,8 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
@@ -1950,10 +1843,8 @@ void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
@@ -1989,10 +1880,8 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_KillRts_Test(void)
@@ -2021,10 +1910,8 @@ void SC_KillRts_Test(void)
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_KillRts_Test_NoActiveRts(void)
@@ -2053,10 +1940,8 @@ void SC_KillRts_Test_NoActiveRts(void)
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_KillRts_Test_InvalidIndex(void)
@@ -2078,10 +1963,8 @@ void SC_KillRts_Test_InvalidIndex(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AutoStartRts_Test_Nominal(void)
@@ -2092,10 +1975,8 @@ void SC_AutoStartRts_Test_Nominal(void)
     SC_AutoStartRts(RtsId);
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_AutoStartRts_Test_InvalidId(void)
@@ -2117,10 +1998,8 @@ void SC_AutoStartRts_Test_InvalidId(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_AutoStartRts_Test_InvalidIdZero(void)
@@ -2142,10 +2021,8 @@ void SC_AutoStartRts_Test_InvalidIdZero(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void UtTest_Setup(void)

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -61,12 +61,11 @@ void SC_GetNextRtsTime_Test_Nominal(void)
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = SC_MAX_TIME;
 
     /* Execute the function being tested */
-    SC_GetNextRtsTime();
+    UtAssert_VOIDCALL(SC_GetNextRtsTime());
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == 1, "SC_OperData.RtsCtrlBlckAddr->RtsNumber == 1");
     UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -81,13 +80,12 @@ void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
     }
 
     /* Execute the function being tested */
-    SC_GetNextRtsTime();
+    UtAssert_VOIDCALL(SC_GetNextRtsTime());
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == SC_INVALID_RTS_NUMBER,
                   "SC_OperData.RtsCtrlBlckAddr->RtsNumber == SC_INVALID_RTS_NUMBER");
     UtAssert_True(SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -101,12 +99,11 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
     SC_OperData.RtsInfoTblAddr[1].NextCommandTime = SC_MAX_TIME - 1;
 
     /* Execute the function being tested */
-    SC_GetNextRtsTime();
+    UtAssert_VOIDCALL(SC_GetNextRtsTime());
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == 2, "SC_OperData.RtsCtrlBlckAddr->RtsNumber == 2 ");
     UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -116,11 +113,10 @@ void SC_UpdateNextTime_Test_Atp(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    SC_UpdateNextTime();
+    UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -133,11 +129,10 @@ void SC_UpdateNextTime_Test_Atp2(void)
     SC_AppData.NextCmdTime[SC_ATP]         = 10;
 
     /* Execute the function being tested */
-    SC_UpdateNextTime();
+    UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -152,11 +147,10 @@ void SC_UpdateNextTime_Test_Rtp(void)
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = 1;
 
     /* Execute the function being tested */
-    SC_UpdateNextTime();
+    UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_RTP, "SC_AppData.NextProcNumber == SC_RTP");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -171,10 +165,9 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].NextCommandTime = 1;
 
     /* Execute the function being tested */
-    SC_UpdateNextTime();
+    UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -204,7 +197,7 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_MSG_ValidateChecksum), 1, true);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].NextCommandPtr ==
@@ -212,14 +205,13 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
                   "SC_OperData.RtsInfoTblAddr[0].NextCommandPtr == (SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 1) / "
                   "SC_BYTES_IN_WORD");
 
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 {
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -251,7 +243,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_MSG_ValidateChecksum), 1, true);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -282,10 +274,9 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_MSG_ValidateChecksum), 1, true);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -315,10 +306,9 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_MSG_ValidateChecksum), 1, true);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -327,10 +317,6 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize1;
     size_t               MsgSize2;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Cmd Runs passed end of table, RTS %%03d Aborted");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -357,7 +343,7 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
         (SC_RTS_BUFF_SIZE32 - (SC_RTS_HDR_WORDS)) - ((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
@@ -372,13 +358,6 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
                   "((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD)");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LNGTH_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -387,10 +366,6 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize1;
     size_t               MsgSize2;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid Length Field in RTS Command, RTS %%03d Aborted. Length: %%u, Max: %%d");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -417,7 +392,7 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
         (SC_RTS_BUFF_SIZE32 - (SC_RTS_HDR_WORDS)) - ((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD);
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
@@ -432,13 +407,6 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
                   "((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD)");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_CMD_LNGTH_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -447,9 +415,6 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize1;
     size_t               MsgSize2;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -477,17 +442,10 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
                                                    1;
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_COMPL_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -496,8 +454,6 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize1;
     size_t               MsgSize2;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -525,10 +481,9 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
                                                    1;
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -536,9 +491,6 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 {
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -564,17 +516,10 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
                                                    1;
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_COMPL_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -607,10 +552,9 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
                                                    1;
 
     /* Execute the function being tested */
-    SC_GetNextRtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
@@ -621,12 +565,11 @@ void SC_GetNextAtsCommand_Test_Starting(void)
     /* Execute the function being tested */
     /* NOTE: Calling SC_ProcessRtpCommand instead of SC_GetNextRtsCommand - SC_ProcessRtpCommand calls
      * SC_GetNextRtsCommand, and it's much easier to test this way. */
-    SC_GetNextAtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_EXECUTING");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -638,12 +581,11 @@ void SC_GetNextAtsCommand_Test_Idle(void)
     /* Execute the function being tested */
     /* NOTE: Calling SC_ProcessRtpCommand instead of SC_GetNextRtsCommand - SC_ProcessRtpCommand calls
      * SC_GetNextRtsCommand, and it's much easier to test this way. */
-    SC_GetNextAtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE,
                   "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_IDLE");
-
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -670,7 +612,7 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
     SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 100;
 
     /* Execute the function being tested */
-    SC_GetNextAtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
     UtAssert_INT32_EQ(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr, 1);
@@ -683,9 +625,6 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
 void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Completed");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -704,26 +643,16 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
     SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    SC_GetNextAtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_COMPL_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    int32                strCmpResult;
-    char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Completed");
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -742,17 +671,10 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
     SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    SC_GetNextAtsCommand();
+    UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_COMPL_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -40,18 +40,6 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-/* sc_state_tests globals */
-
-uint32 SC_ATSRQ_TEST_GlobalAtsCmdStatus[SC_NUMBER_OF_ATS];
-
-SC_AtsInfoTable_t SC_ATSRQ_TEST_GlobalAtsInfoTable[2];
-
-SC_AtpControlBlock_t SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-SC_RtsInfoEntry_t SC_STATE_TEST_GlobalRtsInfoTbl[SC_NUMBER_OF_RTS];
-
-SC_RtpControlBlock_t SC_STATE_TEST_GlobalRtsCtrlBlck;
-
 /*
  * Function Definitions
  */
@@ -69,17 +57,6 @@ int32 SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook(void *UserObj, int32 StubRetcod
 
 void SC_GetNextRtsTime_Test_Nominal(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_EXECUTING;
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = SC_MAX_TIME;
 
@@ -97,14 +74,6 @@ void SC_GetNextRtsTime_Test_Nominal(void)
 void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
 {
     uint8 i;
-
-    SC_InitTables();
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
 
     for (i = 0; i < SC_NUMBER_OF_RTS; i++)
     {
@@ -125,17 +94,6 @@ void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
 
 void SC_GetNextRtsTime_Test_RtsPriority(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_EXECUTING;
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = SC_MAX_TIME;
 
@@ -155,20 +113,6 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
 
 void SC_UpdateNextTime_Test_Atp(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
@@ -183,20 +127,6 @@ void SC_UpdateNextTime_Test_Atp(void)
 
 void SC_UpdateNextTime_Test_Atp2(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = SC_NUMBER_OF_RTS + 1;
     SC_AppData.NextCmdTime[SC_RTP]         = 0;
@@ -214,20 +144,6 @@ void SC_UpdateNextTime_Test_Atp2(void)
 
 void SC_UpdateNextTime_Test_Rtp(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 10;
     SC_AppData.NextCmdTime[SC_RTP]         = 0;
     SC_AppData.NextCmdTime[SC_ATP]         = 10;
@@ -247,20 +163,6 @@ void SC_UpdateNextTime_Test_Rtp(void)
 
 void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 0;
     SC_AppData.NextCmdTime[SC_RTP]         = 0;
     SC_AppData.NextCmdTime[SC_ATP]         = 0;
@@ -279,24 +181,7 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -333,10 +218,6 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 
 void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 {
-    /* Sets SC_OperData.RtsCtrlBlckAddr->RtsNumber to zero */
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     /* Execute the function being tested */
     SC_GetNextRtsCommand();
 
@@ -347,24 +228,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -390,31 +254,13 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                 = 0;
     SC_AppData.CurrentTime                         = 1;
@@ -446,24 +292,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -496,29 +325,12 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize1;
     size_t               MsgSize2;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Cmd Runs passed end of table, RTS %%03d Aborted");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -573,29 +385,12 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize1;
     size_t               MsgSize2;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid Length Field in RTS Command, RTS %%03d Aborted. Length: %%u, Max: %%d");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -650,28 +445,11 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize1;
     size_t               MsgSize2;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS - 1] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -716,27 +494,10 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize1;
     size_t               MsgSize2;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -774,27 +535,10 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
 void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "RTS %%03d Execution Completed");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[0] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -837,24 +581,7 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 {
     SC_RtsEntryHeader_t *Entry;
-    uint32               RtsTable[SC_RTS_BUFF_SIZE32];
     size_t               MsgSize;
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS] = &RtsTable[0];
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -889,20 +616,6 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 
 void SC_GetNextAtsCommand_Test_Starting(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_STARTING;
 
     /* Execute the function being tested */
@@ -920,20 +633,6 @@ void SC_GetNextAtsCommand_Test_Starting(void)
 
 void SC_GetNextAtsCommand_Test_Idle(void)
 {
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
 
     /* Execute the function being tested */
@@ -952,26 +651,6 @@ void SC_GetNextAtsCommand_Test_Idle(void)
 void SC_GetNextAtsCommand_Test_GetNextCommand(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -1004,29 +683,9 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
 void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Completed");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -1062,29 +721,9 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 {
     SC_AtsEntryHeader_t *Entry;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
     int32                strCmpResult;
     char                 ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "ATS %%c Execution Completed");
-
-    SC_InitTables();
-
-    memset(&SC_ATSRQ_TEST_GlobalAtsInfoTable, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-    memset(&SC_ATSRQ_TEST_GlobalAtsCtrlBlck, 0, sizeof(SC_ATSRQ_TEST_GlobalAtsCtrlBlck));
-
-    memset(&SC_STATE_TEST_GlobalRtsInfoTbl, 0, sizeof(SC_STATE_TEST_GlobalRtsInfoTbl));
-    memset(&SC_STATE_TEST_GlobalRtsCtrlBlck, 0, sizeof(SC_STATE_TEST_GlobalRtsCtrlBlck));
-
-    SC_OperData.AtsInfoTblAddr  = &SC_ATSRQ_TEST_GlobalAtsInfoTable[0];
-    SC_OperData.AtsCtrlBlckAddr = &SC_ATSRQ_TEST_GlobalAtsCtrlBlck;
-
-    SC_OperData.RtsInfoTblAddr  = &SC_STATE_TEST_GlobalRtsInfoTbl[0];
-    SC_OperData.RtsCtrlBlckAddr = &SC_STATE_TEST_GlobalRtsCtrlBlck;
-
-    SC_OperData.AtsCmdStatusTblAddr[0] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[0];
-    SC_OperData.AtsCmdStatusTblAddr[1] = &SC_ATSRQ_TEST_GlobalAtsCmdStatus[1];
-
-    SC_OperData.AtsTblAddr[0] = &AtsTable[0];
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -1116,10 +755,6 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
-
-/* Unreachable branch in sc_state.c SC_UpdateNextTime:140.
-   RtsNumber can never be assigned a value > SC_NUMBER_RTS
-   due to processing logic in SC_GetNextRtsTime. */
 
 void UtTest_Setup(void)
 {

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -41,7 +41,6 @@
 #include "utstubs.h"
 
 /* sc_state_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
 
 uint32 SC_ATSRQ_TEST_GlobalAtsCmdStatus[SC_NUMBER_OF_ATS];
 
@@ -91,10 +90,8 @@ void SC_GetNextRtsTime_Test_Nominal(void)
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == 1, "SC_OperData.RtsCtrlBlckAddr->RtsNumber == 1");
     UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
@@ -122,10 +119,8 @@ void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
                   "SC_OperData.RtsCtrlBlckAddr->RtsNumber == SC_INVALID_RTS_NUMBER");
     UtAssert_True(SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsTime_Test_RtsPriority(void)
@@ -154,10 +149,8 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == 2, "SC_OperData.RtsCtrlBlckAddr->RtsNumber == 2 ");
     UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_UpdateNextTime_Test_Atp(void)
@@ -184,10 +177,8 @@ void SC_UpdateNextTime_Test_Atp(void)
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_UpdateNextTime_Test_Atp2(void)
@@ -217,10 +208,8 @@ void SC_UpdateNextTime_Test_Atp2(void)
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_UpdateNextTime_Test_Rtp(void)
@@ -252,10 +241,8 @@ void SC_UpdateNextTime_Test_Rtp(void)
     /* Verify results */
     UtAssert_True(SC_AppData.NextProcNumber == SC_RTP, "SC_AppData.NextProcNumber == SC_RTP");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_UpdateNextTime_Test_RtpAtpPriority(void)
@@ -285,10 +272,8 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
     SC_UpdateNextTime();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_GetNextCommand(void)
@@ -342,10 +327,8 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
                   "SC_OperData.RtsInfoTblAddr[0].NextCommandPtr == (SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 1) / "
                   "SC_BYTES_IN_WORD");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
@@ -407,10 +390,8 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
@@ -458,10 +439,8 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
@@ -510,10 +489,8 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_RtsLengthError(void)
@@ -589,10 +566,8 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextRtsCommand_Test_CommandLengthError(void)
@@ -668,10 +643,8 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
@@ -736,10 +709,8 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
@@ -796,10 +767,8 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
@@ -861,10 +830,8 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
@@ -916,10 +883,8 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
     SC_GetNextRtsCommand();
 
     /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextAtsCommand_Test_Starting(void)
@@ -949,10 +914,8 @@ void SC_GetNextAtsCommand_Test_Starting(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_EXECUTING");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextAtsCommand_Test_Idle(void)
@@ -982,10 +945,8 @@ void SC_GetNextAtsCommand_Test_Idle(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE,
                   "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_IDLE");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextAtsCommand_Test_GetNextCommand(void)
@@ -1094,10 +1055,8 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
@@ -1154,10 +1113,8 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 /* Unreachable branch in sc_state.c SC_UpdateNextTime:140.

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -29,7 +29,6 @@
 #include "utstubs.h"
 
 /* sc_utils_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
 
 void SC_GetCurrentTime_Test(void)
 {
@@ -125,10 +124,8 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     UtAssert_True(Result == true, "Result == true");
     UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-                  call_count_CFE_EVS_SendEvent);
 }
 
 void SC_VerifyCmdLength_Test_LenError(void)
@@ -165,10 +162,8 @@ void SC_VerifyCmdLength_Test_LenError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-                  call_count_CFE_EVS_SendEvent);
 }
 
 void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
@@ -204,10 +199,8 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-                  call_count_CFE_EVS_SendEvent);
 }
 
 void SC_ToggleAtsIndex_Test(void)

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -127,7 +127,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
                   call_count_CFE_EVS_SendEvent);
 }
 
@@ -167,7 +167,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
                   call_count_CFE_EVS_SendEvent);
 }
 
@@ -206,7 +206,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
                   call_count_CFE_EVS_SendEvent);
 }
 

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -111,8 +111,6 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
     size_t            MsgSize   = sizeof(CmdPacket);
 
-    SC_InitTables();
-
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -140,8 +138,6 @@ void SC_VerifyCmdLength_Test_LenError(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid msg length: ID = 0x%%08lX, CC = %%d, Len = %%d, Expected = %%d");
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -178,8 +174,6 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid msg length: ID = 0x%%08lX, CC = %%d, Len = %%d, Expected = %%d");
-
-    SC_InitTables();
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);

--- a/unit-test/utilities/sc_test_utils.c
+++ b/unit-test/utilities/sc_test_utils.c
@@ -41,14 +41,14 @@ CFE_ES_WriteToSysLog_context_t context_CFE_ES_WriteToSysLog;
 UT_CmdBuf_t UT_CmdBuf;
 
 /* Table buffers */
-uint32 AtsTblAddr[SC_NUMBER_OF_ATS][SC_ATS_BUFF_SIZE32];
-uint32 AppendTblAddr[SC_APPEND_BUFF_SIZE32];
-uint32 RtsTblAddr[SC_NUMBER_OF_RTS][SC_RTS_BUFF_SIZE32];
-SC_AtsInfoTable_t AtsInfoTblAddr[SC_NUMBER_OF_ATS];
-SC_RtsInfoEntry_t RtsInfoTblAddr[SC_NUMBER_OF_RTS];
+uint32               AtsTblAddr[SC_NUMBER_OF_ATS][SC_ATS_BUFF_SIZE32];
+uint32               AppendTblAddr[SC_APPEND_BUFF_SIZE32];
+uint32               RtsTblAddr[SC_NUMBER_OF_RTS][SC_RTS_BUFF_SIZE32];
+SC_AtsInfoTable_t    AtsInfoTblAddr[SC_NUMBER_OF_ATS];
+SC_RtsInfoEntry_t    RtsInfoTblAddr[SC_NUMBER_OF_RTS];
 SC_RtpControlBlock_t RtsCtrlBlckAddr;
 SC_AtpControlBlock_t AtsCtrlBlckAddr;
-uint32 AtsCmdStatusTblAddr[SC_NUMBER_OF_ATS][SC_MAX_ATS_CMDS];
+uint32               AtsCmdStatusTblAddr[SC_NUMBER_OF_ATS][SC_MAX_ATS_CMDS];
 
 /*
  * Function Definitions
@@ -91,16 +91,16 @@ void SC_Test_SetTableAddrs(void)
     /* Set table addresses */
     for (i = 0; i < SC_NUMBER_OF_ATS; i++)
     {
-        SC_OperData.AtsTblAddr[i] = AtsTblAddr[i];
+        SC_OperData.AtsTblAddr[i]          = AtsTblAddr[i];
         SC_OperData.AtsCmdStatusTblAddr[i] = AtsCmdStatusTblAddr[i];
     }
     for (i = 0; i < SC_NUMBER_OF_RTS; i++)
     {
         SC_OperData.RtsTblAddr[i] = RtsTblAddr[i];
     }
-    SC_OperData.AppendTblAddr = AppendTblAddr;
-    SC_OperData.AtsInfoTblAddr = AtsInfoTblAddr;
-    SC_OperData.RtsInfoTblAddr = RtsInfoTblAddr;
+    SC_OperData.AppendTblAddr   = AppendTblAddr;
+    SC_OperData.AtsInfoTblAddr  = AtsInfoTblAddr;
+    SC_OperData.RtsInfoTblAddr  = RtsInfoTblAddr;
     SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlckAddr;
     SC_OperData.AtsCtrlBlckAddr = &AtsCtrlBlckAddr;
 }

--- a/unit-test/utilities/sc_test_utils.c
+++ b/unit-test/utilities/sc_test_utils.c
@@ -37,9 +37,18 @@
 #define UT_MAX_SENDEVENT_DEPTH 4
 CFE_EVS_SendEvent_context_t    context_CFE_EVS_SendEvent[UT_MAX_SENDEVENT_DEPTH];
 CFE_ES_WriteToSysLog_context_t context_CFE_ES_WriteToSysLog;
-SC_RtsInfoEntry_t              RtsInfoTbl[SC_NUMBER_OF_RTS];
 
 UT_CmdBuf_t UT_CmdBuf;
+
+/* Table buffers */
+uint32 AtsTblAddr[SC_NUMBER_OF_ATS][SC_ATS_BUFF_SIZE32];
+uint32 AppendTblAddr[SC_APPEND_BUFF_SIZE32];
+uint32 RtsTblAddr[SC_NUMBER_OF_RTS][SC_RTS_BUFF_SIZE32];
+SC_AtsInfoTable_t AtsInfoTblAddr[SC_NUMBER_OF_ATS];
+SC_RtsInfoEntry_t RtsInfoTblAddr[SC_NUMBER_OF_RTS];
+SC_RtpControlBlock_t RtsCtrlBlckAddr;
+SC_AtpControlBlock_t AtsCtrlBlckAddr;
+uint32 AtsCmdStatusTblAddr[SC_NUMBER_OF_ATS][SC_MAX_ATS_CMDS];
 
 /*
  * Function Definitions
@@ -75,20 +84,54 @@ void UT_Handler_CFE_ES_WriteToSysLog(void *UserObj, UT_EntryKey_t FuncKey, const
     context_CFE_ES_WriteToSysLog.Spec[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH - 1] = '\0';
 }
 
+void SC_Test_SetTableAddrs(void)
+{
+    uint8 i;
+
+    /* Set table addresses */
+    for (i = 0; i < SC_NUMBER_OF_ATS; i++)
+    {
+        SC_OperData.AtsTblAddr[i] = AtsTblAddr[i];
+        SC_OperData.AtsCmdStatusTblAddr[i] = AtsCmdStatusTblAddr[i];
+    }
+    for (i = 0; i < SC_NUMBER_OF_RTS; i++)
+    {
+        SC_OperData.RtsTblAddr[i] = RtsTblAddr[i];
+    }
+    SC_OperData.AppendTblAddr = AppendTblAddr;
+    SC_OperData.AtsInfoTblAddr = AtsInfoTblAddr;
+    SC_OperData.RtsInfoTblAddr = RtsInfoTblAddr;
+    SC_OperData.RtsCtrlBlckAddr = &RtsCtrlBlckAddr;
+    SC_OperData.AtsCtrlBlckAddr = &AtsCtrlBlckAddr;
+}
+
 void SC_Test_Setup(void)
 {
+
     /* initialize test environment to default state for every test */
     UT_ResetState(0);
 
+    /* Clear app data */
     memset(&SC_OperData, 0, sizeof(SC_OperData));
     memset(&SC_AppData, 0, sizeof(SC_AppData));
-    memset(RtsInfoTbl, 0, sizeof(RtsInfoTbl));
 
+    /* Clear table buffers */
+    memset(&AtsTblAddr, 0, sizeof(AtsTblAddr));
+    memset(&AppendTblAddr, 0, sizeof(AppendTblAddr));
+    memset(&RtsTblAddr, 0, sizeof(RtsTblAddr));
+    memset(&AtsInfoTblAddr, 0, sizeof(AtsInfoTblAddr));
+    memset(&RtsInfoTblAddr, 0, sizeof(RtsInfoTblAddr));
+    memset(&RtsCtrlBlckAddr, 0, sizeof(RtsCtrlBlckAddr));
+    memset(&AtsCtrlBlckAddr, 0, sizeof(AtsCtrlBlckAddr));
+    memset(&AtsCmdStatusTblAddr, 0, sizeof(AtsCmdStatusTblAddr));
+
+    /* Clear unit test buffers */
     memset(context_CFE_EVS_SendEvent, 0, sizeof(context_CFE_EVS_SendEvent));
     memset(&context_CFE_ES_WriteToSysLog, 0, sizeof(context_CFE_ES_WriteToSysLog));
     memset(&UT_CmdBuf, 0, sizeof(UT_CmdBuf));
 
-    SC_OperData.RtsInfoTblAddr = &RtsInfoTbl[0];
+    /* Set table addresses */
+    SC_Test_SetTableAddrs();
 
     /* Register custom handlers */
     UT_SetVaHandlerFunction(UT_KEY(CFE_EVS_SendEvent), UT_Handler_CFE_EVS_SendEvent, NULL);

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -33,8 +33,8 @@
 #include "cfe_msgids.h"
 #include "cfe_tbl_msg.h"
 
-extern SC_AppData_t      SC_AppData;
-extern SC_OperData_t     SC_OperData;
+extern SC_AppData_t  SC_AppData;
+extern SC_OperData_t SC_OperData;
 
 /*
  * Global context structures

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -35,7 +35,6 @@
 
 extern SC_AppData_t      SC_AppData;
 extern SC_OperData_t     SC_OperData;
-extern SC_RtsInfoEntry_t RtsInfoTbl[SC_NUMBER_OF_RTS];
 
 /*
  * Global context structures
@@ -80,6 +79,7 @@ extern UT_CmdBuf_t UT_CmdBuf;
  * Function Definitions
  */
 
+void SC_Test_SetTableAddrs(void);
 void SC_Test_Setup(void);
 void SC_Test_TearDown(void);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #80 

Also consolidated "result" asserts using modern APIs, removed low-value/high-maintenance checks on event string and type (ID is sufficient to confirm path).

Recommend a follow-on issue to replace the rest of the UtAssert_True uses.

**Testing performed**
CI (including coverage)

**Expected behavior changes**
Greatly reduced technical debt wrt unit tests (large reduction in lines, and consistent table initialization)

**System(s) tested on**
CI

**Additional context**
Note this should make the remaining bug fixes and updates easier, by reducing ut change overhead.

Could squash if CCB wants, just tried to break down the changes a little.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC