### PR TITLE
Fix #99, cmd and tlm messages use payload sub-structure

### DIFF
--- a/fsw/inc/sc_msg.h
+++ b/fsw/inc/sc_msg.h
@@ -52,12 +52,10 @@
  */
 
 /**
- *  \brief Housekeeping Packet Structure
+ *  \brief Housekeeping Packet Payload Structure
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader;
-
     uint8 AtsNumber;                /**< \brief Current ATS number: 1 = ATS A, 2 = ATS B */
     uint8 AtpState;                 /**< \brief Current ATP state: 2 = IDLE, 5 = EXECUTING */
     uint8 ContinueAtsOnFailureFlag; /**< \brief Continue ATS execution on failure flag */
@@ -102,6 +100,15 @@ typedef struct
      the LSB (bit zero) of uint16 array index zero represents RTS number 1, and bit one of uint16 array
      index zero represents RTS number 2, etc.  If an RTS is ENABLED, then the corresponding bit is zero.
      If an RTS is DISABLED, then the corresponding bit is one. */
+} SC_HkTlm_Payload_t;
+
+/**
+ *  \brief Housekeeping Packet Structure
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TlmHeader;
+    SC_HkTlm_Payload_t        Payload;
 } SC_HkTlm_t;
 
 /**\}*/
@@ -110,6 +117,61 @@ typedef struct
  * \defgroup cfssccmdstructs CFS Stored Command Command Structures
  * \{
  */
+
+/**
+ *  \brief ATS Id Command Payload
+ */
+typedef struct
+{
+    uint16 AtsId;   /**< \brief The ID of the ATS to start, 1 = ATS_A, 2 = ATS_B */
+    uint16 Padding; /**< \brief Structure padding */
+} SC_StartAtsCmd_Payload_t;
+
+/**
+ *  \brief RTS Id Command Payload
+ */
+typedef struct
+{
+    uint16 RtsId;   /**< \brief The ID of the RTS to start, 1 through #SC_NUMBER_OF_RTS */
+    uint16 Padding; /**< \brief Structure padding */
+} SC_RtsCmd_Payload_t;
+
+/**
+ *  \brief Jump running ATS to a new time Command Payload
+ */
+typedef struct
+{
+    uint32 NewTime; /**< \brief the time to 'jump' to */
+} SC_JumpAtsCmd_Payload_t;
+
+/**
+ *  \brief Continue ATS on failure command Payload
+ */
+typedef struct
+{
+    uint16 ContinueState; /**< \brief true or false, to continue ATS after a failure  */
+    uint16 Padding;       /**< \brief Structure Padding */
+} SC_SetContinueAtsOnFailureCmd_Payload_t;
+
+/**
+ *  \brief Append to ATS Command Payload
+ */
+typedef struct
+{
+    uint16 AtsId;   /**< \brief The ID of the ATS to append to, 1 = ATS_A, 2 = ATS_B */
+    uint16 Padding; /**< \brief Structure Padding */
+} SC_AppendAtsCmd_Payload_t;
+
+#if (SC_ENABLE_GROUP_COMMANDS == true)
+/**
+ *  \brief RTS Group Command Payload
+ */
+typedef struct
+{
+    uint16 FirstRtsId; /**< \brief ID of the first RTS to act on, 1 through #SC_NUMBER_OF_RTS */
+    uint16 LastRtsId;  /**< \brief ID of the last RTS to act on, 1 through #SC_NUMBER_OF_RTS */
+} SC_RtsGrpCmd_Payload_t;
+#endif
 
 /**
  *  \brief No Arguments Command
@@ -129,10 +191,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint16 AtsId;   /**< \brief The ID of the ATS to start, 1 = ATS_A, 2 = ATS_B */
-    uint16 Padding; /**< \brief Structure padding */
+    CFE_MSG_CommandHeader_t  CmdHeader; /**< \brief Command Header */
+    SC_StartAtsCmd_Payload_t Payload;
 } SC_StartAtsCmd_t;
 
 /**
@@ -143,9 +203,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint16 RtsId;   /**< \brief The ID of the RTS to start, 1 through #SC_NUMBER_OF_RTS */
-    uint16 Padding; /**< \brief Structure padding */
+    SC_RtsCmd_Payload_t     Payload;
 } SC_RtsCmd_t;
 
 /**
@@ -156,8 +214,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint32 NewTime; /**< \brief the time to 'jump' to */
+    SC_JumpAtsCmd_Payload_t Payload;
 } SC_JumpAtsCmd_t;
 
 /**
@@ -167,10 +224,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint16 ContinueState; /**< \brief true or false, to continue ATS after a failure  */
-    uint16 Padding;       /**< \brief Structure Padding */
+    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command Header */
+    SC_SetContinueAtsOnFailureCmd_Payload_t Payload;
 } SC_SetContinueAtsOnFailureCmd_t;
 
 /**
@@ -180,10 +235,8 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint16 AtsId;   /**< \brief The ID of the ATS to append to, 1 = ATS_A, 2 = ATS_B */
-    uint16 Padding; /**< \brief Structure Padding */
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command Header */
+    SC_AppendAtsCmd_Payload_t Payload;
 } SC_AppendAtsCmd_t;
 
 #if (SC_ENABLE_GROUP_COMMANDS == true)
@@ -195,9 +248,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-
-    uint16 FirstRtsId; /**< \brief ID of the first RTS to act on, 1 through #SC_NUMBER_OF_RTS */
-    uint16 LastRtsId;  /**< \brief ID of the last RTS to act on, 1 through #SC_NUMBER_OF_RTS */
+    SC_RtsGrpCmd_Payload_t  Payload;
 } SC_RtsGrpCmd_t;
 #endif
 

--- a/fsw/inc/sc_msgdefs.h
+++ b/fsw/inc/sc_msgdefs.h
@@ -106,7 +106,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_NOOP_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -115,7 +115,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message #SC_LEN_ERR_EID
  *
  *  \par Criticality
@@ -137,7 +137,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will be cleared
+ *       - #SC_HkTlm_Payload_t.CmdCtr will be cleared
  *       - The #SC_STARTATS_CMD_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -146,7 +146,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message #SC_LEN_ERR_EID
  *
  *  \par Criticality
@@ -168,7 +168,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -179,7 +179,7 @@
  *       - All command were skipped
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -200,7 +200,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - the #SC_STOPATS_CMD_INF_EID event message will be generated
  *
  **
@@ -209,7 +209,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *
  *  \par Criticality
  *       None
@@ -230,7 +230,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_STARTRTS_CMD_DBG_EID will be sent
  *
  *  \par Error Conditions
@@ -243,8 +243,8 @@
  *       - Invalid RTS ID
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
- *       - #SC_HkTlm_t.RtsActiveErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.RtsActiveErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -266,7 +266,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_STOPRTS_CMD_INF_EID will be sent
  *
  *  \par Error Conditions
@@ -275,7 +275,7 @@
  *       - RTS ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -297,7 +297,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_DISABLE_RTS_DEB_EID will be sent
  *
  *  \par Error Conditions
@@ -306,7 +306,7 @@
  *       - RTS ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -328,7 +328,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_ENABLE_RTS_DEB_EID will be sent
  *
  *  \par Error Conditions
@@ -337,7 +337,7 @@
  *       - RTS ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -359,7 +359,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_SWITCH_ATS_CMD_INF_EID will be sent
  *
  *  \par Error Conditions
@@ -369,7 +369,7 @@
  *       - There is no currently running ATS to switch from
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -389,7 +389,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_JUMP_ATS_INF_EID will be sent
  *
  *  \par Error Conditions
@@ -399,7 +399,7 @@
  *       - No ATS is active
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -421,7 +421,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_CONT_CMD_DEB_EID will be sent
  *
  *  \par Error Conditions
@@ -430,7 +430,7 @@
  *       - Invalid State specified
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -450,7 +450,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -460,7 +460,7 @@
  *       - Append table contents too large to fit in ATS free space
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - Error specific event message
  *
  *  \par Criticality
@@ -522,7 +522,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - #SC_STARTRTSGRP_CMD_INF_EID event will indicate the number of RTS
  *         in the group that were actually STARTED by the command.
  *
@@ -536,7 +536,7 @@
  *         whether any RTS in the group is actually STARTED by the command.
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_STARTRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
@@ -562,7 +562,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_STOPRTSGRP_CMD_INF_EID event will indicate the number of RTS
  *         in the group that were actually STOPPED by the command
  *
@@ -576,7 +576,7 @@
  *         whether any RTS in the group is actually STOPPED by the command.
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_STOPRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
@@ -600,7 +600,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_DISRTSGRP_CMD_INF_EID event will indicate the number of RTS
  *         in the group that were changed from ENABLED to DISABLED by the command
  *
@@ -614,7 +614,7 @@
  *         whether the group contained an RTS that was not already DISABLED.
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_DISRTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *
@@ -638,7 +638,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #SC_HkTlm_t.CmdCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
  *       - The #SC_ENARTSGRP_CMD_INF_EID event will indicate success and display the
  *         number of RTS that were changed from DISABLED to ENABLED by the command.
  *
@@ -652,7 +652,7 @@
  *         whether the group contained an RTS that was not already ENABLED.
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #SC_HkTlm_t.CmdErrCtr will increment
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
  *       - The #SC_LEN_ERR_EID event will indicate invalid command packet length.
  *       - The #SC_ENARTSGRP_CMD_ERR_EID event will indicate invalid group definition.
  *

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -148,7 +148,7 @@ CFE_Status_t SC_AppInit(void)
     SC_OperData.NumCmdsSec = 0;
 
     /* Continue ATS execution if ATS command checksum fails */
-    SC_OperData.HkPacket.ContinueAtsOnFailureFlag = SC_CONT_ON_FAILURE_START;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_CONT_ON_FAILURE_START;
 
     /* Make sure nothing is running */
     SC_AppData.NextProcNumber      = SC_NONE;

--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -52,7 +52,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
     uint16 AtsId;    /* ATS ID */
     uint16 AtsIndex; /* ATS array index */
 
-    AtsId = ((SC_StartAtsCmd_t *)BufPtr)->AtsId;
+    AtsId = ((SC_StartAtsCmd_t *)BufPtr)->Payload.AtsId;
 
     /* validate ATS ID */
     if ((AtsId > 0) && (AtsId <= SC_NUMBER_OF_ATS))
@@ -73,7 +73,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
                     /* increment the command request counter */
-                    SC_OperData.HkPacket.CmdCtr++;
+                    SC_OperData.HkPacket.Payload.CmdCtr++;
 
                     CFE_EVS_SendEvent(SC_STARTATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                                       "ATS %c Execution Started", (AtsIndex ? 'B' : 'A'));
@@ -83,7 +83,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                     /* event message was sent from SC_BeginAts */
                     /* increment the command request error counter */
                     /* SC_OperData.AtsCtrlBlckAddr->AtpState is updated in SC_KillAts */
-                    SC_OperData.HkPacket.CmdErrCtr++;
+                    SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
                 } /* end if */
             }
@@ -94,7 +94,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                                   "Start ATS Rejected: ATS %c Not Loaded", (AtsIndex ? 'B' : 'A'));
 
                 /* increment the command request error counter */
-                SC_OperData.HkPacket.CmdErrCtr++;
+                SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
             } /* end if */
         }
@@ -104,7 +104,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(SC_STARTATS_CMD_NOT_IDLE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Start ATS Rejected: ATP is not Idle");
             /* increment the command request error counter */
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         } /* end if */
     }
@@ -115,7 +115,7 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                           "Start ATS %d Rejected: Invalid ATS ID", AtsId);
 
         /* increment the command request error counter */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
     } /* end if */
 }
@@ -163,7 +163,7 @@ void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr)
     /* clear the global switch pend flag */
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
 
-    SC_OperData.HkPacket.CmdCtr++;
+    SC_OperData.HkPacket.Payload.CmdCtr++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -308,7 +308,7 @@ void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
                 SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
 
                 /* update the command counter */
-                SC_OperData.HkPacket.CmdCtr++;
+                SC_OperData.HkPacket.Payload.CmdCtr++;
 
                 CFE_EVS_SendEvent(SC_SWITCH_ATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "Switch ATS is Pending");
             }
@@ -319,7 +319,7 @@ void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
                               "Switch ATS Failure: Destination ATS Not Loaded");
 
             /* update command error counter */
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
             SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
 
@@ -332,7 +332,7 @@ void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
                           "Switch ATS Rejected: ATP is idle");
 
         /* update the command error counter */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
 
@@ -445,7 +445,7 @@ bool SC_InlineSwitch(void)
             /*
              **  Update the command counter and return code
              */
-            SC_OperData.HkPacket.CmdCtr++;
+            SC_OperData.HkPacket.Payload.CmdCtr++;
             ReturnCode = true;
         }
         else
@@ -454,7 +454,7 @@ bool SC_InlineSwitch(void)
             /*
              ** update the command error counter
              */
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
             ReturnCode = false;
 
         } /* end if */
@@ -466,7 +466,7 @@ bool SC_InlineSwitch(void)
         /*
          ** update the ATS error counter
          */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
         ReturnCode = false;
 
     } /* end if */
@@ -497,7 +497,7 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 
     if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING)
     {
-        JumpTime = ((SC_JumpAtsCmd_t *)BufPtr)->NewTime;
+        JumpTime = ((SC_JumpAtsCmd_t *)BufPtr)->Payload.NewTime;
         AtsIndex = SC_ATS_NUM_TO_INDEX(SC_OperData.AtsCtrlBlckAddr->AtsNumber);
 
         /*
@@ -555,7 +555,7 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(SC_JUMPATS_CMD_STOPPED_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Jump Cmd: All ATS commands were skipped, ATS stopped");
 
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
             /* stop the ats */
             SC_KillAts();
@@ -574,7 +574,7 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
                 */
             SC_AppData.NextCmdTime[SC_ATP] = ListCmdTime;
 
-            SC_OperData.HkPacket.CmdCtr++;
+            SC_OperData.HkPacket.Payload.CmdCtr++;
 
             /* print out the date in a readable format */
             NewTime.Seconds    = ListCmdTime;
@@ -599,7 +599,7 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(SC_JUMPATS_CMD_NOT_ACT_ERR_EID, CFE_EVS_EventType_ERROR,
                           "ATS Jump Failed: No active ATS");
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
     } /* end if */
 }
@@ -613,20 +613,20 @@ void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     uint16 State;
 
-    State = ((SC_SetContinueAtsOnFailureCmd_t *)BufPtr)->ContinueState;
+    State = ((SC_SetContinueAtsOnFailureCmd_t *)BufPtr)->Payload.ContinueState;
 
     if (State != SC_CONTINUE_TRUE && State != SC_CONTINUE_FALSE)
     {
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_CONT_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Continue ATS On Failure command  failed, invalid state: %d", State);
     }
     else
     {
-        SC_OperData.HkPacket.ContinueAtsOnFailureFlag = State;
+        SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = State;
 
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_CONT_CMD_DEB_EID, CFE_EVS_EventType_DEBUG,
                           "Continue-ATS-On-Failure command, State: %d", State);
@@ -643,32 +643,32 @@ void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
     SC_AppendAtsCmd_t *AppendCmd = (SC_AppendAtsCmd_t *)BufPtr;
     uint16             AtsIndex; /* index (not ID) of target ATS */
 
-    if ((AppendCmd->AtsId == 0) || (AppendCmd->AtsId > SC_NUMBER_OF_ATS))
+    if ((AppendCmd->Payload.AtsId == 0) || (AppendCmd->Payload.AtsId > SC_NUMBER_OF_ATS))
     {
         /* invalid target ATS selection */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_ARG_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Append ATS error: invalid ATS ID = %d", AppendCmd->AtsId);
+                          "Append ATS error: invalid ATS ID = %d", AppendCmd->Payload.AtsId);
 
         return;
     }
 
     /* create base zero array index from base one ID value */
-    AtsIndex = SC_ATS_ID_TO_INDEX(AppendCmd->AtsId);
+    AtsIndex = SC_ATS_ID_TO_INDEX(AppendCmd->Payload.AtsId);
 
     if (SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands == 0)
     {
         /* target ATS table is empty */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_TGT_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Append ATS %c error: ATS table is empty", 'A' + AtsIndex);
     }
-    else if (SC_OperData.HkPacket.AppendEntryCount == 0)
+    else if (SC_OperData.HkPacket.Payload.AppendEntryCount == 0)
     {
         /* append table is empty */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_SRC_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Append ATS %c error: Append table is empty", 'A' + AtsIndex);
@@ -676,7 +676,7 @@ void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
     else if ((SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize + SC_AppData.AppendWordCount) > SC_ATS_BUFF_SIZE32)
     {
         /* not enough room in ATS buffer for Append table data */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_FIT_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Append ATS %c error: ATS size = %d, Append size = %d, ATS buffer = %d", 'A' + AtsIndex,
@@ -686,16 +686,16 @@ void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
     else
     {
         /* store ATS selection from most recent ATS Append command */
-        SC_OperData.HkPacket.AppendCmdArg = AppendCmd->AtsId;
+        SC_OperData.HkPacket.Payload.AppendCmdArg = AppendCmd->Payload.AtsId;
 
         /* copy append data and re-calc timing data */
         SC_ProcessAppend(AtsIndex);
 
         /* increment command success counter */
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Append ATS %c command: %d ATS entries appended", 'A' + AtsIndex,
-                          SC_OperData.HkPacket.AppendEntryCount);
+                          SC_OperData.HkPacket.Payload.AppendEntryCount);
     }
 }

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -137,15 +137,15 @@ void SC_ProcessAtpCmd(void)
                              ** this command
                              */
                             SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_EXECUTED;
-                            SC_OperData.HkPacket.AtsCmdCtr++;
+                            SC_OperData.HkPacket.Payload.AtsCmdCtr++;
                         }
                         else
                         { /* the switch failed for some reason */
 
                             SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_DISTRIB;
-                            SC_OperData.HkPacket.AtsCmdErrCtr++;
-                            SC_OperData.HkPacket.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
-                            SC_OperData.HkPacket.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+                            SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
+                            SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+                            SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                         } /* end if */
                     }
@@ -157,14 +157,14 @@ void SC_ProcessAtpCmd(void)
                         {
                             /* The command sent OK */
                             SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_EXECUTED;
-                            SC_OperData.HkPacket.AtsCmdCtr++;
+                            SC_OperData.HkPacket.Payload.AtsCmdCtr++;
                         }
                         else
                         { /* the command had Software Bus problems */
                             SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_DISTRIB;
-                            SC_OperData.HkPacket.AtsCmdErrCtr++;
-                            SC_OperData.HkPacket.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
-                            SC_OperData.HkPacket.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+                            SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
+                            SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+                            SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                             CFE_EVS_SendEvent(SC_ATS_DIST_ERR_EID, CFE_EVS_EventType_ERROR,
                                               "ATS Command Distribution Failed, Cmd Number: %d, SB returned: 0x%08X",
@@ -185,18 +185,18 @@ void SC_ProcessAtpCmd(void)
                     /*
                      ** Increment the ATS error counter
                      */
-                    SC_OperData.HkPacket.AtsCmdErrCtr++;
+                    SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
 
                     /*
                      ** Update the last ATS error information structure
                      */
-                    SC_OperData.HkPacket.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
-                    SC_OperData.HkPacket.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+                    SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+                    SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                     /* update the command status index table */
                     SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_CHECKSUM;
 
-                    if (SC_OperData.HkPacket.ContinueAtsOnFailureFlag == false)
+                    if (SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false)
                     {
                         /* Mark this ATS for abortion */
                         AbortATS = true;
@@ -215,13 +215,13 @@ void SC_ProcessAtpCmd(void)
                 /*
                  ** Increment the ATS error counter
                  */
-                SC_OperData.HkPacket.AtsCmdErrCtr++;
+                SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
 
                 /*
                  ** Update the last ATS error information structure
                  */
-                SC_OperData.HkPacket.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
-                SC_OperData.HkPacket.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+                SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+                SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                 /* update the command status index table */
                 SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_SKIPPED;
@@ -241,13 +241,13 @@ void SC_ProcessAtpCmd(void)
             /*
              ** Increment the ATS error counter
              */
-            SC_OperData.HkPacket.AtsCmdErrCtr++;
+            SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
 
             /*
              ** Update the last ATS error information structure
              */
-            SC_OperData.HkPacket.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
-            SC_OperData.HkPacket.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+            SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+            SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
             /* Do Not Mark this ATS for abortion. The command could be marked as EXECUTED
                if we alerady jumped back in time */
@@ -341,7 +341,7 @@ void SC_ProcessRtpCommand(void)
             if (Result == CFE_SUCCESS)
             {
                 /* the command was sent OK */
-                SC_OperData.HkPacket.RtsCmdCtr++;
+                SC_OperData.HkPacket.Payload.RtsCmdCtr++;
                 SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr++;
 
                 /*
@@ -359,10 +359,10 @@ void SC_ProcessRtpCommand(void)
                                   "RTS %03d Command Distribution Failed: RTS Stopped. SB returned 0x%08X",
                                   (int)SC_OperData.RtsCtrlBlckAddr->RtsNumber, (unsigned int)Result);
 
-                SC_OperData.HkPacket.RtsCmdErrCtr++;
+                SC_OperData.HkPacket.Payload.RtsCmdErrCtr++;
                 SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr++;
-                SC_OperData.HkPacket.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-                SC_OperData.HkPacket.LastRtsErrCmd = CmdOffset;
+                SC_OperData.HkPacket.Payload.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
+                SC_OperData.HkPacket.Payload.LastRtsErrCmd = CmdOffset;
 
                 /*
                  ** Stop the RTS from executing
@@ -383,10 +383,10 @@ void SC_ProcessRtpCommand(void)
             /*
             ** Update the RTS command error counter and last RTS error info
             */
-            SC_OperData.HkPacket.RtsCmdErrCtr++;
+            SC_OperData.HkPacket.Payload.RtsCmdErrCtr++;
             SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr++;
-            SC_OperData.HkPacket.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-            SC_OperData.HkPacket.LastRtsErrCmd = CmdOffset;
+            SC_OperData.HkPacket.Payload.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
+            SC_OperData.HkPacket.Payload.LastRtsErrCmd = CmdOffset;
 
             /*
              ** Stop the RTS from executing
@@ -408,10 +408,10 @@ void SC_SendHkPacket(void)
     /*
      ** fill in the free bytes in each ATS
      */
-    SC_OperData.HkPacket.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSA)] =
+    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSA)] =
         (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
         (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_ATSA)].AtsSize * SC_BYTES_IN_WORD);
-    SC_OperData.HkPacket.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSB)] =
+    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSB)] =
         (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
         (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_ATSB)].AtsSize * SC_BYTES_IN_WORD);
 
@@ -421,21 +421,21 @@ void SC_SendHkPacket(void)
      **
      */
 
-    SC_OperData.HkPacket.AtsNumber = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+    SC_OperData.HkPacket.Payload.AtsNumber = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
 
-    SC_OperData.HkPacket.AtpState       = SC_OperData.AtsCtrlBlckAddr->AtpState;
-    SC_OperData.HkPacket.AtpCmdNumber   = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
-    SC_OperData.HkPacket.SwitchPendFlag = SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag;
+    SC_OperData.HkPacket.Payload.AtpState       = SC_OperData.AtsCtrlBlckAddr->AtpState;
+    SC_OperData.HkPacket.Payload.AtpCmdNumber   = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
+    SC_OperData.HkPacket.Payload.SwitchPendFlag = SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag;
 
-    SC_OperData.HkPacket.NextAtsTime = SC_AppData.NextCmdTime[SC_ATP];
+    SC_OperData.HkPacket.Payload.NextAtsTime = SC_AppData.NextCmdTime[SC_ATP];
 
     /*
      ** Fill out the RTP control block information
      */
 
-    SC_OperData.HkPacket.NumRtsActive = SC_OperData.RtsCtrlBlckAddr->NumRtsActive;
-    SC_OperData.HkPacket.RtsNumber    = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-    SC_OperData.HkPacket.NextRtsTime  = SC_AppData.NextCmdTime[SC_RTP];
+    SC_OperData.HkPacket.Payload.NumRtsActive = SC_OperData.RtsCtrlBlckAddr->NumRtsActive;
+    SC_OperData.HkPacket.Payload.RtsNumber    = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
+    SC_OperData.HkPacket.Payload.NextRtsTime  = SC_AppData.NextCmdTime[SC_RTP];
 
     /*
      ** Fill out the RTS status bit mask
@@ -443,8 +443,8 @@ void SC_SendHkPacket(void)
      */
     for (i = 0; i < (SC_NUMBER_OF_RTS + (SC_NUMBER_OF_RTS_IN_UINT16 - 1)) / SC_NUMBER_OF_RTS_IN_UINT16; i++)
     {
-        SC_OperData.HkPacket.RtsExecutingStatus[i] = 0;
-        SC_OperData.HkPacket.RtsDisabledStatus[i]  = 0;
+        SC_OperData.HkPacket.Payload.RtsExecutingStatus[i] = 0;
+        SC_OperData.HkPacket.Payload.RtsDisabledStatus[i]  = 0;
 
     } /* end for */
 
@@ -452,12 +452,12 @@ void SC_SendHkPacket(void)
     {
         if (SC_OperData.RtsInfoTblAddr[i].DisabledFlag == true)
         {
-            SC_OperData.HkPacket.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
+            SC_OperData.HkPacket.Payload.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
                 (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
         }
         if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_EXECUTING)
         {
-            SC_OperData.HkPacket.RtsExecutingStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
+            SC_OperData.HkPacket.Payload.RtsExecutingStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
                 (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
         }
     } /* end for */
@@ -477,14 +477,14 @@ void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     CFE_EVS_SendEvent(SC_RESET_DEB_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
 
-    SC_OperData.HkPacket.CmdCtr          = 0;
-    SC_OperData.HkPacket.CmdErrCtr       = 0;
-    SC_OperData.HkPacket.AtsCmdCtr       = 0;
-    SC_OperData.HkPacket.AtsCmdErrCtr    = 0;
-    SC_OperData.HkPacket.RtsCmdCtr       = 0;
-    SC_OperData.HkPacket.RtsCmdErrCtr    = 0;
-    SC_OperData.HkPacket.RtsActiveCtr    = 0;
-    SC_OperData.HkPacket.RtsActiveErrCtr = 0;
+    SC_OperData.HkPacket.Payload.CmdCtr          = 0;
+    SC_OperData.HkPacket.Payload.CmdErrCtr       = 0;
+    SC_OperData.HkPacket.Payload.AtsCmdCtr       = 0;
+    SC_OperData.HkPacket.Payload.AtsCmdErrCtr    = 0;
+    SC_OperData.HkPacket.Payload.RtsCmdCtr       = 0;
+    SC_OperData.HkPacket.Payload.RtsCmdErrCtr    = 0;
+    SC_OperData.HkPacket.Payload.RtsActiveCtr    = 0;
+    SC_OperData.HkPacket.Payload.RtsActiveErrCtr = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -494,7 +494,7 @@ void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    SC_OperData.HkPacket.CmdCtr++;
+    SC_OperData.HkPacket.Payload.CmdCtr++;
     CFE_EVS_SendEvent(SC_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. Version %d.%d.%d.%d",
                       SC_MAJOR_VERSION, SC_MINOR_VERSION, SC_REVISION, SC_MISSION_REV);
 }
@@ -601,7 +601,7 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(SC_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID));
 
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
             break;
     } /* end switch */
 }
@@ -657,7 +657,7 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             }
             else
             {
-                SC_OperData.HkPacket.RtsActiveErrCtr++;
+                SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
             }
             break;
 
@@ -752,7 +752,7 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(SC_INVLD_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid Command Code: MID =  0x%08lX CC =  %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
             break;
     } /* end switch */
 }

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -580,14 +580,14 @@ void SC_UpdateAppend(void)
     }
 
     /* Results will also be reported in HK */
-    SC_OperData.HkPacket.AppendLoadCount++;
-    SC_OperData.HkPacket.AppendEntryCount = EntryCount;
-    SC_OperData.HkPacket.AppendByteCount  = EntryIndex * SC_BYTES_IN_ATS_APPEND_ENTRY;
+    SC_OperData.HkPacket.Payload.AppendLoadCount++;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = EntryCount;
+    SC_OperData.HkPacket.Payload.AppendByteCount  = EntryIndex * SC_BYTES_IN_ATS_APPEND_ENTRY;
     SC_AppData.AppendWordCount            = EntryIndex;
 
     CFE_EVS_SendEvent(SC_UPDATE_APPEND_EID, CFE_EVS_EventType_INFORMATION,
                       "Update Append ATS Table: load count = %d, command count = %d, byte count = %d",
-                      SC_OperData.HkPacket.AppendLoadCount, (int)EntryCount, (int)EntryIndex * SC_BYTES_IN_WORD);
+                      SC_OperData.HkPacket.Payload.AppendLoadCount, (int)EntryCount, (int)EntryIndex * SC_BYTES_IN_WORD);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -623,7 +623,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
     SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize += SC_AppData.AppendWordCount;
 
     /* add appended entries to ats process tables */
-    for (i = 0; i < SC_OperData.HkPacket.AppendEntryCount; i++)
+    for (i = 0; i < SC_OperData.HkPacket.Payload.AppendEntryCount; i++)
     {
         /* get pointer to next appended entry */
         EntryPtr = (SC_AtsEntry_t *)&SC_OperData.AtsTblAddr[AtsIndex][EntryIndex];

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -59,7 +59,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     /*
      ** Check start RTS parameters
      */
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->RtsId;
+    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
 
     if ((RtsId > 0) && (RtsId <= SC_NUMBER_OF_RTS))
     {
@@ -104,10 +104,10 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                         ** starting of the RTS
                         */
                     SC_OperData.RtsCtrlBlckAddr->NumRtsActive++;
-                    SC_OperData.HkPacket.RtsActiveCtr++;
-                    SC_OperData.HkPacket.CmdCtr++;
+                    SC_OperData.HkPacket.Payload.RtsActiveCtr++;
+                    SC_OperData.HkPacket.Payload.CmdCtr++;
 
-                    if (((SC_RtsCmd_t *)CmdPacket)->RtsId <= SC_LAST_RTS_WITH_EVENTS)
+                    if (((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId <= SC_LAST_RTS_WITH_EVENTS)
                     {
                         CFE_EVS_SendEvent(SC_RTS_START_INF_EID, CFE_EVS_EventType_INFORMATION,
                                           "RTS Number %03d Started", RtsId);
@@ -125,8 +125,8 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                         "Start RTS %03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %d",
                         RtsId, (int)CmdLength);
 
-                    SC_OperData.HkPacket.CmdErrCtr++;
-                    SC_OperData.HkPacket.RtsActiveErrCtr++;
+                    SC_OperData.HkPacket.Payload.CmdErrCtr++;
+                    SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
                 } /* end if - check command number */
             }
@@ -135,11 +135,11 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 
                 CFE_EVS_SendEvent(SC_STARTRTS_CMD_NOT_LDED_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Start RTS %03d Rejected: RTS Not Loaded or In Use, Status: %d",
-                                  ((SC_RtsCmd_t *)CmdPacket)->RtsId,
+                                  ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId,
                                   SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus);
 
-                SC_OperData.HkPacket.CmdErrCtr++;
-                SC_OperData.HkPacket.RtsActiveErrCtr++;
+                SC_OperData.HkPacket.Payload.CmdErrCtr++;
+                SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
             } /* end if */
         }
@@ -148,8 +148,8 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
             CFE_EVS_SendEvent(SC_STARTRTS_CMD_DISABLED_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Start RTS %03d Rejected: RTS Disabled", RtsId);
 
-            SC_OperData.HkPacket.CmdErrCtr++;
-            SC_OperData.HkPacket.RtsActiveErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
         } /* end if */
     }
     else
@@ -157,8 +157,8 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
         CFE_EVS_SendEvent(SC_STARTRTS_CMD_INVALID_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Start RTS %03d Rejected: Invalid RTS ID", RtsId);
 
-        SC_OperData.HkPacket.CmdErrCtr++;
-        SC_OperData.HkPacket.RtsActiveErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
     }
 }
 
@@ -177,8 +177,8 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  StartCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->LastRtsId;
+    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
+    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -208,7 +208,7 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 
                     /* maintain counters associated with starting RTS */
                     SC_OperData.RtsCtrlBlckAddr->NumRtsActive++;
-                    SC_OperData.HkPacket.RtsActiveCtr++;
+                    SC_OperData.HkPacket.Payload.RtsActiveCtr++;
 
                     /* count the RTS that were actually started */
                     StartCount++;
@@ -220,7 +220,7 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
                         "Start RTS group error: rejected RTS ID %03d, RTS Not Loaded or In Use, Status: %d",
                         SC_RTS_INDEX_TO_ID(RtsIndex), SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus);
 
-                    SC_OperData.HkPacket.RtsActiveErrCtr++;
+                    SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
                 } /* end if */
             }
@@ -230,7 +230,7 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
                                   "Start RTS group error: rejected RTS ID %03d, RTS Disabled",
                                   SC_RTS_INDEX_TO_ID(RtsIndex));
 
-                SC_OperData.HkPacket.RtsActiveErrCtr++;
+                SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
             } /* end if */
         }
@@ -238,13 +238,13 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         /* success */
         CFE_EVS_SendEvent(SC_STARTRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Start RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)StartCount);
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_STARTRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Start RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
 #endif
@@ -259,7 +259,7 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->RtsId;
+    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
 
     /* check the command parameter */
     if (RtsId <= SC_NUMBER_OF_RTS)
@@ -270,7 +270,7 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
         /* stop the rts by calling a generic routine */
         SC_KillRts(RtsIndex);
 
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_STOPRTS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "RTS %03d Aborted", RtsId);
     }
@@ -281,7 +281,7 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
         CFE_EVS_SendEvent(SC_STOPRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Stop RTS %03d rejected: Invalid RTS ID",
                           RtsId);
 
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
     } /* end if */
 }
@@ -301,8 +301,8 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  StopCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->LastRtsId;
+    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
+    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -322,17 +322,17 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             }
         }
 
-        /* success */
-        CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Stop RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)StopCount);
-        SC_OperData.HkPacket.CmdCtr++;
-    }
-    else
-    { /* error */
-        CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Stop RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
-        SC_OperData.HkPacket.CmdErrCtr++;
-    }
+            /* success */
+            CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Stop RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)StopCount);
+            SC_OperData.HkPacket.Payload.CmdCtr++;
+        }
+        else
+        { /* error */
+            CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Stop RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
+        }
 }
 #endif
 
@@ -346,7 +346,7 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->RtsId;
+    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
 
     /* make sure tha specified rts is valid */
     if (RtsId <= SC_NUMBER_OF_RTS)
@@ -358,7 +358,7 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
         SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
 
         /* update the command status */
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_DISABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Disabled RTS %03d", RtsId);
     }
@@ -368,7 +368,7 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                           "Disable RTS %03d Rejected: Invalid RTS ID", RtsId);
 
         /* update the command error status */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
     } /* end if */
 }
 
@@ -387,8 +387,8 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  DisableCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->LastRtsId;
+    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
+    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -412,13 +412,13 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         CFE_EVS_SendEvent(SC_DISRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Disable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId,
                           (int)DisableCount);
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_DISRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Disable RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
 #endif
@@ -433,7 +433,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->RtsId;
+    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
 
     /* make sure the specified rts is valid */
     if ((RtsId > 0) && (RtsId <= SC_NUMBER_OF_RTS))
@@ -445,7 +445,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
         SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
 
         /* update the command status */
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_ENABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Enabled RTS %03d", RtsId);
     }
@@ -455,7 +455,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                           "Enable RTS %03d Rejected: Invalid RTS ID", RtsId);
 
         /* update the command error status */
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
     } /* end if */
 }
@@ -475,8 +475,8 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  EnableCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->LastRtsId;
+    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
+    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -500,13 +500,13 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         CFE_EVS_SendEvent(SC_ENARTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Enable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId,
                           (int)EnableCount);
-        SC_OperData.HkPacket.CmdCtr++;
+        SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_ENARTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Enable RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
-        SC_OperData.HkPacket.CmdErrCtr++;
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
 #endif
@@ -569,7 +569,7 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Get the RTS ID to start.
          */
-        CmdPkt.RtsId = RtsNumber;
+        CmdPkt.Payload.RtsId = RtsNumber;
 
         /*
          ** Now send the command back to SC

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -238,10 +238,10 @@ void SC_GetNextRtsCommand(void)
                              ** Having a command that runs off of the end of the buffer
                              ** is an error condition, so record it
                              */
-                            SC_OperData.HkPacket.RtsCmdErrCtr++;
+                            SC_OperData.HkPacket.Payload.RtsCmdErrCtr++;
                             SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr++;
-                            SC_OperData.HkPacket.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-                            SC_OperData.HkPacket.LastRtsErrCmd = CmdOffset;
+                            SC_OperData.HkPacket.Payload.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
+                            SC_OperData.HkPacket.Payload.LastRtsErrCmd = CmdOffset;
 
                             /*
                              ** Stop the RTS from executing
@@ -257,10 +257,10 @@ void SC_GetNextRtsCommand(void)
                     { /* the command length is too large */
 
                         /* update the error information */
-                        SC_OperData.HkPacket.RtsCmdErrCtr++;
+                        SC_OperData.HkPacket.Payload.RtsCmdErrCtr++;
                         SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr++;
-                        SC_OperData.HkPacket.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-                        SC_OperData.HkPacket.LastRtsErrCmd = CmdOffset;
+                        SC_OperData.HkPacket.Payload.LastRtsErrSeq = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
+                        SC_OperData.HkPacket.Payload.LastRtsErrCmd = CmdOffset;
 
                         /* Stop the RTS from executing */
                         SC_KillRts(RtsIndex);

--- a/fsw/src/sc_utils.c
+++ b/fsw/src/sc_utils.c
@@ -169,7 +169,7 @@ bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
         Result = false;
         if (CFE_SB_MsgIdToValue(MessageID) == SC_CMD_MID)
         {
-            SC_OperData.HkPacket.CmdErrCtr++;
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
         }
     }
     return (Result);

--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -101,19 +101,19 @@ SC_AtsTable1_t SC_Ats1 = {
     .ats.cmd1.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .ats.hdr2.CmdNumber  = 2,
-    .ats.hdr2.TimeTag_MS = SC_CMD2_TIME >> 16,
-    .ats.hdr2.TimeTag_LS = SC_CMD2_TIME & 0xFFFF,
-    .ats.cmd2.CmdHeader =
+    .ats.hdr2.CmdNumber     = 2,
+    .ats.hdr2.TimeTag_MS    = SC_CMD2_TIME >> 16,
+    .ats.hdr2.TimeTag_LS    = SC_CMD2_TIME & 0xFFFF,
+    .ats.cmd2.CmdHeader     =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS1_CKSUM),
-    .ats.cmd2.RtsId = 1,
+    .ats.cmd2.Payload.RtsId = 1,
 
     /* 3 */
-    .ats.hdr3.CmdNumber  = 3,
-    .ats.hdr3.TimeTag_MS = SC_CMD3_TIME >> 16,
-    .ats.hdr3.TimeTag_LS = SC_CMD3_TIME & 0xFFFF,
-    .ats.cmd3.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
-    .ats.cmd3.RtsId      = 1,
+    .ats.hdr3.CmdNumber     = 3,
+    .ats.hdr3.TimeTag_MS    = SC_CMD3_TIME >> 16,
+    .ats.hdr3.TimeTag_LS    = SC_CMD3_TIME & 0xFFFF,
+    .ats.cmd3.CmdHeader     = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
+    .ats.cmd3.Payload.RtsId = 1,
 
     /* 4 */
     .ats.hdr4.CmdNumber  = 4,

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -82,15 +82,15 @@ SC_RtsTable001_t SC_Rts001 = {
     .rts.cmd1.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .rts.hdr2.TimeTag = 5,
-    .rts.cmd2.CmdHeader =
+    .rts.hdr2.TimeTag       = 5,
+    .rts.cmd2.CmdHeader     =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS2_CKSUM),
-    .rts.cmd2.RtsId = 2,
+    .rts.cmd2.Payload.RtsId = 2,
 
     /* 3 */
-    .rts.hdr3.TimeTag   = 5,
-    .rts.cmd3.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
-    .rts.cmd3.RtsId     = 2};
+    .rts.hdr3.TimeTag       = 5,
+    .rts.cmd3.CmdHeader     = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
+    .rts.cmd3.Payload.RtsId = 2};
 
 /* Macro for table structure */
 CFE_TBL_FILEDEF(SC_Rts001, SC.RTS_TBL001, SC Example RTS_TBL001, sc_rts001.tbl)

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -169,7 +169,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
     Expected_SC_OperData.AtsCmdStatusHandle[0] = 0;
     Expected_SC_OperData.AtsCmdStatusHandle[1] = 0;
 
-    Expected_SC_OperData.HkPacket.ContinueAtsOnFailureFlag = 1;
+    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
 
     UtAssert_MemCmp(&SC_OperData.CmdPipe, &Expected_SC_OperData.CmdPipe, sizeof(Expected_SC_OperData.CmdPipe), "2");
     UtAssert_MemCmp(&SC_OperData.AtsInfoHandle, &Expected_SC_OperData.AtsInfoHandle,
@@ -216,7 +216,7 @@ void SC_AppInit_Test_Nominal(void)
     Expected_SC_AppData.NextCmdTime[SC_RTP] = SC_MAX_TIME;
     Expected_SC_AppData.AutoStartRTS        = RTS_ID_AUTO_PROCESSOR;
 
-    Expected_SC_OperData.HkPacket.ContinueAtsOnFailureFlag = 1;
+    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -71,7 +71,7 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId                    = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
@@ -81,7 +81,7 @@ void SC_StartAtsCmd_Test_NominalA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
@@ -93,7 +93,7 @@ void SC_StartAtsCmd_Test_NominalB(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId                    = 2;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
@@ -103,7 +103,7 @@ void SC_StartAtsCmd_Test_NominalB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
@@ -119,7 +119,7 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
@@ -130,7 +130,7 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ALL_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -144,7 +144,7 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId                    = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
@@ -152,7 +152,7 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_LDED_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -166,7 +166,7 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId                    = 2;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
@@ -174,7 +174,7 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_LDED_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -188,14 +188,14 @@ void SC_StartAtsCmd_Test_InUse(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId           = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_NOT_IDLE_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -209,14 +209,14 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId           = 99;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 99;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_INVLD_ID_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -230,14 +230,14 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.StartAtsCmd.AtsId           = 0;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 0;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTATS_CMD_INVLD_ID_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -257,7 +257,7 @@ void SC_StopAtsCmd_Test_NominalA(void)
     UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -277,7 +277,7 @@ void SC_StopAtsCmd_Test_NominalB(void)
     UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -297,7 +297,7 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
     UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPATS_NO_ATS_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -403,7 +403,7 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == true,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == true");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -425,7 +425,7 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_NOT_LDED_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -446,7 +446,7 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_SWITCH_ATS_CMD_IDLE_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -616,7 +616,7 @@ void SC_InlineSwitch_Test_NominalA(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
 
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -643,7 +643,7 @@ void SC_InlineSwitch_Test_NominalB(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
                   "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
 
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -667,7 +667,7 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
     UtAssert_BOOL_FALSE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -687,7 +687,7 @@ void SC_InlineSwitch_Test_DestinationAtsNotLoaded(void)
     UtAssert_BOOL_FALSE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -731,7 +731,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1, "SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1");
     UtAssert_True(SC_AppData.NextCmdTime[0] == 0, "SC_AppData.NextCmdTime[0] == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, SC_JUMP_ATS_SKIPPED_DBG_EID);
@@ -762,7 +762,7 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_JUMPATS_CMD_STOPPED_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -782,7 +782,7 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
     UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_JUMPATS_CMD_NOT_ACT_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -821,7 +821,7 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1, "SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1");
     UtAssert_True(SC_AppData.NextCmdTime[0] == 0, "SC_AppData.NextCmdTime[0] == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
@@ -835,15 +835,15 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = true;
+    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = true;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.ContinueAtsOnFailureFlag == true,
-                  "SC_OperData.HkPacket.ContinueAtsOnFailureFlag == true");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == true,
+                  "SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == true");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -857,15 +857,15 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = false;
+    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = false;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.ContinueAtsOnFailureFlag == false,
-                  "SC_OperData.HkPacket.ContinueAtsOnFailureFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false,
+                  "SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -879,13 +879,13 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.ContinueState = 99;
+    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = 99;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -904,16 +904,16 @@ void SC_AppendAtsCmd_Test_Nominal(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    UT_CmdBuf.AppendAtsCmd.AtsId                          = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
-    SC_OperData.HkPacket.AppendEntryCount                 = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendCmdArg == 1, "SC_OperData.HkPacket.AppendCmdArg == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendCmdArg == 1, "SC_OperData.HkPacket.Payload.AppendCmdArg == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -927,14 +927,14 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.AtsId          = 99;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId          = 99;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_ARG_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -948,14 +948,14 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.AtsId          = 0;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId          = 0;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_ARG_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -970,15 +970,15 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.AtsId                          = 1;
-    SC_OperData.HkPacket.AppendEntryCount                 = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_TGT_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -993,15 +993,15 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.AtsId                          = 1;
-    SC_OperData.HkPacket.AppendEntryCount                 = 0;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 0;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_SRC_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -1016,8 +1016,8 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.AtsId                          = 1;
-    SC_OperData.HkPacket.AppendEntryCount                 = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize          = SC_ATS_BUFF_SIZE;
     SC_AppData.AppendWordCount                            = SC_ATS_BUFF_SIZE;
@@ -1026,7 +1026,7 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_APPEND_CMD_FIT_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -97,8 +97,8 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.AtsCmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
@@ -144,8 +144,8 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.AtsCmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
@@ -191,13 +191,13 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == 1, "SC_OperData.HkPacket.LastAtsErrSeq == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == 1, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -239,13 +239,13 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -289,13 +289,13 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_DISTRIB,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -323,7 +323,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
-    SC_OperData.HkPacket.ContinueAtsOnFailureFlag = false;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
 
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -340,10 +340,10 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
@@ -373,7 +373,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
-    SC_OperData.HkPacket.ContinueAtsOnFailureFlag = false;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
 
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -390,10 +390,10 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
@@ -423,7 +423,7 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
-    SC_OperData.HkPacket.ContinueAtsOnFailureFlag = true;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = true;
 
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -440,10 +440,10 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
 
@@ -473,10 +473,10 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
 
@@ -507,10 +507,10 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSB");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED");
 
@@ -540,10 +540,10 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.LastAtsErrSeq == SC_ATSA");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 1, "SC_OperData.HkPacket.LastAtsErrCmd == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -572,7 +572,7 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -598,7 +598,7 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -624,7 +624,7 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "SC_OperData.HkPacket.AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -667,7 +667,7 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 1, "SC_OperData.HkPacket.AtsCmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
@@ -693,8 +693,8 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 1, "SC_OperData.HkPacket.RtsCmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 0, "SC_OperData.HkPacket.RtsCmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 0");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdCtr == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 0");
@@ -723,13 +723,13 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 0, "SC_OperData.HkPacket.RtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[0].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrSeq == 1, "SC_OperData.HkPacket.LastRtsErrSeq == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd == 0, "SC_OperData.HkPacket.LastRtsErrCmd == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == 1, "SC_OperData.HkPacket.Payload.LastRtsErrSeq == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd == 0, "SC_OperData.HkPacket.Payload.LastRtsErrCmd == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_DIST_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -753,13 +753,13 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 0, "SC_OperData.HkPacket.RtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[0].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrSeq == 1, "SC_OperData.HkPacket.LastRtsErrSeq == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd == 0, "SC_OperData.HkPacket.LastRtsErrCmd == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == 1, "SC_OperData.HkPacket.Payload.LastRtsErrSeq == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd == 0, "SC_OperData.HkPacket.Payload.LastRtsErrCmd == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_CHKSUM_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -844,22 +844,22 @@ void SC_SendHkPacket_Test(void)
     uint8 i;
     int32 LastRtsHkIndex = 0;
 
-    SC_OperData.HkPacket.CmdErrCtr                = 1;
-    SC_OperData.HkPacket.CmdCtr                   = 2;
-    SC_OperData.HkPacket.RtsActiveErrCtr          = 3;
-    SC_OperData.HkPacket.RtsActiveCtr             = 4;
-    SC_OperData.HkPacket.AtsCmdCtr                = 5;
-    SC_OperData.HkPacket.AtsCmdErrCtr             = 6;
-    SC_OperData.HkPacket.RtsCmdCtr                = 7;
-    SC_OperData.HkPacket.RtsCmdErrCtr             = 8;
-    SC_OperData.HkPacket.LastAtsErrSeq            = 9;
-    SC_OperData.HkPacket.LastAtsErrCmd            = 10;
-    SC_OperData.HkPacket.LastRtsErrSeq            = 11;
-    SC_OperData.HkPacket.LastRtsErrCmd            = 12;
-    SC_OperData.HkPacket.AppendCmdArg             = 13;
-    SC_OperData.HkPacket.AppendEntryCount         = 14;
+    SC_OperData.HkPacket.Payload.CmdErrCtr                = 1;
+    SC_OperData.HkPacket.Payload.CmdCtr                   = 2;
+    SC_OperData.HkPacket.Payload.RtsActiveErrCtr          = 3;
+    SC_OperData.HkPacket.Payload.RtsActiveCtr             = 4;
+    SC_OperData.HkPacket.Payload.AtsCmdCtr                = 5;
+    SC_OperData.HkPacket.Payload.AtsCmdErrCtr             = 6;
+    SC_OperData.HkPacket.Payload.RtsCmdCtr                = 7;
+    SC_OperData.HkPacket.Payload.RtsCmdErrCtr             = 8;
+    SC_OperData.HkPacket.Payload.LastAtsErrSeq            = 9;
+    SC_OperData.HkPacket.Payload.LastAtsErrCmd            = 10;
+    SC_OperData.HkPacket.Payload.LastRtsErrSeq            = 11;
+    SC_OperData.HkPacket.Payload.LastRtsErrCmd            = 12;
+    SC_OperData.HkPacket.Payload.AppendCmdArg             = 13;
+    SC_OperData.HkPacket.Payload.AppendEntryCount         = 14;
     SC_AppData.AppendWordCount                    = 15;
-    SC_OperData.HkPacket.AppendLoadCount          = 16;
+    SC_OperData.HkPacket.Payload.AppendLoadCount          = 16;
     SC_OperData.AtsInfoTblAddr[0].AtsSize         = 0;
     SC_OperData.AtsInfoTblAddr[1].AtsSize         = 0;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber        = 17;
@@ -870,7 +870,7 @@ void SC_SendHkPacket_Test(void)
     SC_AppData.NextCmdTime[1]                     = 0;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive     = 20;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber        = 21;
-    SC_OperData.HkPacket.ContinueAtsOnFailureFlag = 1;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
 
     for (i = 0; i < SC_NUMBER_OF_RTS - 1; i++)
     {
@@ -882,61 +882,61 @@ void SC_SendHkPacket_Test(void)
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].RtsStatus    = 0;
 
     LastRtsHkIndex =
-        sizeof(SC_OperData.HkPacket.RtsExecutingStatus) / sizeof(SC_OperData.HkPacket.RtsExecutingStatus[0]) - 1;
+        sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus) / sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus[0]) - 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_SendHkPacket());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 2, "SC_OperData.HkPacket.CmdCtr == 2");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 3, "SC_OperData.HkPacket.RtsActiveErrCtr == 3");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 4, "SC_OperData.HkPacket.RtsActiveCtr == 4");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 5, "SCSC_OperData.HkPacket.AtsCmdCtr == 5");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 6, "SC_OperData.HkPacket.AtsCmdErrCtr == 6");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 7, "SC_OperData.HkPacket.RtsCmdCtr == 7");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 8, "SC_OperData.HkPacket.RtsCmdErrCtr == 8");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrSeq == 9, "SC_OperData.HkPacket.LastAtsErrSeq == 9");
-    UtAssert_True(SC_OperData.HkPacket.LastAtsErrCmd == 10, "SC_OperData.HkPacket.LastAtsErrCmd == 10");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrSeq == 11, "SC_OperData.HkPacket.LastRtsErrSeq == 11");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd == 12, "SC_OperData.HkPacket.LastRtsErrCmd == 12");
-    UtAssert_True(SC_OperData.HkPacket.AppendCmdArg == 13, "SC_OperData.HkPacket.AppendCmdArg == 13");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 14, "SC_OperData.HkPacket.AppendEntryCount == 14");
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 16, "SC_OperData.HkPacket.AppendLoadCount == 16");
-    UtAssert_True(SC_OperData.HkPacket.AtpFreeBytes[0] ==
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 2, "SC_OperData.HkPacket.Payload.CmdCtr == 2");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 4, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 4");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 5, "SCSC_OperData.HkPacket.Payload.AtsCmdCtr == 5");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 6, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 6");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 7, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 7");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 8, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 8");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == 9, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == 9");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 10, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 10");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == 11, "SC_OperData.HkPacket.Payload.LastRtsErrSeq == 11");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd == 12, "SC_OperData.HkPacket.Payload.LastRtsErrCmd == 12");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendCmdArg == 13, "SC_OperData.HkPacket.Payload.AppendCmdArg == 13");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 14, "SC_OperData.HkPacket.Payload.AppendEntryCount == 14");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 16, "SC_OperData.HkPacket.Payload.AppendLoadCount == 16");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtpFreeBytes[0] ==
                       (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
                           (SC_OperData.AtsInfoTblAddr[0].AtsSize * SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.AtpFreeBytes[0] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
-    UtAssert_True(SC_OperData.HkPacket.AtpFreeBytes[1] ==
+                  "SC_OperData.HkPacket.Payload.AtpFreeBytes[0] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtpFreeBytes[1] ==
                       (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
                           (SC_OperData.AtsInfoTblAddr[1].AtsSize * SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.AtpFreeBytes[1] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
-    UtAssert_True(SC_OperData.HkPacket.AtsNumber == 17, "SC_OperData.HkPacket.AtsNumber == 17");
-    UtAssert_True(SC_OperData.HkPacket.AtpState == 18, "SC_OperData.HkPacket.AtpState == 18");
-    UtAssert_True(SC_OperData.HkPacket.AtpCmdNumber == 19, "SC_OperData.HkPacket.AtpCmdNumber == 19");
-    UtAssert_True(SC_OperData.HkPacket.SwitchPendFlag == 0, "SC_OperData.HkPacket.SwitchPendFlag == 0");
-    UtAssert_True(SC_OperData.HkPacket.NextAtsTime == 0, "SC_OperData.HkPacket.NextAtsTime == 0");
-    UtAssert_True(SC_OperData.HkPacket.NumRtsActive == 20, "SC_OperData.HkPacket.NumRtsActive == 20");
-    UtAssert_True(SC_OperData.HkPacket.RtsNumber == 21, "SC_OperData.HkPacket.RtsNumber == 21");
-    UtAssert_True(SC_OperData.HkPacket.NextRtsTime == 0, "SC_OperData.HkPacket.NextRtsTime == 0");
-    UtAssert_True(SC_OperData.HkPacket.ContinueAtsOnFailureFlag == 1,
-                  "SC_OperData.HkPacket.ContinueAtsOnFailureFlag == 1");
+                  "SC_OperData.HkPacket.Payload.AtpFreeBytes[1] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsNumber == 17, "SC_OperData.HkPacket.Payload.AtsNumber == 17");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtpState == 18, "SC_OperData.HkPacket.Payload.AtpState == 18");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtpCmdNumber == 19, "SC_OperData.HkPacket.Payload.AtpCmdNumber == 19");
+    UtAssert_True(SC_OperData.HkPacket.Payload.SwitchPendFlag == 0, "SC_OperData.HkPacket.Payload.SwitchPendFlag == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.NextAtsTime == 0, "SC_OperData.HkPacket.Payload.NextAtsTime == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.NumRtsActive == 20, "SC_OperData.HkPacket.Payload.NumRtsActive == 20");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsNumber == 21, "SC_OperData.HkPacket.Payload.RtsNumber == 21");
+    UtAssert_True(SC_OperData.HkPacket.Payload.NextRtsTime == 0, "SC_OperData.HkPacket.Payload.NextRtsTime == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == 1,
+                  "SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == 1");
 
     /* Check first element */
-    UtAssert_True(SC_OperData.HkPacket.RtsExecutingStatus[0] == 65535,
-                  "SC_OperData.HkPacket.RtsExecutingStatus[0] == 65535");
-    UtAssert_True(SC_OperData.HkPacket.RtsDisabledStatus[0] == 65535,
-                  "SC_OperData.HkPacket.RtsDisabledStatus[0] == 65535");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsExecutingStatus[0] == 65535,
+                  "SC_OperData.HkPacket.Payload.RtsExecutingStatus[0] == 65535");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsDisabledStatus[0] == 65535,
+                  "SC_OperData.HkPacket.Payload.RtsDisabledStatus[0] == 65535");
 
     /* Check middle element */
-    UtAssert_True(SC_OperData.HkPacket.RtsExecutingStatus[2] == 65535,
-                  "SC_OperData.HkPacket.RtsExecutingStatus[2] == 65535");
-    UtAssert_True(SC_OperData.HkPacket.RtsDisabledStatus[2] == 65535,
-                  "SC_OperData.HkPacket.RtsDisabledStatus[2] == 65535");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsExecutingStatus[2] == 65535,
+                  "SC_OperData.HkPacket.Payload.RtsExecutingStatus[2] == 65535");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsDisabledStatus[2] == 65535,
+                  "SC_OperData.HkPacket.Payload.RtsDisabledStatus[2] == 65535");
 
     /* Check last element */
-    UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsExecutingStatus[LastRtsHkIndex], 32767);
-    UtAssert_INT32_EQ(SC_OperData.HkPacket.RtsDisabledStatus[LastRtsHkIndex], 32767);
+    UtAssert_INT32_EQ(SC_OperData.HkPacket.Payload.RtsExecutingStatus[LastRtsHkIndex], 32767);
+    UtAssert_INT32_EQ(SC_OperData.HkPacket.Payload.RtsDisabledStatus[LastRtsHkIndex], 32767);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -960,8 +960,8 @@ void SC_ProcessRequest_Test_CmdMID(void)
     UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_NOOP_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -1214,8 +1214,8 @@ void SC_ProcessRequest_Test_MIDError(void)
     UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_MID_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -1243,8 +1243,8 @@ void SC_ProcessCommand_Test_NoOp(void)
     UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_NOOP_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -1270,8 +1270,8 @@ void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
     UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1298,14 +1298,14 @@ void SC_ProcessCommand_Test_ResetCounters(void)
     UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "CmdErrCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdCtr == 0, "AtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.AtsCmdErrCtr == 0, "AtsCmdErrCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdCtr == 0, "RtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 0, "RtsCmdErrCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 0, "RtsActiveCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 0, "RtsActiveErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "AtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "AtsCmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "RtsCmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 0, "RtsCmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "RtsActiveCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 0, "RtsActiveErrCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RESET_DEB_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -1351,7 +1351,7 @@ void SC_ProcessCommand_Test_StartAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
 
-    UT_CmdBuf.StartAtsCmd.AtsId = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
@@ -2269,8 +2269,8 @@ void SC_ProcessCommand_Test_StartAtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2288,8 +2288,8 @@ void SC_ProcessCommand_Test_StopAtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2307,8 +2307,8 @@ void SC_ProcessCommand_Test_StartRtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2326,8 +2326,8 @@ void SC_ProcessCommand_Test_StopRtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2345,8 +2345,8 @@ void SC_ProcessCommand_Test_DisableRtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2364,8 +2364,8 @@ void SC_ProcessCommand_Test_EnableRtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2383,8 +2383,8 @@ void SC_ProcessCommand_Test_GroundSwitchInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2402,8 +2402,8 @@ void SC_ProcessCommand_Test_JumpAtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2421,8 +2421,8 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailureInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2440,8 +2440,8 @@ void SC_ProcessCommand_Test_AppendAtsInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2459,8 +2459,8 @@ void SC_ProcessCommand_Test_TableManageInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2478,8 +2478,8 @@ void SC_ProcessCommand_Test_StartRtsGrpInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2497,8 +2497,8 @@ void SC_ProcessCommand_Test_StopRtsGrpInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2516,8 +2516,8 @@ void SC_ProcessCommand_Test_DisableRtsGrpInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2535,8 +2535,8 @@ void SC_ProcessCommand_Test_EnableRtsGrpInvalidCmdLength(void)
     SC_ProcessCommand(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -2561,8 +2561,8 @@ void SC_ProcessCommand_Test_InvalidCmdError(void)
     UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INVLD_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -905,8 +905,8 @@ void SC_UpdateAppend_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 1, "SC_OperData.HkPacket.AppendEntryCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 1, "SC_OperData.HkPacket.Payload.AppendEntryCount == 1");
     UtAssert_True(SC_AppData.AppendWordCount == 15, "SC_AppData.AppendWordCount == 15");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -938,8 +938,8 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 30, "SC_OperData.HkPacket.AppendEntryCount == 30");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 30, "SC_OperData.HkPacket.Payload.AppendEntryCount == 30");
     UtAssert_True(SC_AppData.AppendWordCount == 1980, "SC_AppData.AppendWordCount == 1980");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -964,8 +964,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 0, "SC_OperData.HkPacket.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -990,8 +990,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 0, "SC_OperData.HkPacket.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1029,8 +1029,8 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 31, "SC_OperData.HkPacket.AppendEntryCount == 31");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 31, "SC_OperData.HkPacket.Payload.AppendEntryCount == 31");
     UtAssert_True(SC_AppData.AppendWordCount == 2000, "SC_AppData.AppendWordCount == 2000");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1057,8 +1057,8 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 0, "SC_OperData.HkPacket.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1085,8 +1085,8 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 0, "SC_OperData.HkPacket.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1106,7 +1106,7 @@ void SC_ProcessAppend_Test(void)
     Entry->CmdNumber = 1;
 
     SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
@@ -1151,7 +1151,7 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
     Entry->CmdNumber = 1;
 
     SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
@@ -1193,7 +1193,7 @@ void SC_ProcessAppend_Test_NotExecuting(void)
     Entry->CmdNumber = 1;
 
     SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 
@@ -1234,7 +1234,7 @@ void SC_ProcessAppend_Test_AtsNumber(void)
     Entry->CmdNumber = 1;
 
     SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.AppendEntryCount = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
 

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -53,7 +53,7 @@ void SC_StartRtsCmd_Test_Nominal(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -78,8 +78,8 @@ void SC_StartRtsCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1, "SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1");
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 1, "SC_OperData.HkPacket.RtsActiveCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_START_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -91,9 +91,9 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     uint8                RtsIndex;
     size_t               MsgSize;
 
-    UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS;
 
-    RtsIndex = UT_CmdBuf.RtsCmd.RtsId - 1;
+    RtsIndex = UT_CmdBuf.RtsCmd.Payload.RtsId - 1;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -122,11 +122,11 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1, "SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1");
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 1, "SC_OperData.HkPacket.RtsActiveCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     /* Handle if SC_LAST_RTS_WITH_EVENTS is the same as SC_NUM_OF_RTS */
-    if (UT_CmdBuf.RtsCmd.RtsId > SC_LAST_RTS_WITH_EVENTS)
+    if (UT_CmdBuf.RtsCmd.Payload.RtsId > SC_LAST_RTS_WITH_EVENTS)
     {
         UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DBG_EID);
     }
@@ -147,7 +147,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -175,7 +175,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -202,7 +202,7 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_IDLE;
@@ -223,7 +223,7 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -238,7 +238,7 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 
 void SC_StartRtsCmd_Test_InvalidRtsId(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
@@ -250,7 +250,7 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
 
 void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = 0;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
@@ -267,8 +267,8 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -284,8 +284,8 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1, "SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 1");
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 1");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 1, "SC_OperData.HkPacket.RtsActiveCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -293,14 +293,14 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
 
 void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -308,14 +308,14 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -323,14 +323,14 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -338,14 +338,14 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -353,14 +353,14 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -368,14 +368,14 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -391,8 +391,8 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -406,9 +406,9 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 0");
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 0, "SC_OperData.HkPacket.RtsActiveCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.RtsActiveErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_DISABLED_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTRTSGRP_CMD_INF_EID);
@@ -424,8 +424,8 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -441,9 +441,9 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr == 0");
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveCtr == 0, "SC_OperData.HkPacket.RtsActiveCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.RtsActiveErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTRTSGRP_CMD_INF_EID);
@@ -452,13 +452,13 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 
 void SC_StopRtsCmd_Test_Nominal(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -466,13 +466,13 @@ void SC_StopRtsCmd_Test_Nominal(void)
 
 void SC_StopRtsCmd_Test_InvalidRts(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTS_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -480,14 +480,14 @@ void SC_StopRtsCmd_Test_InvalidRts(void)
 
 void SC_StopRtsGrpCmd_Test_Nominal(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -495,14 +495,14 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
 
 void SC_StopRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -514,14 +514,14 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -529,14 +529,14 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -544,14 +544,14 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -559,14 +559,14 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -574,14 +574,14 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -589,14 +589,14 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STOPRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -606,7 +606,7 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
@@ -614,7 +614,7 @@ void SC_DisableRtsCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISABLE_RTS_DEB_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -622,13 +622,13 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 
 void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTS_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -638,8 +638,8 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -647,7 +647,7 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -655,14 +655,14 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 
 void SC_DisableRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -670,14 +670,14 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -685,14 +685,14 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -700,14 +700,14 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -715,14 +715,14 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -730,14 +730,14 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -749,8 +749,8 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -758,7 +758,7 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISRTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -768,7 +768,7 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
 
-    UT_CmdBuf.RtsCmd.RtsId = 1;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
@@ -776,7 +776,7 @@ void SC_EnableRtsCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENABLE_RTS_DEB_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -784,13 +784,13 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 
 void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTS_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -798,13 +798,13 @@ void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 
 void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 {
-    UT_CmdBuf.RtsCmd.RtsId = 0;
+    UT_CmdBuf.RtsCmd.Payload.RtsId = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTS_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -814,8 +814,8 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
 
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -823,7 +823,7 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -831,14 +831,14 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 
 void SC_EnableRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -846,14 +846,14 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -861,14 +861,14 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -876,14 +876,14 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -891,14 +891,14 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 0;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -906,14 +906,14 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId  = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -925,8 +925,8 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[1].DisabledFlag        = true;
-    UT_CmdBuf.RtsGrpCmd.FirstRtsId                    = 1;
-    UT_CmdBuf.RtsGrpCmd.LastRtsId                     = 2;
+    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId                    = 1;
+    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId                     = 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
@@ -934,7 +934,7 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false");
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 1, "SC_OperData.HkPacket.CmdCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENARTSGRP_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -346,15 +346,15 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
     UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber,
-                  "SC_OperData.HkPacket.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber,
+                  "SC_OperData.HkPacket.Payload.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber");
 
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd ==
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd ==
                       SC_OperData.RtsInfoTblAddr[0].NextCommandPtr +
                           ((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.LastRtsErrCmd == SC_OperData.RtsInfoTblAddr[0].NextCommandPtr + "
+                  "SC_OperData.HkPacket.Payload.LastRtsErrCmd == SC_OperData.RtsInfoTblAddr[0].NextCommandPtr + "
                   "((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD)");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_LNGTH_ERR_EID);
@@ -395,15 +395,15 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
     UtAssert_VOIDCALL(SC_GetNextRtsCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.RtsCmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1, "SC_OperData.RtsInfoTblAddr[0].CmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber,
-                  "SC_OperData.HkPacket.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber,
+                  "SC_OperData.HkPacket.Payload.LastRtsErrSeq == SC_OperData.RtsCtrlBlckAddr->RtsNumber");
 
-    UtAssert_True(SC_OperData.HkPacket.LastRtsErrCmd ==
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd ==
                       SC_OperData.RtsInfoTblAddr[0].NextCommandPtr +
                           ((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.LastRtsErrCmd == SC_OperData.RtsInfoTblAddr[0].NextCommandPtr + "
+                  "SC_OperData.HkPacket.Payload.LastRtsErrCmd == SC_OperData.RtsInfoTblAddr[0].NextCommandPtr + "
                   "((SC_PACKET_MIN_SIZE + SC_RTS_HEADER_SIZE + 3) / SC_BYTES_IN_WORD)");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_CMD_LNGTH_ERR_EID);

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -97,7 +97,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, sizeof(CmdPacket)));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 0, "SC_OperData.HkPacket.CmdErrCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -117,8 +117,8 @@ void SC_VerifyCmdLength_Test_LenError(void)
     UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.CmdErrCtr == 1, "SC_OperData.HkPacket.CmdErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -139,7 +139,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
     UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.CmdCtr == 0, "SC_OperData.HkPacket.CmdCtr == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #99, adds Payload substructure to all command and telemetry messages

**Testing performed**
unit testing

**Expected behavior changes**
 no impact to behavior

**System(s) tested on**
 - OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA
