### PR TITLE
Fix #101, add header update platform config

### DIFF
--- a/fsw/inc/sc_platform_cfg.h
+++ b/fsw/inc/sc_platform_cfg.h
@@ -31,6 +31,38 @@
  */
 
 /**
+ * \brief Whether to update headers on commands when sending on software bus
+ *
+ *  \par Description:
+ *
+ *       This controls whether to update the command header on the outgoing messages
+ *       produced by the SC app.
+ *
+ *        - If the messages in the ATS/RTS tables are expected to be completely
+ *          initialized, including the sequence number and any required checksum
+ *          field, then this should be configured as "false" such that these fields
+ *          will not be modified during message transmission.  The UpdateHeader
+ *          parameter to CFE_SB_TransmitMsg() will be passed as false, and the message
+ *          will be broadcast on the software bus verbatim.  This replicates historical
+ *          behavior of SC.
+ *
+ *        - If the messages in the ATS/RTS tables need a real-time header update as
+ *          part of the sending process, this should be configured as "true".  Any
+ *          checksum embedded within the ATS/RTS will be ignored.  The UpdateHeader
+ *          parameter to CFE_SB_TransmitMsg() will be passed as true, such that the
+ *          command will be sequenced and timestamped with current values.  A correct
+ *          checksum will be computed based on the updated header values, and the
+ *          resulting message is broadcast on the software bus.
+ *
+ * \sa
+ *      CFE_SB_TransmitMsg() - UpdateHeader parameter
+ *
+ *  \par Limits:
+ *       Must be true or false
+ */
+#define SC_PLATFORM_ENABLE_HEADER_UPDATE false
+
+/**
  * \brief  Max number of commands per second
  *
  *  \par Description:

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -150,6 +150,8 @@ CFE_Status_t SC_AppInit(void)
     /* Continue ATS execution if ATS command checksum fails */
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_CONT_ON_FAILURE_START;
 
+    SC_AppData.EnableHeaderUpdate = SC_PLATFORM_ENABLE_HEADER_UPDATE;
+
     /* Make sure nothing is running */
     SC_AppData.NextProcNumber      = SC_NONE;
     SC_AppData.NextCmdTime[SC_ATP] = SC_MAX_TIME;

--- a/fsw/src/sc_app.h
+++ b/fsw/src/sc_app.h
@@ -280,10 +280,11 @@ typedef struct
          These offsets correspond to the addresses of ATS commands located in the ATS table.
          The index used is the ATS command index with values from 0 to SC_MAX_ATS_CMDS-1 */
 
+    bool EnableHeaderUpdate; /**< \brief whether to update headers in outgoing messages */
+
     uint8           NextProcNumber;  /**< \brief the next command processor number */
     SC_AbsTimeTag_t NextCmdTime[2];  /**< \brief The overall next command time  0 - ATP, 1- RTP*/
     SC_AbsTimeTag_t CurrentTime;     /**< \brief this is the current time for SC */
-    uint16          Unused;          /**< \brief Unused */
     uint16          AutoStartRTS;    /**< \brief Start selected auto-exec RTS after init */
     uint16          AppendWordCount; /**< \brief Size of cmd entries in current Append ATS table */
 } SC_AppData_t;

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -64,7 +64,6 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -78,13 +77,11 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
+    SC_AppData.EnableHeaderUpdate = true;
+
     /* Set return value for CFE_TIME_Compare to make SC_CompareAbsTime return false, to satisfy first if-statement of
      * SC_ProcessAtpCmd, and for all other calls to CFE_TIME_Compare called from subfunctions reached by this test */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), Ut_CFE_TIME_CompareHookAlessthanB, NULL);
-
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -111,7 +108,6 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -125,13 +121,11 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
+    SC_AppData.EnableHeaderUpdate = true;
+
     /* Set return value for CFE_TIME_Compare to make SC_CompareAbsTime return false, to satisfy first if-statement of
      * SC_ProcessAtpCmd, and for all other calls to CFE_TIME_Compare called from subfunctions reached by this test */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), Ut_CFE_TIME_CompareHookAlessthanB, NULL);
-
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -158,7 +152,6 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -177,8 +170,7 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), Ut_CFE_TIME_CompareHookAlessthanB, NULL);
 
     /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+    SC_AppData.EnableHeaderUpdate = true;
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -207,7 +199,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -223,9 +214,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+    SC_AppData.EnableHeaderUpdate = true;
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -257,7 +246,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t    FcnCode   = SC_NOOP_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
@@ -273,9 +261,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+    SC_AppData.EnableHeaderUpdate = true;
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -324,6 +310,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
+
+    SC_AppData.EnableHeaderUpdate = false;
 
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -375,6 +363,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
 
+    SC_AppData.EnableHeaderUpdate = false;
+
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
@@ -424,6 +414,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = true;
+
+    SC_AppData.EnableHeaderUpdate = false;
 
     /* Set to return false in order to generate error message SC_ATS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -634,7 +626,6 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     SC_AtsEntryHeader_t *Entry;
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t    FcnCode   = SC_SWITCH_ATS_CC;
-    bool                 ChecksumValid;
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
@@ -648,13 +639,11 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
+    SC_AppData.EnableHeaderUpdate = true;
+
     /* Set return value for CFE_TIME_Compare to make SC_CompareAbsTime return false, to satisfy first if-statement of
      * SC_ProcessAtpCmd, and for all other calls to CFE_TIME_Compare called from subfunctions reached by this test */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), Ut_CFE_TIME_CompareHookAlessthanB, NULL);
-
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Set these two functions to return these values in order to statisfy the if-statement from which they are both
      * called */
@@ -677,17 +666,13 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
 {
-    bool ChecksumValid;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
     SC_AppData.NextProcNumber                                                        = SC_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
 
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+    SC_AppData.EnableHeaderUpdate = true;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -704,20 +689,16 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
-    bool ChecksumValid;
-
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
     SC_AppData.NextProcNumber                                                        = SC_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
 
-    /* Set to return true in order to satisfy the if-statement from which the function is called */
-    ChecksumValid = true;
+    SC_AppData.EnableHeaderUpdate = true;
 
     /* Set to return -1 in order to generate error message SC_RTS_DIST_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -744,6 +725,8 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     SC_AppData.NextProcNumber                                                        = SC_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+
+    SC_AppData.EnableHeaderUpdate = false;
 
     /* Set to return false in order to generate error message SC_RTS_CHKSUM_ERR_EID */
     ChecksumValid = false;
@@ -1170,18 +1153,15 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
 
 void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
 {
-    bool ChecksumValid;
-
     /**
      **  Test case: SC_1HZ_WAKEUP_MID with a pending RTP command that needs to execute immediately, but too many
      *commands are being sent at once
      **/
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    SC_AppData.EnableHeaderUpdate = true;
 
-    ChecksumValid = true;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This adds a new SC platform configuration option:

SC_PLATFORM_SC_ENABLE_HEADER_UPDATE

This option is translated to the UpdateHeader option of CFE_SB_TransmitMsg()

- If set to "false" (default) this replicates current behavior.  In this mode, commands within ATS/RTS tables are expected to be fully initialized, including all headers and checksums, and the message will be passed verbatim to the software bus.

- If set to "true" (new option) this permits the commands to be timestamped and sequenced according to the real time system state. The headers will be updated as part of sending the message on the bus, and a valid checksum will be computed in real time.

Fixes #101

**Testing performed**
Run unit tests
Build SC with configuration each way

**Expected behavior changes**
If configured as true, then headers on outgoing commands are updated in real time as the messages are sent to SB.

**System(s) tested on**
Debian

**Additional context**
This is critical if the message use a strong checksum, as there is currently no way to automatically compute this when generating the table.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
