### PR TITLE
Fix #105, remove SC_ENABLE_GROUP_COMMANDS option

### DIFF
--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -1084,7 +1084,6 @@
  */
 #define SC_TABLE_MANAGE_APPEND_ERR_EID 114
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /**
  * \brief SC Start RTS Group Command Event ID
  *
@@ -1184,7 +1183,6 @@
  *  - Last RTS ID must be greater than or equal to First RTS ID
  */
 #define SC_ENARTSGRP_CMD_ERR_EID 122
-#endif
 
 /**
  * \brief SC Jump Command Entry Event ID

--- a/fsw/inc/sc_msg.h
+++ b/fsw/inc/sc_msg.h
@@ -162,7 +162,6 @@ typedef struct
     uint16 Padding; /**< \brief Structure Padding */
 } SC_AppendAtsCmd_Payload_t;
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /**
  *  \brief RTS Group Command Payload
  */
@@ -171,7 +170,6 @@ typedef struct
     uint16 FirstRtsId; /**< \brief ID of the first RTS to act on, 1 through #SC_NUMBER_OF_RTS */
     uint16 LastRtsId;  /**< \brief ID of the last RTS to act on, 1 through #SC_NUMBER_OF_RTS */
 } SC_RtsGrpCmd_Payload_t;
-#endif
 
 /**
  *  \brief No Arguments Command
@@ -239,7 +237,6 @@ typedef struct
     SC_AppendAtsCmd_Payload_t Payload;
 } SC_AppendAtsCmd_t;
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /**
  *  \brief RTS Group Command
  *
@@ -250,7 +247,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
 } SC_RtsGrpCmd_t;
-#endif
 
 /**\}*/
 

--- a/fsw/inc/sc_msgdefs.h
+++ b/fsw/inc/sc_msgdefs.h
@@ -505,7 +505,6 @@
  */
 #define SC_MANAGE_TABLE_CC 12
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /**
  * \brief START a group of RTS
  *
@@ -662,8 +661,6 @@
  *  \sa #SC_DISABLE_RTS_GRP_CC
  */
 #define SC_ENABLE_RTS_GRP_CC 16
-
-#endif
 
 /**\}*/
 

--- a/fsw/inc/sc_platform_cfg.h
+++ b/fsw/inc/sc_platform_cfg.h
@@ -343,23 +343,6 @@
 #define SC_TIME_TO_USE SC_USE_CFE_TIME
 
 /**
- * \brief Define inclusion state for RTS group commands
- *
- *  \par Description:
- *       This parameter specifies the inclusion state for the
- *       following RTS group commands: Start RTS group, Stop
- *       RTS group, Enable RTS group and Disable RTS group.
- *       RTS group commands affect a range of consecutive RTS
- *       numbers.  When set to true, this definition results
- *       in the inclusion of the group command handlers into
- *       the SC source code.
- *
- *  \par Limits:
- *       Must be defined as true or false
- */
-#define SC_ENABLE_GROUP_COMMANDS true
-
-/**
  * \brief Mission specific version number for SC application
  *
  *  \par Description:

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -717,8 +717,6 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             }
             break;
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-
         case SC_START_RTS_GRP_CC:
             if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_RtsGrpCmd_t)))
             {
@@ -746,7 +744,6 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
                  SC_EnableRtsGrpCmd(BufPtr);
             }
             break;
-#endif
 
         default:
             CFE_EVS_SendEvent(SC_INVLD_CMD_ERR_EID, CFE_EVS_EventType_ERROR,

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -162,7 +162,6 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     }
 }
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Start a group of RTS                                            */
@@ -247,7 +246,6 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -286,7 +284,6 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     } /* end if */
 }
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Stop a group of RTS                                             */
@@ -334,7 +331,6 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             SC_OperData.HkPacket.Payload.CmdErrCtr++;
         }
 }
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -372,7 +368,6 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     } /* end if */
 }
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Disable a group of RTS                                          */
@@ -421,7 +416,6 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -460,7 +454,6 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     } /* end if */
 }
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Enable a group of RTS                                           */
@@ -509,7 +502,6 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/sc_rtsrq.h
+++ b/fsw/src/sc_rtsrq.h
@@ -43,8 +43,6 @@
  */
 void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-
 /**
  * \brief Start a group of RTS Command
  *
@@ -59,7 +57,6 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \sa #SC_START_RTS_GRP_CC
  */
 void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
-#endif
 
 /**
  * \brief  Stop an RTS from executing Command
@@ -76,8 +73,6 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  */
 void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-
 /**
  * \brief  Stop a group of RTS from executing Command
  *
@@ -92,7 +87,6 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \sa #SC_STOP_RTS_CC
  */
 void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
-#endif
 
 /**
  * \brief Disable an RTS Command
@@ -109,8 +103,6 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  */
 void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-
 /**
  * \brief Disable a group of RTS Command
  *
@@ -125,7 +117,6 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \sa #SC_DISABLE_RTS_CC
  */
 void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
-#endif
 
 /**
  * \brief Enable an RTS Command
@@ -142,8 +133,6 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  */
 void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
 
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-
 /**
  * \brief Enable a group of RTS Command
  *
@@ -158,7 +147,6 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \sa #SC_ENABLE_RTS_GRP_CC
  */
 void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
-#endif
 
 /**
  * \brief Stops an RTS & clears out data

--- a/fsw/src/sc_verify.h
+++ b/fsw/src/sc_verify.h
@@ -203,12 +203,6 @@
 #endif
 #endif
 
-#ifndef SC_ENABLE_GROUP_COMMANDS
-#error SC_ENABLE_GROUP_COMMANDS must be defined!
-#elif ((SC_ENABLE_GROUP_COMMANDS != true) && (SC_ENABLE_GROUP_COMMANDS != false))
-#error SC_ENABLE_GROUP_COMMANDS must be either true or false!
-#endif
-
 #ifndef SC_MISSION_REV
 #error SC_MISSION_REV must be defined!
 #elif (SC_MISSION_REV < 0)

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -64,10 +64,8 @@ typedef union
     SC_JumpAtsCmd_t                 JumpAtsCmd;
     SC_SetContinueAtsOnFailureCmd_t SetContinueAtsOnFailureCmd;
     SC_AppendAtsCmd_t               AppendAtsCmd;
-#if (SC_ENABLE_GROUP_COMMANDS == true)
-    SC_RtsGrpCmd_t RtsGrpCmd;
-#endif
-    CFE_TBL_NotifyCmd_t NotifyCmd; /* SC subscribes to the table notify command */
+    SC_RtsGrpCmd_t                  RtsGrpCmd;
+    CFE_TBL_NotifyCmd_t             NotifyCmd; /* SC subscribes to the table notify command */
 } UT_CmdBuf_t;
 
 extern UT_CmdBuf_t UT_CmdBuf;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This was always set true and the software has not been validated with the option set to false.  Turning this off only removed a few small functions and the complexity (and violation of coding standard) does not justify it as an option.

Fixes #105

**Testing performed**
Build and run all tests

**Expected behavior changes**
None, assuming code was always built with this option set `true` anyway

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
