### PR TITLE
Fix #109, use generated stubs in unit tests

### DIFF
--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 add_cfe_coverage_stubs("sc_internal"
   utilities/sc_test_utils.c
+  stubs/sc_global_stubs.c
   stubs/sc_loads_stubs.c
   stubs/sc_cmds_stubs.c
   stubs/sc_atsrq_stubs.c

--- a/unit-test/stubs/sc_app_stubs.c
+++ b/unit-test/stubs/sc_app_stubs.c
@@ -17,56 +17,142 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_app header
  */
 
 #include "sc_app.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-SC_AppData_t  SC_AppData;
-SC_OperData_t SC_OperData;
-
-void SC_AppMain(void)
-{
-    UT_DEFAULT_IMPL(SC_AppMain);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_AppInit()
+ * ----------------------------------------------------
+ */
 CFE_Status_t SC_AppInit(void)
 {
-    return UT_DEFAULT_IMPL(SC_AppMain);
+    UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_AppInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_AppInit, CFE_Status_t);
 }
 
-CFE_Status_t SC_InitTables(void)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_AppMain()
+ * ----------------------------------------------------
+ */
+void SC_AppMain(void)
 {
-    return UT_DEFAULT_IMPL(SC_InitTables);
+
+    UT_GenStub_Execute(SC_AppMain, Basic, NULL);
 }
 
-CFE_Status_t SC_RegisterAllTables(void)
-{
-    return UT_DEFAULT_IMPL(SC_RegisterAllTables);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetDumpTablePointers()
+ * ----------------------------------------------------
+ */
 CFE_Status_t SC_GetDumpTablePointers(void)
 {
-    return UT_DEFAULT_IMPL(SC_GetDumpTablePointers);
+    UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_GetDumpTablePointers, CFE_Status_t);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetLoadTablePointers()
+ * ----------------------------------------------------
+ */
 CFE_Status_t SC_GetLoadTablePointers(void)
 {
-    return UT_DEFAULT_IMPL(SC_GetLoadTablePointers);
+    UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_GetLoadTablePointers, CFE_Status_t);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_InitTables()
+ * ----------------------------------------------------
+ */
+CFE_Status_t SC_InitTables(void)
+{
+    UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_InitTables, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_InitTables, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_LoadDefaultTables()
+ * ----------------------------------------------------
+ */
 void SC_LoadDefaultTables(void)
 {
-    UT_DEFAULT_IMPL(SC_LoadDefaultTables);
+
+    UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_RegisterAllTables()
+ * ----------------------------------------------------
+ */
+CFE_Status_t SC_RegisterAllTables(void)
+{
+    UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_RegisterAllTables, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_RegisterDumpOnlyTables()
+ * ----------------------------------------------------
+ */
+CFE_Status_t SC_RegisterDumpOnlyTables(void)
+{
+    UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_RegisterDumpOnlyTables, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_RegisterLoadableTables()
+ * ----------------------------------------------------
+ */
+CFE_Status_t SC_RegisterLoadableTables(void)
+{
+    UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
+
+    UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_RegisterLoadableTables, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_RegisterManageCmds()
+ * ----------------------------------------------------
+ */
 void SC_RegisterManageCmds(void)
 {
-    UT_DEFAULT_IMPL(SC_RegisterManageCmds);
+
+    UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
 }

--- a/unit-test/stubs/sc_atsrq_stubs.c
+++ b/unit-test/stubs/sc_atsrq_stubs.c
@@ -17,71 +17,136 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_atsrq header
  */
 
 #include "sc_atsrq.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-bool SC_BeginAts(uint16 AtsId, uint16 TimeOffset)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_AppendAtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_BeginAts), AtsId);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_BeginAts), TimeOffset);
-    return UT_DEFAULT_IMPL(SC_BeginAts);
+    UT_GenStub_AddParam(SC_AppendAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
 }
 
-void SC_StartAtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_BeginAts()
+ * ----------------------------------------------------
+ */
+bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_StartAtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StartAtsCmd);
+    UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
+
+    UT_GenStub_AddParam(SC_BeginAts, uint16, AtsIndex);
+    UT_GenStub_AddParam(SC_BeginAts, uint16, TimeOffset);
+
+    UT_GenStub_Execute(SC_BeginAts, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_BeginAts, bool);
 }
 
-void SC_StopAtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ContinueAtsOnFailureCmd()
+ * ----------------------------------------------------
+ */
+void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_StopAtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StopAtsCmd);
+    UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
 }
 
-void SC_KillAts(void)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GroundSwitchCmd()
+ * ----------------------------------------------------
+ */
+void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_DEFAULT_IMPL(SC_KillAts);
+    UT_GenStub_AddParam(SC_GroundSwitchCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_GroundSwitchCmd, Basic, NULL);
 }
 
-void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_GroundSwitchCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_GroundSwitchCmd);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_InlineSwitch()
+ * ----------------------------------------------------
+ */
 bool SC_InlineSwitch(void)
 {
-    return UT_DEFAULT_IMPL(SC_InlineSwitch);
+    UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
+
+    UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_InlineSwitch, bool);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_JumpAtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_JumpAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_KillAts()
+ * ----------------------------------------------------
+ */
+void SC_KillAts(void)
+{
+
+    UT_GenStub_Execute(SC_KillAts, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ServiceSwitchPend()
+ * ----------------------------------------------------
+ */
 void SC_ServiceSwitchPend(void)
 {
-    UT_DEFAULT_IMPL(SC_ServiceSwitchPend);
+
+    UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
 }
 
-void SC_JumpAtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StartAtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_JumpAtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_JumpAtsCmd);
+    UT_GenStub_AddParam(SC_StartAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
 }
 
-void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StopAtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_ContinueAtsOnFailureCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_ContinueAtsOnFailureCmd);
-}
+    UT_GenStub_AddParam(SC_StopAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
 
-void SC_AppendAtsCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_AppendAtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_AppendAtsCmd);
+    UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_cmds_stubs.c
+++ b/unit-test/stubs/sc_cmds_stubs.c
@@ -17,75 +17,141 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_cmds header
  */
 
 #include "sc_cmds.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-void SC_TableManageCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_TableManageCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_TableManageCmd);
-}
-
-void SC_ManageRtsTable(int32 ArrayIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_ManageRtsTable), ArrayIndex);
-    UT_DEFAULT_IMPL(SC_ManageRtsTable);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ManageAtsTable()
+ * ----------------------------------------------------
+ */
 void SC_ManageAtsTable(int32 ArrayIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_ManageAtsTable), ArrayIndex);
-    UT_DEFAULT_IMPL(SC_ManageAtsTable);
+    UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
+
+    UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
 }
 
-void SC_ManageAppendTable(void)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ManageRtsTable()
+ * ----------------------------------------------------
+ */
+void SC_ManageRtsTable(int32 ArrayIndex)
 {
-    UT_DEFAULT_IMPL(SC_ManageAppendTable);
+    UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
+
+    UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
 }
 
-void SC_ProcessRequest(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ManageTable()
+ * ----------------------------------------------------
+ */
+void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_ProcessRequest), CmdPacket);
-    UT_DEFAULT_IMPL(SC_ProcessRequest);
+    UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
+    UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
+
+    UT_GenStub_Execute(SC_ManageTable, Basic, NULL);
 }
 
-void SC_ProcessCommand(const CFE_SB_Buffer_t *CmdPacket)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_NoOpCmd()
+ * ----------------------------------------------------
+ */
+void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_ProcessCommand), CmdPacket);
-    UT_DEFAULT_IMPL(SC_ProcessCommand);
+    UT_GenStub_AddParam(SC_NoOpCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_NoOpCmd, Basic, NULL);
 }
 
-void SC_NoOpCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_NoOpCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_NoOpCmd);
-}
-
-void SC_ResetCountersCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_ResetCountersCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_ResetCountersCmd);
-}
-
-void SC_SendHkPacket(void)
-{
-    UT_DEFAULT_IMPL(SC_SendHkPacket);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessAtpCmd()
+ * ----------------------------------------------------
+ */
 void SC_ProcessAtpCmd(void)
 {
-    UT_DEFAULT_IMPL(SC_ProcessAtpCmd);
+
+    UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessCommand()
+ * ----------------------------------------------------
+ */
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessRequest()
+ * ----------------------------------------------------
+ */
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessRtpCommand()
+ * ----------------------------------------------------
+ */
 void SC_ProcessRtpCommand(void)
 {
-    UT_DEFAULT_IMPL(SC_ProcessRtpCommand);
+
+    UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ResetCountersCmd()
+ * ----------------------------------------------------
+ */
+void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_ResetCountersCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_SendHkPacket()
+ * ----------------------------------------------------
+ */
+void SC_SendHkPacket(void)
+{
+
+    UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_TableManageCmd()
+ * ----------------------------------------------------
+ */
+void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_TableManageCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_TableManageCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_global_stubs.c
+++ b/unit-test/stubs/sc_global_stubs.c
@@ -1,0 +1,28 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "sc_app.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+SC_AppData_t  SC_AppData;
+SC_OperData_t SC_OperData;

--- a/unit-test/stubs/sc_loads_stubs.c
+++ b/unit-test/stubs/sc_loads_stubs.c
@@ -17,95 +17,193 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_loads header
  */
 
 #include "sc_loads.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-bool SC_ParseRts(uint32 Buffer[])
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_ParseRts), Buffer);
-    return UT_DEFAULT_IMPL(SC_ParseRts);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_BuildTimeIndexTable()
+ * ----------------------------------------------------
+ */
 void SC_BuildTimeIndexTable(uint16 AtsIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_BuildTimeIndexTable), AtsIndex);
-    UT_DEFAULT_IMPL(SC_BuildTimeIndexTable);
+    UT_GenStub_AddParam(SC_BuildTimeIndexTable, uint16, AtsIndex);
+
+    UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
 }
 
-void SC_Insert(uint16 AtsIndex, uint32 NewCmdIndex, uint32 ListLength)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_Insert), AtsIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_Insert), NewCmdIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_Insert), ListLength);
-    UT_DEFAULT_IMPL(SC_Insert);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_InitAtsTables()
+ * ----------------------------------------------------
+ */
 void SC_InitAtsTables(uint16 AtsIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_InitAtsTables), AtsIndex);
-    UT_DEFAULT_IMPL(SC_InitAtsTables);
+    UT_GenStub_AddParam(SC_InitAtsTables, uint16, AtsIndex);
+
+    UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
 }
 
-int32 SC_VerifyAtsTable(uint32 *Buffer, int32 BufferWords)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_Insert()
+ * ----------------------------------------------------
+ */
+void SC_Insert(uint16 AtsIndex, uint32 NewCmdIndex, uint32 ListLength)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_VerifyAtsTable), Buffer);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_VerifyAtsTable), BufferWords);
-    return UT_DEFAULT_IMPL(SC_VerifyAtsTable);
+    UT_GenStub_AddParam(SC_Insert, uint16, AtsIndex);
+    UT_GenStub_AddParam(SC_Insert, uint32, NewCmdIndex);
+    UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
+
+    UT_GenStub_Execute(SC_Insert, Basic, NULL);
 }
 
-int32 SC_VerifyAtsEntry(uint32 *Buffer, int32 EntryIndex, int32 BufferWords)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_VerifyAtsEntry), Buffer);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_VerifyAtsEntry), EntryIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_VerifyAtsEntry), BufferWords);
-    return UT_DEFAULT_IMPL(SC_VerifyAtsEntry);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_LoadAts()
+ * ----------------------------------------------------
+ */
 void SC_LoadAts(uint16 AtsIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_LoadAts), AtsIndex);
-    UT_DEFAULT_IMPL(SC_LoadAts);
+    UT_GenStub_AddParam(SC_LoadAts, uint16, AtsIndex);
+
+    UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
 }
 
-int32 SC_ValidateAts(void *TableData)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_ValidateAts), TableData);
-    return UT_DEFAULT_IMPL(SC_ValidateAts);
-}
-
-int32 SC_ValidateAppend(void *TableData)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_ValidateAppend), TableData);
-    return UT_DEFAULT_IMPL(SC_ValidateAppend);
-}
-
-void SC_UpdateAppend(void)
-{
-    UT_DEFAULT_IMPL(SC_UpdateAppend);
-}
-
-void SC_ProcessAppend(uint16 AtsIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_ProcessAppend), AtsIndex);
-    UT_DEFAULT_IMPL(SC_ProcessAppend);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_LoadRts()
+ * ----------------------------------------------------
+ */
 void SC_LoadRts(uint16 RtsIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_LoadRts), RtsIndex);
-    UT_DEFAULT_IMPL(SC_LoadRts);
+    UT_GenStub_AddParam(SC_LoadRts, uint16, RtsIndex);
+
+    UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ParseRts()
+ * ----------------------------------------------------
+ */
+bool SC_ParseRts(uint32 Buffer32[])
+{
+    UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
+
+    UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ParseRts, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessAppend()
+ * ----------------------------------------------------
+ */
+void SC_ProcessAppend(uint16 AtsIndex)
+{
+    UT_GenStub_AddParam(SC_ProcessAppend, uint16, AtsIndex);
+
+    UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_UpdateAppend()
+ * ----------------------------------------------------
+ */
+void SC_UpdateAppend(void)
+{
+
+    UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ValidateAppend()
+ * ----------------------------------------------------
+ */
+int32 SC_ValidateAppend(void *TableData)
+{
+    UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
+
+    UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
+
+    UT_GenStub_Execute(SC_ValidateAppend, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ValidateAppend, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ValidateAts()
+ * ----------------------------------------------------
+ */
+int32 SC_ValidateAts(void *TableData)
+{
+    UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
+
+    UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
+
+    UT_GenStub_Execute(SC_ValidateAts, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ValidateAts, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ValidateRts()
+ * ----------------------------------------------------
+ */
 int32 SC_ValidateRts(void *TableData)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_ValidateRts), TableData);
-    return UT_DEFAULT_IMPL(SC_ValidateRts);
+    UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
+
+    UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
+
+    UT_GenStub_Execute(SC_ValidateRts, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ValidateRts, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_VerifyAtsEntry()
+ * ----------------------------------------------------
+ */
+int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
+{
+    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
+
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, EntryIndex);
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, BufferWords);
+
+    UT_GenStub_Execute(SC_VerifyAtsEntry, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_VerifyAtsEntry, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_VerifyAtsTable()
+ * ----------------------------------------------------
+ */
+int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords)
+{
+    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
+
+    UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);
+    UT_GenStub_AddParam(SC_VerifyAtsTable, int32, BufferWords);
+
+    UT_GenStub_Execute(SC_VerifyAtsTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_VerifyAtsTable, int32);
 }

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -17,81 +17,131 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_rtsrq header
  */
 
 #include "sc_rtsrq.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_StartRtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StartRtsCmd);
-}
-
-#if (SC_ENABLE_GROUP_COMMANDS == TRUE)
-void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_StartRtsGrpCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StartRtsGrpCmd);
-}
-
-#endif
-void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_StopRtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StopRtsCmd);
-}
-
-#if (SC_ENABLE_GROUP_COMMANDS == TRUE)
-void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_StopRtsGrpCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_StopRtsGrpCmd);
-}
-
-#endif
-void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_DisableRtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_DisableRtsCmd);
-}
-
-#if (SC_ENABLE_GROUP_COMMANDS == TRUE)
-void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_DisableRtsGrpCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_DisableRtsGrpCmd);
-}
-#endif
-
-void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_EnableRtsCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_EnableRtsCmd);
-}
-
-#if (SC_ENABLE_GROUP_COMMANDS == TRUE)
-void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_EnableRtsGrpCmd), CmdPacket);
-    UT_DEFAULT_IMPL(SC_EnableRtsGrpCmd);
-}
-#endif
-
-void SC_KillRts(uint16 RtsIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_KillRts), RtsIndex);
-    UT_DEFAULT_IMPL(SC_KillRts);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_AutoStartRts()
+ * ----------------------------------------------------
+ */
 void SC_AutoStartRts(uint16 RtsNumber)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_AutoStartRts), RtsNumber);
-    UT_DEFAULT_IMPL(SC_AutoStartRts);
+    UT_GenStub_AddParam(SC_AutoStartRts, uint16, RtsNumber);
+
+    UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_DisableRtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_DisableRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_DisableRtsGrpCmd()
+ * ----------------------------------------------------
+ */
+void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_EnableRtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_EnableRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_EnableRtsGrpCmd()
+ * ----------------------------------------------------
+ */
+void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_KillRts()
+ * ----------------------------------------------------
+ */
+void SC_KillRts(uint16 RtsIndex)
+{
+    UT_GenStub_AddParam(SC_KillRts, uint16, RtsIndex);
+
+    UT_GenStub_Execute(SC_KillRts, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StartRtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_StartRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StartRtsGrpCmd()
+ * ----------------------------------------------------
+ */
+void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_StartRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StopRtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_StopRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_StopRtsGrpCmd()
+ * ----------------------------------------------------
+ */
+void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+{
+    UT_GenStub_AddParam(SC_StopRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+
+    UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_state_stubs.c
+++ b/unit-test/stubs/sc_state_stubs.c
@@ -17,33 +17,55 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_state header
  */
 
 #include "sc_state.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-void SC_GetNextRtsTime(void)
-{
-    UT_DEFAULT_IMPL(SC_GetNextRtsTime);
-}
-
-void SC_UpdateNextTime(void)
-{
-    UT_DEFAULT_IMPL(SC_UpdateNextTime);
-}
-
-void SC_GetNextRtsCommand(void)
-{
-    UT_DEFAULT_IMPL(SC_GetNextRtsCommand);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetNextAtsCommand()
+ * ----------------------------------------------------
+ */
 void SC_GetNextAtsCommand(void)
 {
-    UT_DEFAULT_IMPL(SC_GetNextAtsCommand);
+
+    UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetNextRtsCommand()
+ * ----------------------------------------------------
+ */
+void SC_GetNextRtsCommand(void)
+{
+
+    UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetNextRtsTime()
+ * ----------------------------------------------------
+ */
+void SC_GetNextRtsTime(void)
+{
+
+    UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_UpdateNextTime()
+ * ----------------------------------------------------
+ */
+void SC_UpdateNextTime(void)
+{
+
+    UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
 }

--- a/unit-test/stubs/sc_utils_stubs.c
+++ b/unit-test/stubs/sc_utils_stubs.c
@@ -17,49 +17,102 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_utils header
  */
 
 #include "sc_utils.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-void SC_GetCurrentTime(void)
-{
-    UT_DEFAULT_IMPL(SC_GetCurrentTime);
-}
-
-SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
-{
-    UT_Stub_RegisterContext(UT_KEY(SC_GetAtsEntryTime), Entry);
-    return UT_DEFAULT_IMPL(SC_GetAtsEntryTime);
-}
-
-SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_ComputeAbsTime), RelTime);
-    return UT_DEFAULT_IMPL(SC_ComputeAbsTime);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_CompareAbsTime()
+ * ----------------------------------------------------
+ */
 bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_CompareAbsTime), AbsTime1);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_CompareAbsTime), AbsTime2);
-    return UT_DEFAULT_IMPL(SC_CompareAbsTime);
+    UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
+
+    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
+    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime2);
+
+    UT_GenStub_Execute(SC_CompareAbsTime, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_CompareAbsTime, bool);
 }
 
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ComputeAbsTime()
+ * ----------------------------------------------------
+ */
+SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
 {
-    UT_Stub_RegisterContext(UT_KEY(SC_VerifyCmdLength), Msg);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(SC_VerifyCmdLength), ExpectedLength);
-    return UT_DEFAULT_IMPL(SC_VerifyCmdLength);
+    UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+
+    UT_GenStub_AddParam(SC_ComputeAbsTime, SC_RelTimeTag_t, RelTime);
+
+    UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ComputeAbsTime, SC_AbsTimeTag_t);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetAtsEntryTime()
+ * ----------------------------------------------------
+ */
+SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
+{
+    UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+
+    UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
+
+    UT_GenStub_Execute(SC_GetAtsEntryTime, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_GetCurrentTime()
+ * ----------------------------------------------------
+ */
+void SC_GetCurrentTime(void)
+{
+
+    UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ToggleAtsIndex()
+ * ----------------------------------------------------
+ */
 uint16 SC_ToggleAtsIndex(void)
 {
-    return UT_DEFAULT_IMPL(SC_ToggleAtsIndex);
+    UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, uint16);
+
+    UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, uint16);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_VerifyCmdLength()
+ * ----------------------------------------------------
+ */
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
+{
+    UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
+
+    UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
+    UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
+
+    UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Regenerate all SC stub functions using the current version of the script.

The global data structures are moved to a separate stub file.

Fixes #109

**Testing performed**
Build and run all tests

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Debian

**Additional context**
  Change is for future ease of management of stub implementations.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
