### PR TITLE
Fix #108, dispatch pattern for SC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(APP_SRC_FILES
   fsw/src/sc_state.c
   fsw/src/sc_loads.c
   fsw/src/sc_cmds.c
+  fsw/src/sc_dispatch.c
 )
 
 # Create the app module

--- a/fsw/inc/sc_msg.h
+++ b/fsw/inc/sc_msg.h
@@ -36,6 +36,8 @@
 #include <sc_platform_cfg.h>
 #include <sc_msgdefs.h>
 
+#include "cfe_tbl_msg.h"
+
 /************************************************************************
  * Macro Definitions
  ************************************************************************/
@@ -172,17 +174,6 @@ typedef struct
 } SC_RtsGrpCmd_Payload_t;
 
 /**
- *  \brief No Arguments Command
- *
- *  For command details see #SC_NOOP_CC, #SC_RESET_COUNTERS_CC, #SC_STOP_ATS_CC, #SC_SWITCH_ATS_CC
- *  Also see #SC_SEND_HK_MID
- */
-typedef struct
-{
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-} SC_NoArgsCmd_t;
-
-/**
  *  \brief ATS Id Command
  *
  *  For command details see #SC_START_ATS_CC
@@ -192,17 +183,6 @@ typedef struct
     CFE_MSG_CommandHeader_t  CmdHeader; /**< \brief Command Header */
     SC_StartAtsCmd_Payload_t Payload;
 } SC_StartAtsCmd_t;
-
-/**
- *  \brief RTS Id Command
- *
- *  For command details see #SC_START_RTS_CC, #SC_STOP_RTS_CC, #SC_DISABLE_RTS_CC, #SC_ENABLE_RTS_CC
- */
-typedef struct
-{
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
-    SC_RtsCmd_Payload_t     Payload;
-} SC_RtsCmd_t;
 
 /**
  *  \brief Jump running ATS to a new time Command
@@ -238,15 +218,174 @@ typedef struct
 } SC_AppendAtsCmd_t;
 
 /**
+ *  \brief Send HK Command
+ *
+ *  For command details see #SC_SEND_HK_MID
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_SendHkCmd_t;
+
+/**
+ *  \brief 1Hz Wakeup Command
+ *
+ *  For command details see #SC_1HZ_WAKEUP_MID
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_OneHzWakeupCmd_t;
+
+/**
+ *  \brief No operation Command
+ *
+ *  For command details see #SC_NOOP_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_NoopCmd_t;
+
+/**
+ *  \brief Reset Counters Command
+ *
+ *  For command details see #SC_RESET_COUNTERS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_ResetCountersCmd_t;
+
+/**
+ *  \brief Stop ATS Command
+ *
+ *  For command details see #SC_STOP_ATS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_StopAtsCmd_t;
+
+/**
+ *  \brief Switch ATS Command
+ *
+ *  For command details see #SC_SWITCH_ATS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+} SC_SwitchAtsCmd_t;
+
+/**
+ *  \brief Start RTS Command
+ *
+ *  For command details see #SC_START_RTS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsCmd_Payload_t     Payload;
+} SC_StartRtsCmd_t;
+
+/**
+ *  \brief Stop RTS Command
+ *
+ *  For command details see #SC_STOP_RTS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsCmd_Payload_t     Payload;
+} SC_StopRtsCmd_t;
+
+/**
+ *  \brief Disable RTS Command
+ *
+ *  For command details see #SC_DISABLE_RTS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsCmd_Payload_t     Payload;
+} SC_DisableRtsCmd_t;
+
+/**
+ *  \brief Enable RTS Command
+ *
+ *  For command details see #SC_ENABLE_RTS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsCmd_Payload_t     Payload;
+} SC_EnableRtsCmd_t;
+
+/**
+ *  \brief Continue ATS on failure command
+ *
+ *  For command details see #SC_CONTINUE_ATS_ON_FAILURE_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command Header */
+    SC_SetContinueAtsOnFailureCmd_Payload_t Payload;
+} SC_ContinueAtsOnFailureCmd_t;
+
+/**
+ *  \brief Manage Table Command
+ *
+ *  For command details see #SC_MANAGE_TABLE_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command Header */
+    CFE_TBL_NotifyCmd_Payload_t Payload;
+} SC_ManageTableCmd_t;
+
+/**
  *  \brief RTS Group Command
  *
- *  For command details see #SC_START_RTS_GRP_CC, #SC_STOP_RTS_GRP_CC, #SC_DISABLE_RTS_GRP_CC, #SC_ENABLE_RTS_GRP_CC
+ *  For command details see #SC_START_RTS_GRP_CC
  */
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
-} SC_RtsGrpCmd_t;
+} SC_StartRtsGrpCmd_t;
+
+/**
+ *  \brief RTS Group Command
+ *
+ *  For command details see #SC_STOP_RTS_GRP_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsGrpCmd_Payload_t  Payload;
+} SC_StopRtsGrpCmd_t;
+
+/**
+ *  \brief RTS Group Command
+ *
+ *  For command details see #SC_DISABLE_RTS_GRP_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsGrpCmd_Payload_t  Payload;
+} SC_DisableRtsGrpCmd_t;
+
+/**
+ *  \brief RTS Group Command
+ *
+ *  For command details see #SC_ENABLE_RTS_GRP_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    SC_RtsGrpCmd_Payload_t  Payload;
+} SC_EnableRtsGrpCmd_t;
 
 /**\}*/
 

--- a/fsw/inc/sc_msgdefs.h
+++ b/fsw/inc/sc_msgdefs.h
@@ -101,7 +101,7 @@
  *       Implements the Noop command that insures the SC app is alive
  *
  *  \par Command Structure
- *       #SC_NoArgsCmd_t
+ *       #SC_NoopCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -132,7 +132,7 @@
  *       Resets the SC housekeeping counters
  *
  *  \par Command Structure
- *       #SC_NoArgsCmd_t
+ *       #SC_ResetCountersCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -195,7 +195,7 @@
  *       Stops the specified ATS
  *
  *  \par Command Structure
- *       #SC_NoArgsCmd_t
+ *       #SC_StopAtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -225,7 +225,7 @@
  *       Starts the specified RTS
  *
  *  \par Command Structure
- *       #SC_RtsCmd_t
+ *       #SC_StartRtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -261,7 +261,7 @@
  *       Stops the specified RTS
  *
  *  \par Command Structure
- *       #SC_RtsCmd_t
+ *       #SC_StopRtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -292,7 +292,7 @@
  *       Disables the specified RTS
  *
  *  \par Command Structure
- *       #SC_RtsCmd_t
+ *       #SC_DisableRtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -323,7 +323,7 @@
  *       Enables the specified RTS
  *
  *  \par Command Structure
- *       #SC_RtsCmd_t
+ *       #SC_EnableRtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -354,7 +354,7 @@
  *       Switches the running ATS and the ATS no running
  *
  *  \par Command Structure
- *       #SC_NoArgsCmd_t
+ *       #SC_SwitchAtsCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -416,7 +416,7 @@
  *        checksum validation before being sent out.
  *
  *  \par Command Structure
- *       #SC_SetContinueAtsOnFailureCmd_t
+ *       #SC_ContinueAtsOnFailureCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -485,7 +485,7 @@
  *       any source other than cFE Table Services.
  *
  *  \par Command Structure
- *       #CFE_TBL_NotifyCmd_t
+ *       #SC_ManageTableCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified via:
@@ -516,7 +516,7 @@
  *       currently LOADED, ENABLED and STOPPED.
  *
  *  \par Command Structure
- *       #SC_RtsGrpCmd_t
+ *       #SC_StartRtsGrpCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -556,7 +556,7 @@
  *       This command STOPS each RTS in the specified group that is currently STARTED.
  *
  *  \par Command Structure
- *       #SC_RtsGrpCmd_t
+ *       #SC_StopRtsGrpCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -594,7 +594,7 @@
  *       This command sets the enable state for the specified group of RTS to DISABLED.
  *
  *  \par Command Structure
- *       #SC_RtsGrpCmd_t
+ *       #SC_DisableRtsGrpCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -632,7 +632,7 @@
  *       This command sets the enable state for the specified group of RTS to ENABLED.
  *
  *  \par Command Structure
- *       #SC_RtsGrpCmd_t
+ *       #SC_EnableRtsGrpCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -34,7 +34,7 @@
 #include "cfe.h"
 #include "sc_app.h"
 #include "sc_rts.h"
-#include "sc_cmds.h"
+#include "sc_dispatch.h"
 #include "sc_loads.h"
 #include "sc_events.h"
 #include "sc_msgids.h"

--- a/fsw/src/sc_app.h
+++ b/fsw/src/sc_app.h
@@ -174,7 +174,7 @@ void SC_LoadDefaultTables(void);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \sa #SC_TableManageCmd
+ *  \sa #SC_ManageTableCmd
  */
 void SC_RegisterManageCmds(void);
 

--- a/fsw/src/sc_atsrq.h
+++ b/fsw/src/sc_atsrq.h
@@ -27,6 +27,7 @@
 #define SC_ATSRQ_H
 
 #include "cfe.h"
+#include "sc_msg.h"
 
 /**
  * \brief Starts an ATS
@@ -59,11 +60,11 @@ bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_START_ATS_CC
  */
-void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd);
 
 /**
  * \brief Stop the executing ATS Command
@@ -76,11 +77,11 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_STOP_ATS_CC
  */
-void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd);
 
 /**
  * \brief Stops an ATS & clears out data
@@ -110,11 +111,11 @@ void SC_KillAts(void);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_SWITCH_ATS_CC
  */
-void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd);
 
 /**
  * \brief
@@ -180,11 +181,11 @@ void SC_ServiceSwitchPend(void);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_JUMP_ATS_CC
  */
-void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd);
 
 /**
  * \brief Lets an ATS continue if a command failed the checksum
@@ -196,11 +197,11 @@ void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_CONTINUE_ATS_ON_FAILURE_CC
  */
-void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd);
 
 /**
  * \brief  Append to an ATS Command
@@ -215,10 +216,10 @@ void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_APPEND_ATS_CC
  */
-void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd);
 
 #endif

--- a/fsw/src/sc_cmds.h
+++ b/fsw/src/sc_cmds.h
@@ -25,7 +25,8 @@
 #ifndef SC_CMDS_H
 #define SC_CMDS_H
 
-#include "cfe.h"
+#include "common_types.h"
+#include "sc_msg.h"
 
 typedef enum
 {
@@ -47,11 +48,11 @@ typedef enum
  *  \par Assumptions, External Events, and Notes:
  *       None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_MANAGE_TABLE_CC
  */
-void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd);
 
 /**
  * \brief Manage pending update to an RTS table
@@ -68,7 +69,7 @@ void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]         ArrayIndex     index into array of RTS tables
  *
- *  \sa #SC_TableManageCmd
+ *  \sa #SC_ManageTableCmd
  */
 void SC_ManageRtsTable(int32 ArrayIndex);
 
@@ -87,7 +88,7 @@ void SC_ManageRtsTable(int32 ArrayIndex);
  *
  *  \param [in]         ArrayIndex     index into array of ATS tables
  *
- *  \sa #SC_TableManageCmd
+ *  \sa #SC_ManageTableCmd
  */
 void SC_ManageAtsTable(int32 ArrayIndex);
 
@@ -104,38 +105,9 @@ void SC_ManageAtsTable(int32 ArrayIndex);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \sa #SC_TableManageCmd
+ *  \sa #SC_ManageTableCmd
  */
 void SC_ManageTable(SC_TableType type, int32 ArrayIndex);
-
-/**
- * \brief Routes commands to be processed
- *
- *  \par Description
- *           This routine determines the source of a request to
- *           the Stored Command processor and routes it to one of the lower
- *           level request processing routines
- *
- *  \par Assumptions, External Events, and Notes:
- *        None
- *
- *  \param[in] BufPtr Pointer to Software Bus buffer
- */
-void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr);
-
-/**
- * \brief Processes commands
- *
- *  \par Description
- *       Process commands. Commands can be from external sources or from SC
- *       itself.
- *
- *  \par Assumptions, External Events, and Notes:
- *        None
- *
- *  \param[in] BufPtr Pointer to Software Bus buffer
- */
-void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Sends out an Event message
@@ -146,11 +118,11 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_NOOP_CC
  */
-void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_NoopCmd(const SC_NoopCmd_t *Cmd);
 
 /**
  * \brief Reset Counters Command
@@ -161,11 +133,11 @@ void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param[in] BufPtr Pointer to Software Bus buffer
+ *  \param[in] Cmd Pointer to Software Bus buffer
  *
  *  \sa #SC_RESET_COUNTERS_CC
  */
-void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
+void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd);
 
 /**
  * \brief Send Hk Packet to the ground
@@ -179,6 +151,9 @@ void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
  *        None
  */
 void SC_SendHkPacket(void);
+
+void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd);
+void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd);
 
 /**
  * \brief Process an ATS Command

--- a/fsw/src/sc_dispatch.c
+++ b/fsw/src/sc_dispatch.c
@@ -1,0 +1,273 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,924-1, and identified as “Core Flight
+ * System (cFS) Stored Command Application version 3.1.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   This file contains the functions to handle processing of ground
+ *   command requests, housekeeping requests, and table updates
+ */
+
+/**************************************************************************
+ **
+ ** Include section
+ **
+ **************************************************************************/
+
+#include "cfe.h"
+#include "sc_app.h"
+#include "sc_atsrq.h"
+#include "sc_cmds.h"
+#include "sc_dispatch.h"
+#include "sc_events.h"
+#include "sc_msgids.h"
+#include "sc_rtsrq.h"
+#include "sc_utils.h"
+
+/**************************************************************************
+ **
+ ** Functions
+ **
+ **************************************************************************/
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* SC Verify the length of the command                             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
+{
+    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_FcnCode_t CommandCode  = 0;
+    bool              Result       = true;
+    size_t            ActualLength = 0;
+
+    CFE_MSG_GetSize(Msg, &ActualLength);
+
+    /* Verify the command packet length */
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(Msg, &MessageID);
+        CFE_MSG_GetFcnCode(Msg, &CommandCode);
+
+        CFE_EVS_SendEvent(SC_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
+                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
+                          (int)ExpectedLength);
+        Result = false;
+        if (CFE_SB_MsgIdToValue(MessageID) == SC_CMD_MID)
+        {
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
+        }
+    }
+    return (Result);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/*  Process Requests                                               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
+{
+    CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
+
+    /* cast the packet header pointer on the packet buffer */
+    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
+    /*
+     ** Get the current system time in the global SC_AppData.CurrentTime
+     */
+    SC_GetCurrentTime();
+
+    switch (CFE_SB_MsgIdToValue(MessageID))
+    {
+        case SC_CMD_MID:
+            /* request from the ground */
+            SC_ProcessCommand(BufPtr);
+            break;
+
+        case SC_SEND_HK_MID:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_SendHkCmd_t)))
+            {
+                SC_SendHkCmd((const SC_SendHkCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_1HZ_WAKEUP_MID:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_OneHzWakeupCmd_t)))
+            {
+                SC_OneHzWakeupCmd((const SC_OneHzWakeupCmd_t *)BufPtr);
+            }
+            break;
+
+        default:
+            CFE_EVS_SendEvent(SC_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID));
+
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
+            break;
+    } /* end switch */
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/*  Process a command                                              */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
+{
+    CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
+
+    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+    CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+    switch (CommandCode)
+    {
+        case SC_NOOP_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_NoopCmd_t)))
+            {
+                SC_NoopCmd((const SC_NoopCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_RESET_COUNTERS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_ResetCountersCmd_t)))
+            {
+                SC_ResetCountersCmd((const SC_ResetCountersCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_START_ATS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StartAtsCmd_t)))
+            {
+                SC_StartAtsCmd((const SC_StartAtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_STOP_ATS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StopAtsCmd_t)))
+            {
+                SC_StopAtsCmd((const SC_StopAtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_START_RTS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StartRtsCmd_t)))
+            {
+                SC_StartRtsCmd((const SC_StartRtsCmd_t *)BufPtr);
+            }
+            else
+            {
+                SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
+            }
+            break;
+
+        case SC_STOP_RTS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StopRtsCmd_t)))
+            {
+                SC_StopRtsCmd((const SC_StopRtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_DISABLE_RTS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_DisableRtsCmd_t)))
+            {
+                SC_DisableRtsCmd((const SC_DisableRtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_ENABLE_RTS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_EnableRtsCmd_t)))
+            {
+                SC_EnableRtsCmd((const SC_EnableRtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_SWITCH_ATS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_SwitchAtsCmd_t)))
+            {
+                SC_SwitchAtsCmd((const SC_SwitchAtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_JUMP_ATS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_JumpAtsCmd_t)))
+            {
+                SC_JumpAtsCmd((const SC_JumpAtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_CONTINUE_ATS_ON_FAILURE_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_ContinueAtsOnFailureCmd_t)))
+            {
+                SC_ContinueAtsOnFailureCmd((const SC_ContinueAtsOnFailureCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_APPEND_ATS_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_AppendAtsCmd_t)))
+            {
+                SC_AppendAtsCmd((const SC_AppendAtsCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_MANAGE_TABLE_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_ManageTableCmd_t)))
+            {
+                SC_ManageTableCmd((const SC_ManageTableCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_START_RTS_GRP_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StartRtsGrpCmd_t)))
+            {
+                SC_StartRtsGrpCmd((const SC_StartRtsGrpCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_STOP_RTS_GRP_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_StopRtsGrpCmd_t)))
+            {
+                SC_StopRtsGrpCmd((const SC_StopRtsGrpCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_DISABLE_RTS_GRP_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_DisableRtsGrpCmd_t)))
+            {
+                SC_DisableRtsGrpCmd((const SC_DisableRtsGrpCmd_t *)BufPtr);
+            }
+            break;
+
+        case SC_ENABLE_RTS_GRP_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_EnableRtsGrpCmd_t)))
+            {
+                SC_EnableRtsGrpCmd((const SC_EnableRtsGrpCmd_t *)BufPtr);
+            }
+            break;
+
+        default:
+            CFE_EVS_SendEvent(SC_INVLD_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Invalid Command Code: MID =  0x%08lX CC =  %d",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
+            SC_OperData.HkPacket.Payload.CmdErrCtr++;
+            break;
+    } /* end switch */
+}

--- a/fsw/src/sc_dispatch.h
+++ b/fsw/src/sc_dispatch.h
@@ -1,0 +1,82 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,924-1, and identified as “Core Flight
+ * System (cFS) Stored Command Application version 3.1.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   This file contains functions to handle dispatching of commands
+ */
+#ifndef SC_DISPATCH_H
+#define SC_DISPATCH_H
+
+#include "cfe_sb.h"
+#include "cfe_msg.h"
+
+/**
+ * \brief Verify command message length
+ *
+ *  \par Description
+ *       This routine will check if the actual length of a software bus
+ *       command message matches the expected length and send an
+ *       error event message if a mismatch occurs
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param [in]   Msg              Pointer to message
+ *  \param [in]   ExpectedLength   The expected length of the message
+ *                                 based upon the command code
+ *
+ *  \return Boolean length verification result
+ *  \retval true  Length matches expected
+ *  \retval false Length does not match expected
+ *
+ *  \sa #SC_LEN_ERR_EID
+ */
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength);
+
+/**
+ * \brief Routes commands to be processed
+ *
+ *  \par Description
+ *           This routine determines the source of a request to
+ *           the Stored Command processor and routes it to one of the lower
+ *           level request processing routines
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        None
+ *
+ *  \param[in] BufPtr Pointer to Software Bus buffer
+ */
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Processes commands
+ *
+ *  \par Description
+ *       Process commands. Commands can be from external sources or from SC
+ *       itself.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        None
+ *
+ *  \param[in] BufPtr Pointer to Software Bus buffer
+ */
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr);
+
+#endif

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -48,7 +48,7 @@
 /* Starts and RTS                                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
 {
     uint16               RtsId;         /* rts ID */
     uint16               RtsIndex;      /* rts array index */
@@ -59,7 +59,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     /*
      ** Check start RTS parameters
      */
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
+    RtsId = Cmd->Payload.RtsId;
 
     if ((RtsId > 0) && (RtsId <= SC_NUMBER_OF_RTS))
     {
@@ -73,8 +73,8 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
             if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED)
             {
                 /*
-                    ** Check the command length
-                    */
+                 ** Check the command length
+                 */
                 RtsEntryPtr = (SC_RtsEntryHeader_t *)SC_OperData.RtsTblAddr[RtsIndex];
                 RtsEntryCmd = (CFE_MSG_Message_t *)((uint8_t *)RtsEntryPtr + SC_RTS_HEADER_SIZE);
 
@@ -84,8 +84,8 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                 if (CmdLength >= SC_PACKET_MIN_SIZE && CmdLength <= SC_PACKET_MAX_SIZE)
                 {
                     /*
-                        **  Initialize the RTS info table entry
-                        */
+                     **  Initialize the RTS info table entry
+                     */
                     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr      = 0;
@@ -93,21 +93,21 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
                     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr++;
 
                     /*
-                        ** Get the absolute time for the RTSs next_cmd_time
-                        ** using the current time and the relative time tag.
-                        */
+                     ** Get the absolute time for the RTSs next_cmd_time
+                     ** using the current time and the relative time tag.
+                     */
                     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime =
                         SC_ComputeAbsTime(((SC_RtsEntryHeader_t *)SC_OperData.RtsTblAddr[RtsIndex])->TimeTag);
 
                     /*
-                        ** Last, Increment some global counters associated with the
-                        ** starting of the RTS
-                        */
+                     ** Last, Increment some global counters associated with the
+                     ** starting of the RTS
+                     */
                     SC_OperData.RtsCtrlBlckAddr->NumRtsActive++;
                     SC_OperData.HkPacket.Payload.RtsActiveCtr++;
                     SC_OperData.HkPacket.Payload.CmdCtr++;
 
-                    if (((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId <= SC_LAST_RTS_WITH_EVENTS)
+                    if (Cmd->Payload.RtsId <= SC_LAST_RTS_WITH_EVENTS)
                     {
                         CFE_EVS_SendEvent(SC_RTS_START_INF_EID, CFE_EVS_EventType_INFORMATION,
                                           "RTS Number %03d Started", RtsId);
@@ -134,8 +134,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
             { /* Cannot use the RTS now */
 
                 CFE_EVS_SendEvent(SC_STARTRTS_CMD_NOT_LDED_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Start RTS %03d Rejected: RTS Not Loaded or In Use, Status: %d",
-                                  ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId,
+                                  "Start RTS %03d Rejected: RTS Not Loaded or In Use, Status: %d", Cmd->Payload.RtsId,
                                   SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus);
 
                 SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -167,7 +166,7 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Start a group of RTS                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
 {
     uint16 FirstId;
     uint16 LastId;
@@ -176,8 +175,8 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  StartCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
+    FirstId = Cmd->Payload.FirstRtsId;
+    LastId  = Cmd->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -252,12 +251,12 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Stop an RTS                                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
 {
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
+    RtsId = Cmd->Payload.RtsId;
 
     /* check the command parameter */
     if (RtsId <= SC_NUMBER_OF_RTS)
@@ -289,7 +288,7 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Stop a group of RTS                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
 {
     uint16 FirstId;
     uint16 LastId;
@@ -298,8 +297,8 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  StopCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
+    FirstId = Cmd->Payload.FirstRtsId;
+    LastId  = Cmd->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -319,17 +318,17 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
             }
         }
 
-            /* success */
-            CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Stop RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)StopCount);
-            SC_OperData.HkPacket.Payload.CmdCtr++;
-        }
-        else
-        { /* error */
-            CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Stop RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
-            SC_OperData.HkPacket.Payload.CmdErrCtr++;
-        }
+        /* success */
+        CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Stop RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)StopCount);
+        SC_OperData.HkPacket.Payload.CmdCtr++;
+    }
+    else
+    { /* error */
+        CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Stop RTS group error: FirstID=%d, LastID=%d", FirstId, LastId);
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -337,12 +336,12 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Disables an RTS                                                 */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
 {
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
+    RtsId = Cmd->Payload.RtsId;
 
     /* make sure tha specified rts is valid */
     if (RtsId <= SC_NUMBER_OF_RTS)
@@ -360,8 +359,8 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     }
     else
     { /* it is not a valid RTS id */
-        CFE_EVS_SendEvent(SC_DISRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Disable RTS %03d Rejected: Invalid RTS ID", RtsId);
+        CFE_EVS_SendEvent(SC_DISRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Disable RTS %03d Rejected: Invalid RTS ID",
+                          RtsId);
 
         /* update the command error status */
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -373,7 +372,7 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Disable a group of RTS                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
 {
     uint16 FirstId;
     uint16 LastId;
@@ -382,8 +381,8 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  DisableCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
+    FirstId = Cmd->Payload.FirstRtsId;
+    LastId  = Cmd->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -405,8 +404,7 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 
         /* success */
         CFE_EVS_SendEvent(SC_DISRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Disable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId,
-                          (int)DisableCount);
+                          "Disable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)DisableCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
@@ -422,12 +420,12 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Enables an RTS                                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
 {
     uint16 RtsId;    /* RTS ID */
     uint16 RtsIndex; /* RTS array index */
 
-    RtsId = ((SC_RtsCmd_t *)CmdPacket)->Payload.RtsId;
+    RtsId = Cmd->Payload.RtsId;
 
     /* make sure the specified rts is valid */
     if ((RtsId > 0) && (RtsId <= SC_NUMBER_OF_RTS))
@@ -445,8 +443,8 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
     }
     else
     { /* it is not a valid RTS id */
-        CFE_EVS_SendEvent(SC_ENARTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Enable RTS %03d Rejected: Invalid RTS ID", RtsId);
+        CFE_EVS_SendEvent(SC_ENARTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Enable RTS %03d Rejected: Invalid RTS ID",
+                          RtsId);
 
         /* update the command error status */
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -459,7 +457,7 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
 /* Enable a group of RTS                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
 {
     uint16 FirstId;
     uint16 LastId;
@@ -468,8 +466,8 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
     uint16 RtsIndex;
     int32  EnableCount = 0;
 
-    FirstId = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.FirstRtsId;
-    LastId  = ((SC_RtsGrpCmd_t *)CmdPacket)->Payload.LastRtsId;
+    FirstId = Cmd->Payload.FirstRtsId;
+    LastId  = Cmd->Payload.LastRtsId;
 
     /* make sure the specified group is valid */
     if ((FirstId > 0) && (LastId > 0) && (FirstId <= SC_NUMBER_OF_RTS) && (LastId <= SC_NUMBER_OF_RTS) &&
@@ -491,8 +489,7 @@ void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
 
         /* success */
         CFE_EVS_SendEvent(SC_ENARTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Enable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId,
-                          (int)EnableCount);
+                          "Enable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstId, LastId, (int)EnableCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
@@ -544,7 +541,7 @@ void SC_KillRts(uint16 RtsIndex)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_AutoStartRts(uint16 RtsNumber)
 {
-    SC_RtsCmd_t CmdPkt; /* the command packet to start an RTS */
+    SC_StartRtsCmd_t CmdPkt; /* the command packet to start an RTS */
 
     memset(&CmdPkt, 0, sizeof(CmdPkt));
 
@@ -554,7 +551,7 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Format the command packet to start the first RTS
          */
-        CFE_MSG_Init(&CmdPkt.CmdHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(SC_RtsCmd_t));
+        CFE_MSG_Init(&CmdPkt.CmdHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
 
         CFE_MSG_SetFcnCode(&CmdPkt.CmdHeader.Msg, SC_START_RTS_CC);
 

--- a/fsw/src/sc_rtsrq.h
+++ b/fsw/src/sc_rtsrq.h
@@ -26,7 +26,8 @@
 #ifndef SC_RTSRQ_H
 #define SC_RTSRQ_H
 
-#include "cfe.h"
+#include "common_types.h"
+#include "sc_msg.h"
 
 /**
  * \brief Start an RTS Command
@@ -37,11 +38,11 @@
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_START_RTS_CC
  */
-void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd);
 
 /**
  * \brief Start a group of RTS Command
@@ -52,11 +53,11 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_START_RTS_GRP_CC
  */
-void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd);
 
 /**
  * \brief  Stop an RTS from executing Command
@@ -67,11 +68,11 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_STOP_RTS_CC
  */
-void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd);
 
 /**
  * \brief  Stop a group of RTS from executing Command
@@ -82,11 +83,11 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_STOP_RTS_CC
  */
-void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd);
 
 /**
  * \brief Disable an RTS Command
@@ -97,11 +98,11 @@ void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_DISABLE_RTS_CC
  */
-void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd);
 
 /**
  * \brief Disable a group of RTS Command
@@ -112,11 +113,11 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_DISABLE_RTS_CC
  */
-void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd);
 
 /**
  * \brief Enable an RTS Command
@@ -127,11 +128,11 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_ENABLE_RTS_CC
  */
-void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd);
 
 /**
  * \brief Enable a group of RTS Command
@@ -142,11 +143,11 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket);
  *  \par Assumptions, External Events, and Notes:
  *        None
  *
- *  \param [in]         CmdPacket      Pointer to Software Bus buffer
+ *  \param [in]         Cmd      Pointer to Software Bus buffer
  *
  *  \sa #SC_ENABLE_RTS_GRP_CC
  */
-void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket);
+void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd);
 
 /**
  * \brief Stops an RTS & clears out data

--- a/fsw/src/sc_utils.c
+++ b/fsw/src/sc_utils.c
@@ -142,39 +142,6 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
     return Status;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* SC Verify the length of the command                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
-{
-    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID;
-    CFE_MSG_FcnCode_t CommandCode  = 0;
-    bool              Result       = true;
-    size_t            ActualLength = 0;
-
-    CFE_MSG_GetSize(Msg, &ActualLength);
-
-    /* Verify the command packet length */
-    if (ExpectedLength != ActualLength)
-    {
-        CFE_MSG_GetMsgId(Msg, &MessageID);
-        CFE_MSG_GetFcnCode(Msg, &CommandCode);
-
-        CFE_EVS_SendEvent(SC_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
-                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ActualLength,
-                          (int)ExpectedLength);
-        Result = false;
-        if (CFE_SB_MsgIdToValue(MessageID) == SC_CMD_MID)
-        {
-            SC_OperData.HkPacket.Payload.CmdErrCtr++;
-        }
-    }
-    return (Result);
-}
-
 uint16 SC_ToggleAtsIndex(void)
 {
     uint16 CurrAtsIndex = SC_ATS_NUM_TO_INDEX(SC_OperData.AtsCtrlBlckAddr->AtsNumber);

--- a/fsw/src/sc_utils.h
+++ b/fsw/src/sc_utils.h
@@ -90,29 +90,6 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime);
 bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2);
 
 /**
- * \brief Verify command message length
- *
- *  \par Description
- *       This routine will check if the actual length of a software bus
- *       command message matches the expected length and send an
- *       error event message if a mismatch occurs
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param [in]   Msg              Pointer to message
- *  \param [in]   ExpectedLength   The expected length of the message
- *                                 based upon the command code
- *
- *  \return Boolean length verification result
- *  \retval true  Length matches expected
- *  \retval false Length does not match expected
- *
- *  \sa #SC_LEN_ERR_EID
- */
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength);
-
-/**
  * \brief Toggles the ATS index
  *
  *  \par Description

--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -72,14 +72,14 @@
 /* Custom table structure, modify as needed to add desired commands */
 typedef struct
 {
-    SC_AtsEntryHeader_t hdr1;
-    SC_NoArgsCmd_t      cmd1;
-    SC_AtsEntryHeader_t hdr2;
-    SC_RtsCmd_t         cmd2;
-    SC_AtsEntryHeader_t hdr3;
-    SC_RtsCmd_t         cmd3;
-    SC_AtsEntryHeader_t hdr4;
-    SC_NoArgsCmd_t      cmd4;
+    SC_AtsEntryHeader_t   hdr1;
+    SC_NoopCmd_t          cmd1;
+    SC_AtsEntryHeader_t   hdr2;
+    SC_EnableRtsCmd_t     cmd2;
+    SC_AtsEntryHeader_t   hdr3;
+    SC_StartRtsCmd_t      cmd3;
+    SC_AtsEntryHeader_t   hdr4;
+    SC_ResetCountersCmd_t cmd4;
 } SC_AtsStruct1_t;
 
 /* Define the union to size the table correctly */
@@ -101,18 +101,18 @@ SC_AtsTable1_t SC_Ats1 = {
     .ats.cmd1.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .ats.hdr2.CmdNumber     = 2,
-    .ats.hdr2.TimeTag_MS    = SC_CMD2_TIME >> 16,
-    .ats.hdr2.TimeTag_LS    = SC_CMD2_TIME & 0xFFFF,
-    .ats.cmd2.CmdHeader     =
+    .ats.hdr2.CmdNumber  = 2,
+    .ats.hdr2.TimeTag_MS = SC_CMD2_TIME >> 16,
+    .ats.hdr2.TimeTag_LS = SC_CMD2_TIME & 0xFFFF,
+    .ats.cmd2.CmdHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS1_CKSUM),
     .ats.cmd2.Payload.RtsId = 1,
 
     /* 3 */
-    .ats.hdr3.CmdNumber     = 3,
-    .ats.hdr3.TimeTag_MS    = SC_CMD3_TIME >> 16,
-    .ats.hdr3.TimeTag_LS    = SC_CMD3_TIME & 0xFFFF,
-    .ats.cmd3.CmdHeader     = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
+    .ats.hdr3.CmdNumber  = 3,
+    .ats.hdr3.TimeTag_MS = SC_CMD3_TIME >> 16,
+    .ats.hdr3.TimeTag_LS = SC_CMD3_TIME & 0xFFFF,
+    .ats.cmd3.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
     .ats.cmd3.Payload.RtsId = 1,
 
     /* 4 */

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -58,11 +58,11 @@
 typedef struct
 {
     SC_RtsEntryHeader_t hdr1;
-    SC_NoArgsCmd_t      cmd1;
+    SC_NoopCmd_t        cmd1;
     SC_RtsEntryHeader_t hdr2;
-    SC_RtsCmd_t         cmd2;
+    SC_EnableRtsCmd_t   cmd2;
     SC_RtsEntryHeader_t hdr3;
-    SC_RtsCmd_t         cmd3;
+    SC_StartRtsCmd_t    cmd3;
 } SC_RtsStruct001_t;
 
 /* Define the union to size the table correctly */
@@ -82,14 +82,14 @@ SC_RtsTable001_t SC_Rts001 = {
     .rts.cmd1.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .rts.hdr2.TimeTag       = 5,
-    .rts.cmd2.CmdHeader     =
+    .rts.hdr2.TimeTag = 5,
+    .rts.cmd2.CmdHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS2_CKSUM),
     .rts.cmd2.Payload.RtsId = 2,
 
     /* 3 */
-    .rts.hdr3.TimeTag       = 5,
-    .rts.cmd3.CmdHeader     = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
+    .rts.hdr3.TimeTag   = 5,
+    .rts.cmd3.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
     .rts.cmd3.Payload.RtsId = 2};
 
 /* Macro for table structure */

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -52,11 +52,11 @@
 typedef struct
 {
     SC_RtsEntryHeader_t hdr1;
-    SC_NoArgsCmd_t      cmd1;
+    SC_NoopCmd_t        cmd1;
     SC_RtsEntryHeader_t hdr2;
-    SC_NoArgsCmd_t      cmd2;
+    SC_NoopCmd_t        cmd2;
     SC_RtsEntryHeader_t hdr3;
-    SC_NoArgsCmd_t      cmd3;
+    SC_NoopCmd_t        cmd3;
 } SC_RtsStruct002_t;
 
 /* Define the union to size the table correctly */

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_cfe_coverage_stubs("sc_internal"
   stubs/sc_global_stubs.c
   stubs/sc_loads_stubs.c
   stubs/sc_cmds_stubs.c
+  stubs/sc_dispatch_stubs.c
   stubs/sc_atsrq_stubs.c
   stubs/sc_state_stubs.c
   stubs/sc_app_stubs.c

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -66,7 +66,7 @@ void UT_Setup_InitTables(void)
 void SC_AppMain_Test_Nominal(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    size_t         MsgSize   = sizeof(SC_NoArgsCmd_t);
+    size_t         MsgSize   = sizeof(SC_NoopCmd_t);
 
     /* Called in a subfunction.  Set here to prevent segmentation fault. */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -71,12 +71,12 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    UT_CmdBuf.StartAtsCmd.Payload.AtsId                    = 1;
+    UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -98,7 +98,7 @@ void SC_StartAtsCmd_Test_NominalB(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
@@ -127,7 +127,7 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -149,7 +149,7 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -171,7 +171,7 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -192,7 +192,7 @@ void SC_StartAtsCmd_Test_InUse(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -213,7 +213,7 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -234,7 +234,7 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -254,7 +254,7 @@ void SC_StopAtsCmd_Test_NominalA(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -274,7 +274,7 @@ void SC_StopAtsCmd_Test_NominalB(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -294,7 +294,7 @@ void SC_StopAtsCmd_Test_NoRunningAts(void)
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 99;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -385,7 +385,7 @@ void SC_KillAts_Test(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_GroundSwitchCmd_Test_Nominal(void)
+void SC_SwitchAtsCmd_Test_Nominal(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
@@ -398,7 +398,7 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SwitchAtsCmd(&UT_CmdBuf.SwitchAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == true,
@@ -409,7 +409,7 @@ void SC_GroundSwitchCmd_Test_Nominal(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
+void SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
@@ -420,7 +420,7 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SwitchAtsCmd(&UT_CmdBuf.SwitchAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -431,7 +431,7 @@ void SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_GroundSwitchCmd_Test_AtpIdle(void)
+void SC_SwitchAtsCmd_Test_AtpIdle(void)
 {
     CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
 
@@ -441,7 +441,7 @@ void SC_GroundSwitchCmd_Test_AtpIdle(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState  = 99;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_GroundSwitchCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SwitchAtsCmd(&UT_CmdBuf.SwitchAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -720,7 +720,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
@@ -759,7 +759,7 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -779,7 +779,7 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -810,7 +810,7 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
@@ -832,13 +832,13 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = true;
+    UT_CmdBuf.ContinueAtsOnFailureCmd.Payload.ContinueState = true;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.ContinueAtsOnFailureCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == true,
@@ -854,13 +854,13 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = false;
+    UT_CmdBuf.ContinueAtsOnFailureCmd.Payload.ContinueState = false;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.ContinueAtsOnFailureCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false,
@@ -876,13 +876,13 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_SetContinueAtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.SetContinueAtsOnFailureCmd.Payload.ContinueState = 99;
+    UT_CmdBuf.ContinueAtsOnFailureCmd.Payload.ContinueState = 99;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.ContinueAtsOnFailureCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -904,12 +904,12 @@ void SC_AppendAtsCmd_Test_Nominal(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                  = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
-    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount         = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AppendCmdArg == 1, "SC_OperData.HkPacket.Payload.AppendCmdArg == 1");
@@ -931,7 +931,7 @@ void SC_AppendAtsCmd_Test_InvalidAtsId(void)
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -952,7 +952,7 @@ void SC_AppendAtsCmd_Test_InvalidAtsIdZero(void)
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -970,12 +970,12 @@ void SC_AppendAtsCmd_Test_AtsTableEmpty(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
-    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                  = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount         = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -993,12 +993,12 @@ void SC_AppendAtsCmd_Test_AppendTableEmpty(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
-    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 0;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                  = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount         = 0;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -1016,14 +1016,14 @@ void SC_AppendAtsCmd_Test_NoRoomForAppendInAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                          = 1;
-    SC_OperData.HkPacket.Payload.AppendEntryCount                 = 1;
+    UT_CmdBuf.AppendAtsCmd.Payload.AtsId                  = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount         = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize          = SC_ATS_BUFF_SIZE;
     SC_AppData.AppendWordCount                            = SC_ATS_BUFF_SIZE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -1051,10 +1051,10 @@ void UtTest_Setup(void)
                "SC_BeginAts_Test_AllCommandsSkipped");
     UtTest_Add(SC_BeginAts_Test_InvalidAtsIndex, SC_Test_Setup, SC_Test_TearDown, "SC_BeginAts_Test_InvalidAtsIndex");
     UtTest_Add(SC_KillAts_Test, SC_Test_Setup, SC_Test_TearDown, "SC_KillAts_Test");
-    UtTest_Add(SC_GroundSwitchCmd_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_GroundSwitchCmd_Test_Nominal");
-    UtTest_Add(SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded, SC_Test_Setup, SC_Test_TearDown,
-               "SC_GroundSwitchCmd_Test_DestinationAtsNotLoaded");
-    UtTest_Add(SC_GroundSwitchCmd_Test_AtpIdle, SC_Test_Setup, SC_Test_TearDown, "SC_GroundSwitchCmd_Test_AtpIdle");
+    UtTest_Add(SC_SwitchAtsCmd_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_SwitchAtsCmd_Test_Nominal");
+    UtTest_Add(SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded, SC_Test_Setup, SC_Test_TearDown,
+               "SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded");
+    UtTest_Add(SC_SwitchAtsCmd_Test_AtpIdle, SC_Test_Setup, SC_Test_TearDown, "SC_SwitchAtsCmd_Test_AtpIdle");
     UtTest_Add(SC_ServiceSwitchPend_Test_NominalA, SC_Test_Setup, SC_Test_TearDown,
                "SC_ServiceSwitchPend_Test_NominalA");
     UtTest_Add(SC_ServiceSwitchPend_Test_NominalB, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -233,7 +233,8 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
@@ -280,7 +281,8 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_DISTRIB,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
@@ -330,7 +332,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
@@ -382,7 +385,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
@@ -434,7 +438,8 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
@@ -467,7 +472,8 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED,
                   "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
@@ -501,7 +507,8 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
     UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED,
                   "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED");
@@ -534,7 +541,8 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ERR_EID);
@@ -841,18 +849,18 @@ void SC_SendHkPacket_Test(void)
     SC_OperData.HkPacket.Payload.LastRtsErrCmd            = 12;
     SC_OperData.HkPacket.Payload.AppendCmdArg             = 13;
     SC_OperData.HkPacket.Payload.AppendEntryCount         = 14;
-    SC_AppData.AppendWordCount                    = 15;
+    SC_AppData.AppendWordCount                            = 15;
     SC_OperData.HkPacket.Payload.AppendLoadCount          = 16;
-    SC_OperData.AtsInfoTblAddr[0].AtsSize         = 0;
-    SC_OperData.AtsInfoTblAddr[1].AtsSize         = 0;
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber        = 17;
-    SC_OperData.AtsCtrlBlckAddr->AtpState         = 18;
-    SC_OperData.AtsCtrlBlckAddr->CmdNumber        = 19;
-    SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag   = 0;
-    SC_AppData.NextCmdTime[0]                     = 0;
-    SC_AppData.NextCmdTime[1]                     = 0;
-    SC_OperData.RtsCtrlBlckAddr->NumRtsActive     = 20;
-    SC_OperData.RtsCtrlBlckAddr->RtsNumber        = 21;
+    SC_OperData.AtsInfoTblAddr[0].AtsSize                 = 0;
+    SC_OperData.AtsInfoTblAddr[1].AtsSize                 = 0;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber                = 17;
+    SC_OperData.AtsCtrlBlckAddr->AtpState                 = 18;
+    SC_OperData.AtsCtrlBlckAddr->CmdNumber                = 19;
+    SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag           = 0;
+    SC_AppData.NextCmdTime[0]                             = 0;
+    SC_AppData.NextCmdTime[1]                             = 0;
+    SC_OperData.RtsCtrlBlckAddr->NumRtsActive             = 20;
+    SC_OperData.RtsCtrlBlckAddr->RtsNumber                = 21;
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
 
     for (i = 0; i < SC_NUMBER_OF_RTS - 1; i++)
@@ -864,8 +872,9 @@ void SC_SendHkPacket_Test(void)
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].DisabledFlag = 0;
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].RtsStatus    = 0;
 
-    LastRtsHkIndex =
-        sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus) / sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus[0]) - 1;
+    LastRtsHkIndex = sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus) /
+                         sizeof(SC_OperData.HkPacket.Payload.RtsExecutingStatus[0]) -
+                     1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_SendHkPacket());
@@ -873,7 +882,8 @@ void SC_SendHkPacket_Test(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 2, "SC_OperData.HkPacket.Payload.CmdCtr == 2");
-    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3,
+                  "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 3");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 4, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 4");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 5, "SCSC_OperData.HkPacket.Payload.AtsCmdCtr == 5");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 6, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 6");
@@ -884,8 +894,10 @@ void SC_SendHkPacket_Test(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrSeq == 11, "SC_OperData.HkPacket.Payload.LastRtsErrSeq == 11");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastRtsErrCmd == 12, "SC_OperData.HkPacket.Payload.LastRtsErrCmd == 12");
     UtAssert_True(SC_OperData.HkPacket.Payload.AppendCmdArg == 13, "SC_OperData.HkPacket.Payload.AppendCmdArg == 13");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 14, "SC_OperData.HkPacket.Payload.AppendEntryCount == 14");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 16, "SC_OperData.HkPacket.Payload.AppendLoadCount == 16");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 14,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 14");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 16,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 16");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtpFreeBytes[0] ==
                       (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
                           (SC_OperData.AtsInfoTblAddr[0].AtsSize * SC_BYTES_IN_WORD),
@@ -924,63 +936,10 @@ void SC_SendHkPacket_Test(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_CmdMID(void)
-{
-    /**
-     **  Test case: SC_CMD_MID
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_NOOP_INF_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-}
-
 void SC_ProcessRequest_Test_HkMID(void)
 {
-    /**
-     **  Test case: SC_SEND_HK_MID
-     **/
-
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
-{
-    /**
-     **  Test case: SC_SEND_HK_MID
-     **/
-
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SendHkCmd(&UT_CmdBuf.SendHkCmd));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -988,23 +947,13 @@ void SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength(void)
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
 {
-    /**
-     **  Test case: SC_SEND_HK_MID
-     **/
-
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-
     SC_AppData.AutoStartRTS = 1;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SendHkCmd(&UT_CmdBuf.SendHkCmd));
 
     /* Verify results */
-    UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
+    UtAssert_UINT32_EQ(SC_AppData.AutoStartRTS, 0);
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1012,117 +961,69 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
 
 void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 {
-    /**
-     **  Test case: SC_SEND_HK_MID
-     **/
-
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-
     SC_AppData.AutoStartRTS                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS - 1].RtsStatus = SC_LOADED;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SendHkCmd(&UT_CmdBuf.SendHkCmd));
 
     /* Verify results */
-    UtAssert_True(SC_AppData.AutoStartRTS == 0, "SC_AppData.AutoStartRTS == 0");
+    UtAssert_UINT32_EQ(SC_AppData.AutoStartRTS, 0);
     UtAssert_BOOL_FALSE(SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS].DisabledFlag);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_1HzWakeupNONE(void)
+void SC_ProcessRequest_Test_OneHzWakeupNONE(void)
 {
-    /**
-     **  Test case: SC_1HZ_WAKEUP_MID with SC_AppData.NextProcNumber == SC_NONE
-     **/
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
     SC_AppData.NextProcNumber                   = SC_NONE;
     SC_AppData.NextCmdTime[SC_ATP]              = 0;
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_1HzWakeupNoSwitchPending(void)
+void SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending(void)
 {
-    /**
-     **  Test case: SC_1HZ_WAKEUP_MID with SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false
-     **/
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
     SC_AppData.NextProcNumber                   = SC_NONE;
     SC_AppData.NextCmdTime[SC_ATP]              = 0;
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime(void)
+void SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime(void)
 {
-    /**
-     **  Test case: SC_1HZ_WAKEUP_MID with a pending ATP command that should not execute yet
-     **/
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
     SC_AppData.NextProcNumber                   = SC_ATP;
     SC_AppData.NextCmdTime[SC_ATP]              = 1000;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
+void SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime(void)
 {
-    /**
-     **  Test case: SC_1HZ_WAKEUP_MID with a pending RTP command that needs to execute immediately
-     **/
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
     SC_AtsEntryHeader_t *Entry;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     /* required to exit processing loop after 2 iterations */
     /* second iteration tests "IsThereAnotherCommandToExecute" */
@@ -1145,25 +1046,15 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime(void)
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
+void SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds(void)
 {
-    /**
-     **  Test case: SC_1HZ_WAKEUP_MID with a pending RTP command that needs to execute immediately, but too many
-     *commands are being sent at once
-     **/
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
-
     SC_AppData.EnableHeaderUpdate = true;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     SC_AppData.NextProcNumber             = SC_RTP;
     SC_AppData.NextCmdTime[SC_RTP]        = 0;
@@ -1172,55 +1063,18 @@ void SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds(void)
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.NumCmdsSec == 0, "SC_OperData.NumCmdsSec == 0");
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_ProcessRequest_Test_MIDError(void)
-{
-    /**
-     **  Test case: SC_MID_ERR_EID
-     **/
-
-    CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "CmdErrCtr == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_MID_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-}
-
 void SC_ProcessCommand_Test_NoOp(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_NoopCmd(&UT_CmdBuf.NoopCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -1230,52 +1084,10 @@ void SC_ProcessCommand_Test_NoOp(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_ProcessCommand_Test_NoOpNoVerifyCmdLength(void)
-{
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
 void SC_ProcessCommand_Test_ResetCounters(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_RESET_COUNTERS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ResetCountersCmd(&UT_CmdBuf.ResetCountersCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
@@ -1291,317 +1103,115 @@ void SC_ProcessCommand_Test_ResetCounters(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength(void)
-{
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_RESET_COUNTERS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
 void SC_ProcessCommand_Test_StartAts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     UT_CmdBuf.StartAtsCmd.Payload.AtsId = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_StopAts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_StartRts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_StopRts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.StopRtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_DisableRts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.DisableRtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_EnableRts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.EnableRtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_SwitchAts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_SWITCH_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_SwitchAtsCmd(&UT_CmdBuf.SwitchAtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_JumpAts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_ContinueAtsOnFailure(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.ContinueAtsOnFailureCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_AppendAts(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_AppendAtsCmd(&UT_CmdBuf.AppendAtsCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAtsTableNominal(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
 
     /* Set to reach "SC_LoadAts(ArrayIndex)" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
 
     /* Set to generate error message SC_TABLE_MANAGE_ATS_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_ATS_ERR_EID);
@@ -1610,33 +1220,19 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressError(void)
 
 void SC_ProcessCommand_Test_TableManageAtsTableID(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
 
     /* test TableID >= SC_TBL_ID_ATS_0 */
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = 0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = 0;
 
     /* Set to reach "SC_LoadAts(ArrayIndex)" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1655,31 +1251,17 @@ void SC_ProcessCommand_Test_TableManageAtsTable_InvalidIndex(void)
 
 void SC_ProcessCommand_Test_TableManageAtsTableGetAddressNeverLoaded(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1695,22 +1277,16 @@ void SC_ProcessCommand_Test_TableManageAtsTableGetAddressSuccess(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_0;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1726,51 +1302,30 @@ void SC_ProcessCommand_Test_TableManageAppendTableNominal(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_APPEND;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_APPEND;
 
     /* Set to reach "SC_UpdateAppend()" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAppendTableGetAddressError(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_APPEND;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_APPEND;
 
     /* Set to generate error message SC_TABLE_MANAGE_APPEND_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_APPEND_ERR_EID);
@@ -1788,22 +1343,16 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressNeverLoaded(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_APPEND;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_APPEND;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1819,78 +1368,42 @@ void SC_ProcessCommand_Test_TableManageAppendTableGetAddressSuccess(void)
      **/
 
     SC_AtsEntryHeader_t *Entry;
-    CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t    FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
 
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AppendTblAddr;
     Entry->CmdNumber = 0;
 
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_APPEND;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_APPEND;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageRtsTableNominal(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
     /* Set to reach "SC_LoadRts(ArrayIndex)" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
     /* Set to generate error message SC_TABLE_MANAGE_RTS_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_RTS_ERR_EID);
@@ -1899,29 +1412,14 @@ void SC_ProcessCommand_Test_TableManageRtsTableGetAddressError(void)
 
 void SC_ProcessCommand_Test_TableManageRtsTableID(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
     /* test TableID >= SC_TBL_ID_RTS_0 */
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = 0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = 0;
 
     /* Set to reach "SC_LoadRts(ArrayIndex)" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
@@ -1940,204 +1438,84 @@ void SC_ProcessCommand_Test_TableManageRtsTable_InvalidIndex(void)
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressNeverLoaded(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageRtsTableGetAddressSuccess(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTS_0;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_SUCCESS);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageRtsInfo(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTS_INFO;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTS_INFO;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageRtpCtrl(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_RTP_CTRL;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_RTP_CTRL;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAtsInfo(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_INFO;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_INFO;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAtpCtrl(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATP_CTRL;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATP_CTRL;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageAtsCmdStatus(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = SC_TBL_ID_ATS_CMD_0;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = SC_TBL_ID_ATS_CMD_0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
-    UT_CmdBuf.NotifyCmd.Payload.Parameter = 999;
+    UT_CmdBuf.ManageTableCmd.Payload.Parameter = 999;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_ManageTableCmd(&UT_CmdBuf.ManageTableCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_TABLE_MANAGE_ID_ERR_EID);
@@ -2146,406 +1524,34 @@ void SC_ProcessCommand_Test_TableManageInvalidTableID(void)
 
 void SC_ProcessCommand_Test_StartRtsGrp(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_StopRtsGrp(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_DisableRtsGrp(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
 }
 
 void SC_ProcessCommand_Test_EnableRtsGrp(void)
 {
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDefaultReturnValue(UT_KEY(SC_VerifyCmdLength), true);
-
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* This function is already verified to work correctly in another file, so no verifications here. */
-}
-
-void SC_ProcessCommand_Test_StartAtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_StopAtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_StartRtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_StopRtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_DisableRtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_EnableRtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_GroundSwitchInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_SWITCH_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_JumpAtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_ContinueAtsOnFailureInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_AppendAtsInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_TableManageInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_StartRtsGrpInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_StopRtsGrpInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_DisableRtsGrpInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_EnableRtsGrpInvalidCmdLength(void)
-{
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_GRP_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDeferredRetcode(UT_KEY(SC_VerifyCmdLength), 1, false);
-
-    /* Execute the function being tested */
-    SC_ProcessCommand(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessCommand_Test_InvalidCmdError(void)
-{
-    /**
-     **  Note: This test does not follow the standard test guideline to only test what's directly in the
-     *function-under-test.
-     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
-     *to
-     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
-     **/
-
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = 99;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "CmdErrCtr == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INVLD_CMD_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 /* Unreachable branches in sc_cmds.c SC_ProcessAtpCmd:236, 274, 310.
@@ -2594,32 +1600,24 @@ void UtTest_Setup(void)
     UtTest_Add(SC_ProcessRtpCommand_Test_RtsStatus, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRtpCommand_Test_RtsStatus");
     UtTest_Add(SC_SendHkPacket_Test, SC_Test_Setup, SC_Test_TearDown, "SC_SendHkPacket_Test");
-    UtTest_Add(SC_ProcessRequest_Test_CmdMID, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_CmdMID");
     UtTest_Add(SC_ProcessRequest_Test_HkMID, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_HkMID");
-    UtTest_Add(SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_HkMIDNoVerifyCmdLength");
     UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRts, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_HkMIDAutoStartRts");
     UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded");
-    UtTest_Add(SC_ProcessRequest_Test_1HzWakeupNONE, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_1HzWakeupNONE");
-    UtTest_Add(SC_ProcessRequest_Test_1HzWakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_1HzWakeupNoSwitchPending");
-    UtTest_Add(SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_1HzWakeupAtpNotExecutionTime");
-    UtTest_Add(SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_1HzWakeupRtpExecutionTime");
-    UtTest_Add(SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_1HzWakeupRtpExecutionTimeTooManyCmds");
-    UtTest_Add(SC_ProcessRequest_Test_MIDError, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_MIDError");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNONE, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupNONE");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds");
     UtTest_Add(SC_ProcessCommand_Test_NoOp, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessCommand_Test_NoOp");
-    UtTest_Add(SC_ProcessCommand_Test_NoOpNoVerifyCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_NoOpNoVerifyCmdLength");
     UtTest_Add(SC_ProcessCommand_Test_ResetCounters, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_ResetCounters");
-    UtTest_Add(SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_ResetCountersNoVerifyCmdLength");
     UtTest_Add(SC_ProcessCommand_Test_StartAts, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessCommand_Test_StartAts");
     UtTest_Add(SC_ProcessCommand_Test_StopAts, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessCommand_Test_StopAts");
     UtTest_Add(SC_ProcessCommand_Test_StartRts, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessCommand_Test_StartRts");
@@ -2682,36 +1680,4 @@ void UtTest_Setup(void)
                "SC_ProcessCommand_Test_DisableRtsGrp");
     UtTest_Add(SC_ProcessCommand_Test_EnableRtsGrp, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_EnableRtsGrp");
-    UtTest_Add(SC_ProcessCommand_Test_StartAtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StartAtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_StopAtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StopAtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_StartRtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StartRtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_StopRtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StopRtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_DisableRtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_DisableRtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_EnableRtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_EnableRtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_GroundSwitchInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_GroundSwitchInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_JumpAtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_JumpAtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_ContinueAtsOnFailureInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_ContinueAtsOnFailureInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_AppendAtsInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_AppendAtsInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_TableManageInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_TableManageInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_StartRtsGrpInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StartRtsGrpInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_StopRtsGrpInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_StopRtsGrpInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_DisableRtsGrpInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_DisableRtsGrpInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_EnableRtsGrpInvalidCmdLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_EnableRtsGrpInvalidCmdLength");
-    UtTest_Add(SC_ProcessCommand_Test_InvalidCmdError, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessCommand_Test_InvalidCmdError");
 }

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -1,0 +1,1028 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,924-1, and identified as “Core Flight
+ * System (cFS) Stored Command Application version 3.1.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "sc_cmds.h"
+#include "sc_dispatch.h"
+#include "sc_atsrq.h"
+#include "sc_rtsrq.h"
+#include "sc_state.h"
+#include "sc_events.h"
+#include "sc_msgids.h"
+#include "sc_test_utils.h"
+#include "sc_utils.h"
+#include "sc_version.h"
+#include "cfe_tbl_msg.h"
+#include <time.h>
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+void UT_SC_Dispatch_MsgSizeHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CFE_MSG_Size_t *Size            = UT_Hook_GetArgValueByName(Context, "Size", CFE_MSG_Size_t *);
+    CFE_MSG_Size_t *TestCaseMsgSize = UserObj;
+
+    *Size = *TestCaseMsgSize;
+}
+
+void UT_SC_Dispatch_MsgIdHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CFE_SB_MsgId_t *MsgId         = UT_Hook_GetArgValueByName(Context, "MsgId", CFE_SB_MsgId_t *);
+    CFE_SB_MsgId_t *TestCaseMsgId = UserObj;
+
+    *MsgId = *TestCaseMsgId;
+}
+
+void UT_SC_Dispatch_FcnCodeHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CFE_MSG_FcnCode_t *FcnCode         = UT_Hook_GetArgValueByName(Context, "FcnCode", CFE_MSG_FcnCode_t *);
+    CFE_MSG_FcnCode_t *TestCaseFcnCode = UserObj;
+
+    *FcnCode = *TestCaseFcnCode;
+}
+
+void UT_SC_Dispatch_SetMsgSize(CFE_MSG_Size_t MsgSize)
+{
+    static CFE_MSG_Size_t TestCaseMsgSize;
+
+    TestCaseMsgSize = MsgSize;
+
+    UT_SetHandlerFunction(UT_KEY(CFE_MSG_GetSize), UT_SC_Dispatch_MsgSizeHandler, &TestCaseMsgSize);
+}
+
+void UT_SC_Dispatch_SetMsgId(CFE_SB_MsgId_t MsgId)
+{
+    static CFE_SB_MsgId_t TestCaseMsgId;
+
+    TestCaseMsgId = MsgId;
+
+    UT_SetHandlerFunction(UT_KEY(CFE_MSG_GetMsgId), UT_SC_Dispatch_MsgIdHandler, &TestCaseMsgId);
+}
+
+void UT_SC_Dispatch_SetFcnCode(CFE_MSG_FcnCode_t FcnCode)
+{
+    static CFE_MSG_FcnCode_t TestCaseFcnCode;
+
+    TestCaseFcnCode = FcnCode;
+
+    UT_SetHandlerFunction(UT_KEY(CFE_MSG_GetFcnCode), UT_SC_Dispatch_FcnCodeHandler, &TestCaseFcnCode);
+}
+
+void SC_VerifyCmdLength_Test_Nominal(void)
+{
+    SC_NoopCmd_t      CmdPacket;
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
+    size_t            MsgSize   = sizeof(CmdPacket);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(MsgSize);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, sizeof(CmdPacket)));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 0);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+}
+
+void SC_VerifyCmdLength_Test_LenError(void)
+{
+    SC_NoopCmd_t      CmdPacket;
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
+    size_t            MsgSize   = sizeof(CmdPacket);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(MsgSize);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
+{
+    SC_NoopCmd_t      CmdPacket;
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+    CFE_MSG_FcnCode_t FcnCode   = 0;
+    size_t            MsgSize   = sizeof(CmdPacket);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(MsgSize);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void SC_ProcessRequest_Test_CmdNominal(void)
+{
+    /**
+     **  Test case: SC_CMD_MID
+     **/
+
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_NoopCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_NoopCmd, 1);
+}
+
+void SC_ProcessRequest_Test_SendHkNominal(void)
+{
+    /**
+     **  Test case: SC_SEND_HK_MID
+     **/
+
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(0);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_SendHkCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(SC_SendHkCmd, 1);
+}
+
+void SC_ProcessRequest_Test_SendHkCmdInvalidLength(void)
+{
+    /**
+     **  Test case: SC_SEND_HK_MID
+     **/
+
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(0);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(SC_SendHkCmd, 0);
+}
+
+void SC_ProcessRequest_Test_OneHzWakeupNominal(void)
+{
+    /**
+     **  Test case: SC_1HZ_WAKEUP_MID
+     **/
+
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(0);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_OneHzWakeupCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(SC_OneHzWakeupCmd, 1);
+}
+
+void SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength(void)
+{
+    /**
+     **  Test case: SC_1HZ_WAKEUP_MID
+     **/
+
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(0);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(SC_OneHzWakeupCmd, 0);
+}
+
+void SC_ProcessRequest_Test_MIDError(void)
+{
+    /**
+     **  Test case: SC_MID_ERR_EID
+     **/
+
+    CFE_SB_MsgId_t TestMsgId = SC_UT_MID_1;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_MID_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void SC_ProcessCommand_Test_NoopCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(SC_NoopCmd, 0);
+}
+
+void SC_ProcessCommand_Test_ResetCounterCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_RESET_COUNTERS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+    UtAssert_STUB_COUNT(SC_ResetCountersCmd, 0);
+}
+
+void SC_ProcessCommand_Test_StartAtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_StopAtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_StartRtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_StopRtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_DisableRtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_EnableRtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_SwitchAtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_SWITCH_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_JumpAtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_AppendAtsCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_TableManageCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_StartRtsGrpCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_StopRtsGrpCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_DisableRtsGrpCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_EnableRtsGrpCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
+}
+
+void SC_ProcessCommand_Test_NoopCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_NoopCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_NoopCmd, 1);
+}
+
+void SC_ProcessCommand_Test_ResetCounterCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_RESET_COUNTERS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_ResetCountersCmd_t));
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_ResetCountersCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StartAtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StartAtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StartAtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StopAtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StopAtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StopAtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StartRtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StartRtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StartRtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StopRtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StopRtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StopRtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_DisableRtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_DisableRtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_DisableRtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_EnableRtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_EnableRtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_EnableRtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_SwitchAtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_SWITCH_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_SwitchAtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_SwitchAtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_JumpAtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_JUMP_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_JumpAtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_JumpAtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_ATS_ON_FAILURE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_ContinueAtsOnFailureCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_ContinueAtsOnFailureCmd, 1);
+}
+
+void SC_ProcessCommand_Test_AppendAtsCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_APPEND_ATS_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_AppendAtsCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_AppendAtsCmd, 1);
+}
+
+void SC_ProcessCommand_Test_TableManageCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_MANAGE_TABLE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_ManageTableCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_ManageTableCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StartRtsGrpCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_START_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StartRtsGrpCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StartRtsGrpCmd, 1);
+}
+
+void SC_ProcessCommand_Test_StopRtsGrpCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_STOP_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_StopRtsGrpCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_StopRtsGrpCmd, 1);
+}
+
+void SC_ProcessCommand_Test_DisableRtsGrpCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_DISABLE_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_DisableRtsGrpCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_DisableRtsGrpCmd, 1);
+}
+
+void SC_ProcessCommand_Test_EnableRtsGrpCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_ENABLE_RTS_GRP_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_EnableRtsGrpCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_EnableRtsGrpCmd, 1);
+}
+
+void SC_ProcessCommand_Test_InvalidCmdError(void)
+{
+    /**
+     **  Note: This test does not follow the standard test guideline to only test what's directly in the
+     *function-under-test.
+     **  Since the code for reaching each branch in SC_ProcessCommand is so trivial and non-verifiable, it was decided
+     *to
+     **  combine the tests for each command with the tests for reaching the command from SC_ProcessCommand.
+     **/
+
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = 99;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessCommand(&UT_CmdBuf.Buf));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INVLD_CMD_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+/* Unreachable branches in sc_cmds.c SC_ProcessAtpCmd:236, 274, 310.
+   There are only 2 ATS IDs defined, invalid IDs are already handled. */
+
+void UtTest_Setup(void)
+{
+    UtTest_Add(SC_VerifyCmdLength_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_VerifyCmdLength_Test_Nominal");
+    UtTest_Add(SC_VerifyCmdLength_Test_LenError, SC_Test_Setup, SC_Test_TearDown, "SC_VerifyCmdLength_Test_LenError");
+    UtTest_Add(SC_VerifyCmdLength_Test_LenErrorNotMID, SC_Test_Setup, SC_Test_TearDown,
+               "SC_VerifyCmdLength_Test_LenErrorNotMID");
+
+    UtTest_Add(SC_ProcessRequest_Test_CmdNominal, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_CmdNominal");
+    UtTest_Add(SC_ProcessRequest_Test_SendHkNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_SendHkNominal");
+    UtTest_Add(SC_ProcessRequest_Test_SendHkCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_SendHkCmdInvalidLength");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupNominal");
+    UtTest_Add(SC_ProcessRequest_Test_MIDError, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_MIDError");
+#ifdef jphfix
+    UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRts, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_HkMIDAutoStartRts");
+    UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNONE, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupNONE");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds");
+#endif
+
+    UtTest_Add(SC_ProcessCommand_Test_NoopCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_NoopCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_ResetCounterCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ResetCounterCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StartAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartAtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StopAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopAtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StartRtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartRtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StopRtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopRtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_DisableRtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_DisableRtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_EnableRtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_EnableRtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_SwitchAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_SwitchAtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_JumpAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_JumpAtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_AppendAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_AppendAtsCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_TableManageCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_TableManageCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StartRtsGrpCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartRtsGrpCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_StopRtsGrpCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopRtsGrpCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_DisableRtsGrpCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_DisableRtsGrpCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_EnableRtsGrpCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_EnableRtsGrpCmdNominal");
+
+    UtTest_Add(SC_ProcessCommand_Test_NoopCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_NoopCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_ResetCounterCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ResetCounterCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StartAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartAtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StopAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopAtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StartRtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartRtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StopRtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopRtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_DisableRtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_DisableRtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_EnableRtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_EnableRtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_SwitchAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_SwitchAtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_JumpAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_JumpAtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_AppendAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_AppendAtsCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_TableManageCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_TableManageCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StartRtsGrpCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StartRtsGrpCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_StopRtsGrpCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_StopRtsGrpCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_DisableRtsGrpCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_DisableRtsGrpCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_EnableRtsGrpCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_EnableRtsGrpCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_InvalidCmdError, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_InvalidCmdError");
+}

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -65,7 +65,7 @@ CFE_TIME_Compare_t UT_SC_Insert_CompareHookAgreaterthanB(void *UserObj, int32 St
 void SC_LoadAts_Test_Nominal(void)
 {
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    size_t               MsgSize   = sizeof(SC_NoArgsCmd_t);
+    size_t               MsgSize   = sizeof(SC_NoopCmd_t);
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
 
@@ -383,7 +383,7 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 void SC_LoadAts_Test_CmdNotEmpty(void)
 {
     CFE_SB_MsgId_t       TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    size_t               MsgSize   = sizeof(SC_NoArgsCmd_t);
+    size_t               MsgSize   = sizeof(SC_NoopCmd_t);
     SC_AtsEntryHeader_t *Entry;
     uint8                AtsIndex = 0;
     uint8                EntryLoc;
@@ -905,8 +905,10 @@ void SC_UpdateAppend_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 1, "SC_OperData.HkPacket.Payload.AppendEntryCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 1");
     UtAssert_True(SC_AppData.AppendWordCount == 15, "SC_AppData.AppendWordCount == 15");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -938,8 +940,10 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 30, "SC_OperData.HkPacket.Payload.AppendEntryCount == 30");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 30,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 30");
     UtAssert_True(SC_AppData.AppendWordCount == 1980, "SC_AppData.AppendWordCount == 1980");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -964,8 +968,10 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -990,8 +996,10 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1029,8 +1037,10 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 31, "SC_OperData.HkPacket.Payload.AppendEntryCount == 31");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 31,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 31");
     UtAssert_True(SC_AppData.AppendWordCount == 2000, "SC_AppData.AppendWordCount == 2000");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1057,8 +1067,10 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1085,8 +1097,10 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1, "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0, "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 1,
+                  "SC_OperData.HkPacket.Payload.AppendLoadCount == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.AppendEntryCount == 0,
+                  "SC_OperData.HkPacket.Payload.AppendEntryCount == 0");
     UtAssert_True(SC_AppData.AppendWordCount == 0, "SC_AppData.AppendWordCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
@@ -1105,7 +1119,7 @@ void SC_ProcessAppend_Test(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.AppendWordCount            = 1;
+    SC_AppData.AppendWordCount                    = 1;
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -1150,7 +1164,7 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.AppendWordCount            = 1;
+    SC_AppData.AppendWordCount                    = 1;
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -1192,7 +1206,7 @@ void SC_ProcessAppend_Test_NotExecuting(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.AppendWordCount            = 1;
+    SC_AppData.AppendWordCount                    = 1;
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -1233,7 +1247,7 @@ void SC_ProcessAppend_Test_AtsNumber(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[AtsIndex][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.AppendWordCount            = 1;
+    SC_AppData.AppendWordCount                    = 1;
     SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -53,19 +53,19 @@ void SC_StartRtsCmd_Test_Nominal(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
      * big" */
-    MsgSize = sizeof(SC_RtsCmd_t);
+    MsgSize = sizeof(UT_CmdBuf.StartRtsCmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -91,9 +91,9 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     uint8                RtsIndex;
     size_t               MsgSize;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS;
 
-    RtsIndex = UT_CmdBuf.RtsCmd.Payload.RtsId - 1;
+    RtsIndex = UT_CmdBuf.StartRtsCmd.Payload.RtsId - 1;
 
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
@@ -104,12 +104,12 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
      * big" */
-    MsgSize = sizeof(SC_RtsCmd_t);
+    MsgSize = sizeof(UT_CmdBuf.StartRtsCmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -126,7 +126,7 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     /* Handle if SC_LAST_RTS_WITH_EVENTS is the same as SC_NUM_OF_RTS */
-    if (UT_CmdBuf.RtsCmd.Payload.RtsId > SC_LAST_RTS_WITH_EVENTS)
+    if (UT_CmdBuf.DisableRtsCmd.Payload.RtsId > SC_LAST_RTS_WITH_EVENTS)
     {
         UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DBG_EID);
     }
@@ -147,7 +147,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -159,7 +159,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVLD_LEN_ERR_EID);
@@ -175,7 +175,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
@@ -187,7 +187,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVLD_LEN_ERR_EID);
@@ -202,13 +202,13 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_IDLE;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_NOT_LDED_ERR_EID);
@@ -223,13 +223,13 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
     Entry          = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[RtsIndex][0];
     Entry->TimeTag = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_DISABLED_ERR_EID);
@@ -238,10 +238,10 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
 
 void SC_StartRtsCmd_Test_InvalidRtsId(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVALID_ERR_EID);
@@ -250,10 +250,10 @@ void SC_StartRtsCmd_Test_InvalidRtsId(void)
 
 void SC_StartRtsCmd_Test_InvalidRtsIdZero(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 0;
+    UT_CmdBuf.StartRtsCmd.Payload.RtsId = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTS_CMD_INVALID_ERR_EID);
@@ -267,11 +267,11 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -293,11 +293,11 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
 
 void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -308,11 +308,11 @@ void SC_StartRtsGrpCmd_Test_StartRtsGroupError(void)
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -323,11 +323,11 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -338,11 +338,11 @@ void SC_StartRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -353,11 +353,11 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -368,11 +368,11 @@ void SC_StartRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_StartRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -391,11 +391,11 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
@@ -407,7 +407,8 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1,
+                  "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_DISABLED_ERR_EID);
@@ -424,11 +425,11 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StartRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
@@ -442,7 +443,8 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveCtr == 0, "SC_OperData.HkPacket.Payload.RtsActiveCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
+    UtAssert_True(SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1,
+                  "SC_OperData.HkPacket.Payload.RtsActiveErrCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID);
@@ -452,10 +454,10 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 
 void SC_StopRtsCmd_Test_Nominal(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.StopRtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.StopRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -466,10 +468,10 @@ void SC_StopRtsCmd_Test_Nominal(void)
 
 void SC_StopRtsCmd_Test_InvalidRts(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StopRtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsCmd(&UT_CmdBuf.StopRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -480,11 +482,11 @@ void SC_StopRtsCmd_Test_InvalidRts(void)
 
 void SC_StopRtsGrpCmd_Test_Nominal(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -495,11 +497,11 @@ void SC_StopRtsGrpCmd_Test_Nominal(void)
 
 void SC_StopRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -514,11 +516,11 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
@@ -529,11 +531,11 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -544,11 +546,11 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -559,11 +561,11 @@ void SC_StopRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -574,11 +576,11 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -589,11 +591,11 @@ void SC_StopRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_StopRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_StopRtsGrpCmd(&UT_CmdBuf.StopRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -606,10 +608,10 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.DisableRtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.DisableRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -622,10 +624,10 @@ void SC_DisableRtsCmd_Test_Nominal(void)
 
 void SC_DisableRtsCmd_Test_InvalidRtsID(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.DisableRtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsCmd(&UT_CmdBuf.DisableRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -638,11 +640,11 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -655,11 +657,11 @@ void SC_DisableRtsGrpCmd_Test_Nominal(void)
 
 void SC_DisableRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -670,11 +672,11 @@ void SC_DisableRtsGrpCmd_Test_Error(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -685,11 +687,11 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -700,11 +702,11 @@ void SC_DisableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -715,11 +717,11 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -730,11 +732,11 @@ void SC_DisableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_DisableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -749,11 +751,11 @@ void SC_DisableRtsGrpCmd_Test_DisabledFlag(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.DisableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_DisableRtsGrpCmd(&UT_CmdBuf.DisableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == true,
@@ -768,10 +770,10 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
 
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 1;
+    UT_CmdBuf.EnableRtsCmd.Payload.RtsId = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.EnableRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
@@ -784,10 +786,10 @@ void SC_EnableRtsCmd_Test_Nominal(void)
 
 void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.EnableRtsCmd.Payload.RtsId = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.EnableRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -798,10 +800,10 @@ void SC_EnableRtsCmd_Test_InvalidRtsID(void)
 
 void SC_EnableRtsCmd_Test_InvalidRtsIDZero(void)
 {
-    UT_CmdBuf.RtsCmd.Payload.RtsId = 0;
+    UT_CmdBuf.EnableRtsCmd.Payload.RtsId = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsCmd(&UT_CmdBuf.EnableRtsCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -814,11 +816,11 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0; /* RtsId - 1 */
 
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,
@@ -831,11 +833,11 @@ void SC_EnableRtsGrpCmd_Test_Nominal(void)
 
 void SC_EnableRtsGrpCmd_Test_Error(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS * 2;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS * 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -846,11 +848,11 @@ void SC_EnableRtsGrpCmd_Test_Error(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -861,11 +863,11 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndex(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 0;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = 0;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -876,11 +878,11 @@ void SC_EnableRtsGrpCmd_Test_FirstRtsIndexZero(void)
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = SC_NUMBER_OF_RTS + 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -891,11 +893,11 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndex(void)
 
 void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 0;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = 0;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -906,11 +908,11 @@ void SC_EnableRtsGrpCmd_Test_LastRtsIndexZero(void)
 
 void SC_EnableRtsGrpCmd_Test_FirstLastRtsIndex(void)
 {
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId = 2;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId  = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId = 2;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId  = 1;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
@@ -925,11 +927,11 @@ void SC_EnableRtsGrpCmd_Test_DisabledFlag(void)
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
     SC_OperData.RtsInfoTblAddr[1].DisabledFlag        = true;
-    UT_CmdBuf.RtsGrpCmd.Payload.FirstRtsId                    = 1;
-    UT_CmdBuf.RtsGrpCmd.Payload.LastRtsId                     = 2;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.FirstRtsId      = 1;
+    UT_CmdBuf.EnableRtsGrpCmd.Payload.LastRtsId       = 2;
 
     /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(SC_EnableRtsGrpCmd(&UT_CmdBuf.EnableRtsGrpCmd));
 
     /* Verify results */
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false,

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -173,8 +173,7 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 
 void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 {
-    SC_RtsEntryHeader_t *Entry;
-    size_t               MsgSize;
+    size_t MsgSize;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -182,10 +181,6 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
-
-    Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[0][0];
-
-    CFE_MSG_Init((CFE_MSG_Message_t *)Entry, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(SC_NoArgsCmd_t));
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
     MsgSize = SC_PACKET_MIN_SIZE;
@@ -219,8 +214,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberZero(void)
 
 void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 {
-    SC_RtsEntryHeader_t *Entry;
-    size_t               MsgSize;
+    size_t MsgSize;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -228,10 +222,6 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_NUMBER_OF_RTS;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
-
-    Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1][0];
-
-    CFE_MSG_Init((CFE_MSG_Message_t *)Entry, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(SC_NoArgsCmd_t));
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
     MsgSize = SC_PACKET_MIN_SIZE;
@@ -251,18 +241,13 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 
 void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 {
-    SC_RtsEntryHeader_t *Entry;
-    size_t               MsgSize;
+    size_t MsgSize;
 
     SC_AppData.NextCmdTime[SC_RTP]                 = 0;
     SC_AppData.CurrentTime                         = 1;
     SC_AppData.NextProcNumber                      = SC_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber         = SC_NUMBER_OF_RTS + 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
-
-    Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1][0];
-
-    CFE_MSG_Init((CFE_MSG_Message_t *)Entry, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(SC_NoArgsCmd_t));
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
     MsgSize = SC_PACKET_MIN_SIZE;
@@ -282,8 +267,7 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 
 void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 {
-    SC_RtsEntryHeader_t *Entry;
-    size_t               MsgSize;
+    size_t MsgSize;
 
     SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
     SC_AppData.CurrentTime                                                           = 1;
@@ -291,10 +275,6 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_NUMBER_OF_RTS;
     SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_IDLE;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
-
-    Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_NUMBER_OF_RTS - 1][0];
-
-    CFE_MSG_Init((CFE_MSG_Message_t *)Entry, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(SC_NoArgsCmd_t));
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
     MsgSize = SC_PACKET_MIN_SIZE;

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -82,69 +82,6 @@ void SC_CompareAbsTime_Test_False(void)
     UtAssert_BOOL_FALSE(SC_CompareAbsTime(AbsTimeTag1, AbsTimeTag2));
 }
 
-void SC_VerifyCmdLength_Test_Nominal(void)
-{
-    SC_NoArgsCmd_t    CmdPacket;
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-    size_t            MsgSize   = sizeof(CmdPacket);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, sizeof(CmdPacket)));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 0, "SC_OperData.HkPacket.Payload.CmdErrCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_VerifyCmdLength_Test_LenError(void)
-{
-    SC_NoArgsCmd_t    CmdPacket;
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
-    CFE_MSG_FcnCode_t FcnCode   = SC_NOOP_CC;
-    size_t            MsgSize   = sizeof(CmdPacket);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-}
-
-void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
-{
-    SC_NoArgsCmd_t    CmdPacket;
-    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_SEND_HK_MID);
-    CFE_MSG_FcnCode_t FcnCode   = 0;
-    size_t            MsgSize   = sizeof(CmdPacket);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_AppendAtsCmd_t), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 0, "SC_OperData.HkPacket.Payload.CmdCtr == 0");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_LEN_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-}
-
 void SC_ToggleAtsIndex_Test(void)
 {
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
@@ -163,9 +100,5 @@ void UtTest_Setup(void)
     UtTest_Add(SC_ComputeAbsTime_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ComputeAbsTime_Test");
     UtTest_Add(SC_CompareAbsTime_Test_True, SC_Test_Setup, SC_Test_TearDown, "SC_CompareAbsTime_Test_True");
     UtTest_Add(SC_CompareAbsTime_Test_False, SC_Test_Setup, SC_Test_TearDown, "SC_CompareAbsTime_Test_False");
-    UtTest_Add(SC_VerifyCmdLength_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_VerifyCmdLength_Test_Nominal");
-    UtTest_Add(SC_VerifyCmdLength_Test_LenError, SC_Test_Setup, SC_Test_TearDown, "SC_VerifyCmdLength_Test_LenError");
-    UtTest_Add(SC_VerifyCmdLength_Test_LenErrorNotMID, SC_Test_Setup, SC_Test_TearDown,
-               "SC_VerifyCmdLength_Test_LenErrorNotMID");
     UtTest_Add(SC_ToggleAtsIndex_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ToggleAtsIndex_Test");
 }

--- a/unit-test/stubs/sc_atsrq_stubs.c
+++ b/unit-test/stubs/sc_atsrq_stubs.c
@@ -31,9 +31,9 @@
  * Generated stub function for SC_AppendAtsCmd()
  * ----------------------------------------------------
  */
-void SC_AppendAtsCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_AppendAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
 }
@@ -60,23 +60,11 @@ bool SC_BeginAts(uint16 AtsIndex, uint16 TimeOffset)
  * Generated stub function for SC_ContinueAtsOnFailureCmd()
  * ----------------------------------------------------
  */
-void SC_ContinueAtsOnFailureCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd, const SC_ContinueAtsOnFailureCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_GroundSwitchCmd()
- * ----------------------------------------------------
- */
-void SC_GroundSwitchCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_GroundSwitchCmd, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(SC_GroundSwitchCmd, Basic, NULL);
 }
 
 /*
@@ -98,9 +86,9 @@ bool SC_InlineSwitch(void)
  * Generated stub function for SC_JumpAtsCmd()
  * ----------------------------------------------------
  */
-void SC_JumpAtsCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_JumpAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
 }
@@ -132,9 +120,9 @@ void SC_ServiceSwitchPend(void)
  * Generated stub function for SC_StartAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StartAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
 }
@@ -144,9 +132,21 @@ void SC_StartAtsCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for SC_StopAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopAtsCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StopAtsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_SwitchAtsCmd()
+ * ----------------------------------------------------
+ */
+void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd)
+{
+    UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
+
+    UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_cmds_stubs.c
+++ b/unit-test/stubs/sc_cmds_stubs.c
@@ -65,14 +65,38 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for SC_NoOpCmd()
+ * Generated stub function for SC_ManageTableCmd()
  * ----------------------------------------------------
  */
-void SC_NoOpCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_NoOpCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_NoOpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_NoopCmd()
+ * ----------------------------------------------------
+ */
+void SC_NoopCmd(const SC_NoopCmd_t *Cmd)
+{
+    UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
+
+    UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_OneHzWakeupCmd()
+ * ----------------------------------------------------
+ */
+void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
+{
+    UT_GenStub_AddParam(SC_OneHzWakeupCmd, const SC_OneHzWakeupCmd_t *, Cmd);
+
+    UT_GenStub_Execute(SC_OneHzWakeupCmd, Basic, NULL);
 }
 
 /*
@@ -84,30 +108,6 @@ void SC_ProcessAtpCmd(void)
 {
 
     UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_ProcessCommand()
- * ----------------------------------------------------
- */
-void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_ProcessRequest()
- * ----------------------------------------------------
- */
-void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
 }
 
 /*
@@ -126,11 +126,23 @@ void SC_ProcessRtpCommand(void)
  * Generated stub function for SC_ResetCountersCmd()
  * ----------------------------------------------------
  */
-void SC_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
+void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_ResetCountersCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_SendHkCmd()
+ * ----------------------------------------------------
+ */
+void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
+{
+    UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
+
+    UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
 }
 
 /*
@@ -142,16 +154,4 @@ void SC_SendHkPacket(void)
 {
 
     UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_TableManageCmd()
- * ----------------------------------------------------
- */
-void SC_TableManageCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_TableManageCmd, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(SC_TableManageCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_dispatch_stubs.c
+++ b/unit-test/stubs/sc_dispatch_stubs.c
@@ -1,0 +1,68 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,924-1, and identified as “Core Flight
+ * System (cFS) Stored Command Application version 3.1.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in sc_dispatch header
+ */
+
+#include "sc_dispatch.h"
+#include "utgenstub.h"
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessCommand()
+ * ----------------------------------------------------
+ */
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ProcessRequest()
+ * ----------------------------------------------------
+ */
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_VerifyCmdLength()
+ * ----------------------------------------------------
+ */
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
+{
+    UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
+
+    UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
+    UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
+
+    UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
+}

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -43,9 +43,9 @@ void SC_AutoStartRts(uint16 RtsNumber)
  * Generated stub function for SC_DisableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_DisableRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
 }
@@ -55,9 +55,9 @@ void SC_DisableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_DisableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
 }
@@ -67,9 +67,9 @@ void SC_DisableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_EnableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_EnableRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
 }
@@ -79,9 +79,9 @@ void SC_EnableRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_EnableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
 }
@@ -103,9 +103,9 @@ void SC_KillRts(uint16 RtsIndex)
  * Generated stub function for SC_StartRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StartRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
 }
@@ -115,9 +115,9 @@ void SC_StartRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_StartRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StartRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
 }
@@ -127,9 +127,9 @@ void SC_StartRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_StopRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StopRtsCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
 }
@@ -139,9 +139,9 @@ void SC_StopRtsCmd(const CFE_SB_Buffer_t *CmdPacket)
  * Generated stub function for SC_StopRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsGrpCmd(const CFE_SB_Buffer_t *CmdPacket)
+void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
 {
-    UT_GenStub_AddParam(SC_StopRtsGrpCmd, const CFE_SB_Buffer_t *, CmdPacket);
+    UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
 
     UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_utils_stubs.c
+++ b/unit-test/stubs/sc_utils_stubs.c
@@ -99,20 +99,3 @@ uint16 SC_ToggleAtsIndex(void)
 
     return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, uint16);
 }
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_VerifyCmdLength()
- * ----------------------------------------------------
- */
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
-{
-    UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
-
-    UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
-    UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
-
-    UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
-}

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -29,6 +29,7 @@
  */
 
 #include "sc_app.h"
+#include "sc_msg.h"
 #include "utstubs.h"
 #include "cfe_msgids.h"
 #include "cfe_tbl_msg.h"
@@ -57,15 +58,26 @@ extern CFE_ES_WriteToSysLog_context_t context_CFE_ES_WriteToSysLog;
 /* Command buffer typedef for any handler */
 typedef union
 {
-    CFE_SB_Buffer_t                 Buf;
-    SC_NoArgsCmd_t                  NoArgsCmd;
-    SC_StartAtsCmd_t                StartAtsCmd;
-    SC_RtsCmd_t                     RtsCmd;
-    SC_JumpAtsCmd_t                 JumpAtsCmd;
-    SC_SetContinueAtsOnFailureCmd_t SetContinueAtsOnFailureCmd;
-    SC_AppendAtsCmd_t               AppendAtsCmd;
-    SC_RtsGrpCmd_t                  RtsGrpCmd;
-    CFE_TBL_NotifyCmd_t             NotifyCmd; /* SC subscribes to the table notify command */
+    CFE_SB_Buffer_t              Buf;
+    SC_SendHkCmd_t               SendHkCmd;
+    SC_OneHzWakeupCmd_t          OneHzWakeupCmd;
+    SC_NoopCmd_t                 NoopCmd;
+    SC_ResetCountersCmd_t        ResetCountersCmd;
+    SC_StopAtsCmd_t              StopAtsCmd;
+    SC_SwitchAtsCmd_t            SwitchAtsCmd;
+    SC_StartAtsCmd_t             StartAtsCmd;
+    SC_StartRtsCmd_t             StartRtsCmd;
+    SC_StopRtsCmd_t              StopRtsCmd;
+    SC_DisableRtsCmd_t           DisableRtsCmd;
+    SC_EnableRtsCmd_t            EnableRtsCmd;
+    SC_JumpAtsCmd_t              JumpAtsCmd;
+    SC_ContinueAtsOnFailureCmd_t ContinueAtsOnFailureCmd;
+    SC_AppendAtsCmd_t            AppendAtsCmd;
+    SC_ManageTableCmd_t          ManageTableCmd;
+    SC_StartRtsGrpCmd_t          StartRtsGrpCmd;
+    SC_StopRtsGrpCmd_t           StopRtsGrpCmd;
+    SC_DisableRtsGrpCmd_t        DisableRtsGrpCmd;
+    SC_EnableRtsGrpCmd_t         EnableRtsGrpCmd;
 } UT_CmdBuf_t;
 
 extern UT_CmdBuf_t UT_CmdBuf;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Move switch statements to a separate dispatch source file, and update all unit tests accordingly.

All business logic of commands is put into separate command handler functions in sc_cmds.c.  No logic is inside the switch statement, outside of message validation.

Fixes #108

**Testing performed**
Build and run SC and all tests

**Expected behavior changes**
No external/observable behavior change

**System(s) tested on**
Debian

**Additional context**
Intent is to improve code consistency, ease future maintenance, and to match patterns used elsewhere.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
