### PR TITLE
Fix #123, use CFE_MSG_PTR conversion macro

### DIFF
--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -157,7 +157,7 @@ CFE_Status_t SC_AppInit(void)
     SC_AppData.NextCmdTime[SC_RTP] = SC_MAX_TIME;
 
     /* Initialize the SC housekeeping packet */
-    CFE_MSG_Init(&SC_OperData.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(SC_HK_TLM_MID), sizeof(SC_HkTlm_t));
+    CFE_MSG_Init(CFE_MSG_PTR(SC_OperData.HkPacket), CFE_SB_ValueToMsgId(SC_HK_TLM_MID), sizeof(SC_HkTlm_t));
 
     /* Select auto-exec RTS to start during first HK request */
     if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -105,7 +105,7 @@ void SC_ProcessAtpCmd(void)
                 if (!SC_AppData.EnableHeaderUpdate)
                 {
                     /* If header update is NOT enabled, confirm this table entry has a valid checksum already */
-                    CFE_MSG_ValidateChecksum(&EntryPtr->Msg, &ChecksumValid);
+                    CFE_MSG_ValidateChecksum(CFE_MSG_PTR(EntryPtr->Msg), &ChecksumValid);
                 }
                 if (ChecksumValid)
                 {
@@ -127,8 +127,8 @@ void SC_ProcessAtpCmd(void)
                      **  SC immediately executes the switch command.
                      */
 
-                    CFE_MSG_GetMsgId(&EntryPtr->Msg, &MessageID);
-                    CFE_MSG_GetFcnCode(&EntryPtr->Msg, &CommandCode);
+                    CFE_MSG_GetMsgId(CFE_MSG_PTR(EntryPtr->Msg), &MessageID);
+                    CFE_MSG_GetFcnCode(CFE_MSG_PTR(EntryPtr->Msg), &CommandCode);
 
                     if (CommandCode == SC_SWITCH_ATS_CC && CFE_SB_MsgIdToValue(MessageID) == SC_CMD_MID)
                     {
@@ -156,7 +156,7 @@ void SC_ProcessAtpCmd(void)
                     }
                     else
                     {
-                        Result = CFE_SB_TransmitMsg(&EntryPtr->Msg, SC_AppData.EnableHeaderUpdate);
+                        Result = CFE_SB_TransmitMsg(CFE_MSG_PTR(EntryPtr->Msg), SC_AppData.EnableHeaderUpdate);
 
                         if (Result == CFE_SUCCESS)
                         {
@@ -338,7 +338,7 @@ void SC_ProcessRtpCommand(void)
         if (!SC_AppData.EnableHeaderUpdate)
         {
             /* If header update is NOT enabled, confirm this table entry has a valid checksum already */
-            CFE_MSG_ValidateChecksum(&EntryPtr->Msg, &ChecksumValid);
+            CFE_MSG_ValidateChecksum(CFE_MSG_PTR(EntryPtr->Msg), &ChecksumValid);
         }
         if (ChecksumValid)
         {
@@ -346,7 +346,7 @@ void SC_ProcessRtpCommand(void)
              ** Try Sending the command on the Software Bus
              */
 
-            Result = CFE_SB_TransmitMsg(&EntryPtr->Msg, SC_AppData.EnableHeaderUpdate);
+            Result = CFE_SB_TransmitMsg(CFE_MSG_PTR(EntryPtr->Msg), SC_AppData.EnableHeaderUpdate);
 
             if (Result == CFE_SUCCESS)
             {
@@ -473,8 +473,8 @@ void SC_SendHkPacket(void)
     } /* end for */
 
     /* send the status packet */
-    CFE_SB_TimeStampMsg(&SC_OperData.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&SC_OperData.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(SC_OperData.HkPacket));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(SC_OperData.HkPacket), true);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -110,7 +110,7 @@ void SC_LoadAts(uint16 AtsIndex)
                      SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] == SC_EMPTY)
             {
                 /* get message size */
-                CFE_MSG_GetSize(&EntryPtr->Msg, &MessageSize);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &MessageSize);
 
                 /* if the length of the command is valid */
                 if (MessageSize >= SC_PACKET_MIN_SIZE && MessageSize <= SC_PACKET_MAX_SIZE)
@@ -403,12 +403,12 @@ bool SC_ParseRts(uint32 Buffer32[])
              */
             EntryPtr = (SC_RtsEntry_t *)&Buffer32[i];
 
-            CFE_MSG_GetSize(&EntryPtr->Msg, &CmdSize);
+            CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdSize);
 
             /* Add header size, round up to boundary, convert to index delta  */
             IndexDelta = (CmdSize + SC_RTS_HEADER_SIZE + SC_ROUND_UP_BYTES) / sizeof(Buffer32[0]);
 
-            CFE_MSG_GetMsgId(&EntryPtr->Msg, &MessageID);
+            CFE_MSG_GetMsgId(CFE_MSG_PTR(EntryPtr->Msg), &MessageID);
 
             if (!CFE_SB_IsValidMsgId(MessageID))
             {
@@ -556,7 +556,7 @@ void SC_UpdateAppend(void)
             }
             else
             {
-                CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
                 CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;
 
                 if ((CommandBytes < SC_PACKET_MIN_SIZE) || (CommandBytes > SC_PACKET_MAX_SIZE))
@@ -642,7 +642,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
         SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_LOADED;
 
         /* update entry index to point to the next entry */
-        CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+        CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
         CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;
         EntryIndex += (SC_ATS_HDR_NOPKT_WORDS + CommandWords);
     }
@@ -795,7 +795,7 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
     else
     {
         /* Start with the byte length of the command packet */
-        CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+        CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
 
         /* Convert packet byte length to word length (round up odd bytes) */
         CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -551,9 +551,9 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Format the command packet to start the first RTS
          */
-        CFE_MSG_Init(&CmdPkt.CmdHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
+        CFE_MSG_Init(CFE_MSG_PTR(CmdPkt), CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
 
-        CFE_MSG_SetFcnCode(&CmdPkt.CmdHeader.Msg, SC_START_RTS_CC);
+        CFE_MSG_SetFcnCode(CFE_MSG_PTR(CmdPkt), SC_START_RTS_CC);
 
         /*
          ** Get the RTS ID to start.
@@ -563,7 +563,7 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Now send the command back to SC
          */
-        CFE_SB_TransmitMsg(&CmdPkt.CmdHeader.Msg, true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdPkt), true);
     }
     else
     {

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -168,7 +168,7 @@ void SC_GetNextRtsCommand(void)
             CmdOffset = SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr;
             EntryPtr  = (SC_RtsEntry_t *)&SC_OperData.RtsTblAddr[RtsIndex][CmdOffset];
 
-            CFE_MSG_GetSize(&EntryPtr->Msg, &CmdLength);
+            CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdLength);
             CmdLength += SC_RTS_HEADER_SIZE;
 
             /*
@@ -196,7 +196,7 @@ void SC_GetNextRtsCommand(void)
                 /*
                  ** get the length of the new command
                  */
-                CFE_MSG_GetSize(&EntryPtr->Msg, &CmdLength);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdLength);
                 CmdLength += SC_RTS_HEADER_SIZE;
 
                 /*

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -102,7 +102,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, sizeof(CmdPacket)));
+    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket), sizeof(CmdPacket)));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 0);
@@ -122,7 +122,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket), 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
@@ -144,7 +144,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket), 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Rather than taking the address of a sub-member, use the macro provided from the CFE_MSG module to convert from a local container to a CFE_MSG_Messge_t pointer.

Fixes #123

**Testing performed**
Build and run all tests

**Expected behavior changes**
None.

**System(s) tested on**
Debian

**Additional context**
This makes the source code more compatible with alternative implementations of the CFE_MSG module (e.g. if sub-structs are not named identically).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
