### PR TITLE
Fix #113, Fix #123, Symbol naming convention and message conversions

### DIFF
--- a/config/default_sc_internal_cfg.h
+++ b/config/default_sc_internal_cfg.h
@@ -327,16 +327,16 @@
 #define SC_ATS_CMD_STAT_TABLE_NAME "ATSCMD_TBL"
 
 /**
- * \brief Defnies default state of Continue-Ats-On-Checksum-Failure Flag
+ * \brief Defines default state of Continue-Ats-On-Checksum-Failure Flag
  *
  *  \par Description:
  *       This parameter specifies the default state to continue an ATS
  *       when a command in the ATS fails checksum validation
  *
  *  \par Limits:
- *       Must be true or false
+ *       Must be SC_AtsCont_TRUE or SC_AtsCont_FALSE
  */
-#define SC_CONT_ON_FAILURE_START true
+#define SC_CONT_ON_FAILURE_START SC_AtsCont_TRUE
 
 /**
  * \brief Defines the TIME SC should use for its commands

--- a/config/default_sc_msgdefs.h
+++ b/config/default_sc_msgdefs.h
@@ -37,43 +37,94 @@
 #define SC_NUMBER_OF_RTS_IN_UINT16 16 /**< \brief Number of RTS represented in a uint16 */
 
 /**
- * \name ATS/RTS Cmd Status macros
+ * ATS/RTS Cmd Status Enumeratoion
+ */
+enum SC_Status
+{
+    SC_Status_EMPTY,           /**< \brief the object is not loaded */
+    SC_Status_LOADED,          /**< \brief the object is loaded */
+    SC_Status_IDLE,            /**< \brief the object is not executing */
+    SC_Status_EXECUTED,        /**< \brief the object has completed executing */
+    SC_Status_SKIPPED,         /**< \brief the object (ats command) was skipped */
+    SC_Status_EXECUTING,       /**< \brief the object is currently executing */
+    SC_Status_FAILED_CHECKSUM, /**< \brief the object failed a checksum test */
+    SC_Status_FAILED_DISTRIB,  /**< \brief the object could not be sent on the SWB */
+    SC_Status_STARTING         /**< \brief used when an inline switch is executed */
+};
+
+typedef uint8 SC_Status_Enum_t;
+
+#ifndef SC_OMIT_DEPRECATED
+/**
+ * \name Old-style ATS/RTS Cmd Status macros
  * \{
  */
-#define SC_EMPTY           0 /**< \brief the object is not loaded */
-#define SC_LOADED          1 /**< \brief the object is loaded */
-#define SC_IDLE            2 /**< \brief the object is not executing */
-#define SC_EXECUTED        3 /**< \brief the object has completed executing */
-#define SC_SKIPPED         4 /**< \brief the object (ats command) was skipped */
-#define SC_EXECUTING       5 /**< \brief the object is currently executing */
-#define SC_FAILED_CHECKSUM 6 /**< \brief the object failed a checksum test */
-#define SC_FAILED_DISTRIB  7 /**< \brief the object could not be sent on the SWB */
-#define SC_STARTING        8 /**< \brief used when an inline switch is executed */
+#define SC_EMPTY           SC_Status_EMPTY
+#define SC_LOADED          SC_Status_LOADED
+#define SC_IDLE            SC_Status_IDLE
+#define SC_EXECUTED        SC_Status_EXECUTED
+#define SC_SKIPPED         SC_Status_SKIPPED
+#define SC_EXECUTING       SC_Status_EXECUTING
+#define SC_FAILED_CHECKSUM SC_Status_FAILED_CHECKSUM
+#define SC_FAILED_DISTRIB  SC_Status_FAILED_DISTRIB
+#define SC_STARTING        SC_Status_STARTING
 /**\}*/
+#endif
 
 /************************************************************************
  * Macro Definitions
  ************************************************************************/
 
 /**
- * \name Which processor runs next
+ * Enumeration for SC processes
+ * This specifies which process runs next
+ */
+enum SC_ProcessNum
+{
+    SC_Process_ATP  = 0,   /**< \brief ATP process next */
+    SC_Process_RTP  = 1,   /**< \brief RTP process next */
+    SC_Process_NONE = 0xFF /**< \brief No pending process */
+};
+
+typedef uint8 SC_Process_Enum_t;
+
+#ifndef SC_OMIT_DEPRECATED
+/**
+ * \name Old-style defines for which process runs next
  * \{
  */
-#define SC_ATP  0    /**< \brief ATP process next */
-#define SC_RTP  1    /**< \brief RTP process next */
-#define SC_NONE 0xFF /**< \brief No pending process */
+#define SC_ATP  SC_Process_ATP
+#define SC_RTP  SC_Process_RTP
+#define SC_NONE SC_Process_NONE
 /**\}*/
+#endif
 
 #define SC_MAX_TIME 0xFFFFFFFF /**< \brief Maximum time in SC */
 
 /**
- * \name Defines for each ATS
+ * Enumeration for ATS identifiers
+ *
+ * ATS identifiers are alphabetic letters that correspond to ATS numbers
+ */
+enum SC_AtsId
+{
+    SC_AtsId_NO_ATS, /**<\ brief No ATS */
+    SC_AtsId_ATSA,   /**< \brief ATS A */
+    SC_AtsId_ATSB    /**< \brief ATS B */
+};
+
+typedef uint8 SC_AtsId_Enum_t;
+
+#ifndef SC_OMIT_DEPRECATED
+/**
+ * \name Old-style defines for each ATS
  * \{
  */
-#define SC_NO_ATS 0 /**<\ brief No ATS */
-#define SC_ATSA   1 /**< \brief ATS A */
-#define SC_ATSB   2 /**< \brief ATS B */
+#define SC_NO_ATS SC_AtsId_NO_ATS
+#define SC_ATSA   SC_AtsId_ATSA
+#define SC_ATSB   SC_AtsId_ATSB
 /**\}*/
+#endif
 
 /**
  * \name constants for config parameters for which TIME to use
@@ -87,12 +138,24 @@
 #define SC_INVALID_RTS_NUMBER 0 /**< \brief Invalid RTS number */
 
 /**
- * \name SC Continue Flags
+ * SC Continue After Failure Enumeration
+ */
+enum SC_AtsCont
+{
+    SC_AtsCont_FALSE = false, /**< \brief Do not continue on failure */
+    SC_AtsCont_TRUE  = true   /**< \brief Continue on failure */
+};
+typedef uint8 SC_AtsCont_Enum_t;
+
+#ifndef SC_OMIT_DEPRECATED
+/**
+ * \name Old-style SC Continue Flags
  * \{
  */
-#define SC_CONTINUE_TRUE  1 /**< \brief Continue on failure */
-#define SC_CONTINUE_FALSE 0 /**< \brief Do not continue on failure */
+#define SC_CONTINUE_TRUE  SC_AtsCont_TRUE
+#define SC_CONTINUE_FALSE SC_AtsCont_FALSE
 /**\}*/
+#endif
 
 /************************************************************************
  * Type Definitions
@@ -108,9 +171,9 @@
  */
 typedef struct
 {
-    uint8 AtsNumber;                /**< \brief Current ATS number: 1 = ATS A, 2 = ATS B */
-    uint8 AtpState;                 /**< \brief Current ATP state: 2 = IDLE, 5 = EXECUTING */
-    uint8 ContinueAtsOnFailureFlag; /**< \brief Continue ATS execution on failure flag */
+    SC_AtsId_Enum_t   CurrAtsId;                /**< \brief Current ATS number: 1 = ATS A, 2 = ATS B */
+    SC_Status_Enum_t  AtpState;                 /**< \brief Current ATP state: 2 = IDLE, 5 = EXECUTING */
+    SC_AtsCont_Enum_t ContinueAtsOnFailureFlag; /**< \brief Continue ATS execution on failure flag */
 
     uint8 CmdErrCtr; /**< \brief Counts Request Errors */
     uint8 CmdCtr;    /**< \brief Counts Ground Requests */
@@ -192,8 +255,8 @@ typedef struct
  */
 typedef struct
 {
-    uint16 ContinueState; /**< \brief true or false, to continue ATS after a failure  */
-    uint16 Padding;       /**< \brief Structure Padding */
+    SC_AtsCont_Enum_t ContinueState; /**< \brief true or false, to continue ATS after a failure  */
+    uint16            Padding;       /**< \brief Structure Padding */
 } SC_SetContinueAtsOnFailureCmd_Payload_t;
 
 /**

--- a/config/default_sc_msgids.h
+++ b/config/default_sc_msgids.h
@@ -29,9 +29,9 @@
  * \{
  */
 
-#define SC_CMD_MID        (0x18A9) /**< \brief Msg ID for cmds to SC   */
-#define SC_SEND_HK_MID    (0x18AA) /**< \brief Msg ID to request SC HK */
-#define SC_1HZ_WAKEUP_MID (0x18AB) /**< \brief Msg ID to receive the 1Hz */
+#define SC_CMD_MID          (0x18A9) /**< \brief Msg ID for cmds to SC   */
+#define SC_SEND_HK_MID      (0x18AA) /**< \brief Msg ID to request SC HK */
+#define SC_ONEHZ_WAKEUP_MID (0x18AB) /**< \brief Msg ID to receive the 1Hz */
 
 /**\}*/
 
@@ -43,5 +43,10 @@
 #define SC_HK_TLM_MID (0x08AA) /**< \brief Msg ID to send telemtry down on */
 
 /**\}*/
+
+/* Compatibility identifiers - in case existing SCH table(s) use the old wakeup MID define */
+#ifndef SC_OMIT_DEPRECATED
+#define SC_1HZ_WAKEUP_MID SC_ONEHZ_WAKEUP_MID
+#endif
 
 #endif

--- a/config/default_sc_msgstruct.h
+++ b/config/default_sc_msgstruct.h
@@ -56,7 +56,7 @@
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader;
+    CFE_MSG_TelemetryHeader_t TelemetryHeader;
     SC_HkTlm_Payload_t        Payload;
 } SC_HkTlm_t;
 
@@ -74,7 +74,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t  CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t  CommandHeader; /**< \brief Command Header */
     SC_StartAtsCmd_Payload_t Payload;
 } SC_StartAtsCmd_t;
 
@@ -85,7 +85,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_JumpAtsCmd_Payload_t Payload;
 } SC_JumpAtsCmd_t;
 
@@ -96,7 +96,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command Header */
     SC_SetContinueAtsOnFailureCmd_Payload_t Payload;
 } SC_SetContinueAtsOnFailureCmd_t;
 
@@ -107,7 +107,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command Header */
     SC_AppendAtsCmd_Payload_t Payload;
 } SC_AppendAtsCmd_t;
 
@@ -118,17 +118,17 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_SendHkCmd_t;
 
 /**
  *  \brief 1Hz Wakeup Command
  *
- *  For command details see #SC_1HZ_WAKEUP_MID
+ *  For command details see #SC_ONEHZ_WAKEUP_MID
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_OneHzWakeupCmd_t;
 
 /**
@@ -138,7 +138,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_NoopCmd_t;
 
 /**
@@ -148,7 +148,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_ResetCountersCmd_t;
 
 /**
@@ -158,7 +158,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_StopAtsCmd_t;
 
 /**
@@ -168,7 +168,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
 } SC_SwitchAtsCmd_t;
 
 /**
@@ -178,7 +178,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsCmd_Payload_t     Payload;
 } SC_StartRtsCmd_t;
 
@@ -189,7 +189,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsCmd_Payload_t     Payload;
 } SC_StopRtsCmd_t;
 
@@ -200,7 +200,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsCmd_Payload_t     Payload;
 } SC_DisableRtsCmd_t;
 
@@ -211,7 +211,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsCmd_Payload_t     Payload;
 } SC_EnableRtsCmd_t;
 
@@ -222,7 +222,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command Header */
     SC_SetContinueAtsOnFailureCmd_Payload_t Payload;
 } SC_ContinueAtsOnFailureCmd_t;
 
@@ -233,7 +233,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command Header */
     CFE_TBL_NotifyCmd_Payload_t Payload;
 } SC_ManageTableCmd_t;
 
@@ -244,7 +244,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
 } SC_StartRtsGrpCmd_t;
 
@@ -255,7 +255,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
 } SC_StopRtsGrpCmd_t;
 
@@ -266,7 +266,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
 } SC_DisableRtsGrpCmd_t;
 
@@ -277,7 +277,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
     SC_RtsGrpCmd_Payload_t  Payload;
 } SC_EnableRtsGrpCmd_t;
 

--- a/config/default_sc_tbldefs.h
+++ b/config/default_sc_tbldefs.h
@@ -87,8 +87,8 @@ typedef struct
  */
 typedef struct
 {
-    SC_AtsEntryHeader_t Header; /**< \brief ATS header */
-    CFE_MSG_Message_t   Msg;    /**< \brief MSG header */
+    SC_AtsEntryHeader_t     Header; /**< \brief ATS header */
+    CFE_MSG_CommandHeader_t Msg;    /**< \brief Command Message to be sent */
 } SC_AtsEntry_t;
 
 /**
@@ -110,8 +110,8 @@ typedef struct
  */
 typedef struct
 {
-    SC_RtsEntryHeader_t Header; /**< \brief RTS header */
-    CFE_MSG_Message_t   Msg;    /**< \brief MSG header */
+    SC_RtsEntryHeader_t     Header; /**< \brief RTS header */
+    CFE_MSG_CommandHeader_t Msg;    /**< \brief Command Message to be sent */
 } SC_RtsEntry_t;
 
 #endif

--- a/docs/dox_src/cfs_sc.dox
+++ b/docs/dox_src/cfs_sc.dox
@@ -310,7 +310,7 @@
   CFS Stored Command requires that two message ID's be put in the CFS Scheduler
   table for proper operation. Those message ID's are #SC_SEND_HK_MID, which
   should be sent out at the housekeeping request interval, and
-  #SC_1HZ_WAKEUP_MID, which needs to be sent out every second.
+  #SC_ONEHZ_WAKEUP_MID, which needs to be sent out every second.
 
   CFS Stored Command generates telemetry when it receives the housekeeping
   request. Its telemetry message ID is #SC_HK_TLM_MID.

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -83,7 +83,7 @@
  *  This event message is issued when #CFE_SB_Subscribe to the 1 Hz
  *  Request packet fails
  */
-#define SC_INIT_SB_SUBSCRIBE_1HZ_ERR_EID 5
+#define SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID 5
 
 /**
  * \brief HS Command Message Subscribe Failed Event ID
@@ -474,7 +474,7 @@
  *
  *  \par Cause:
  *  This event message is issued when an ATS command is about to be send out,
- *  but the command isn't marked as '#SC_LOADED'
+ *  but the command isn't marked as '#SC_Status_LOADED'
  */
 #define SC_ATS_SKP_ERR_EID 48
 
@@ -701,7 +701,7 @@
  *
  *  \par Cause:
  *  This event message is issued when an RTS is tried to be started, but the RTS is not
- *  marked as #SC_LOADED
+ *  marked as #SC_Status_LOADED
  */
 #define SC_STARTRTS_CMD_NOT_LDED_ERR_EID 75
 
@@ -1225,7 +1225,7 @@
  *
  *  \par Cause:
  *  This event message is issued when a #SC_START_RTS_GRP_CC command was received, but an
- *  RTS is marked as #SC_LOADED
+ *  RTS is marked as #SC_Status_LOADED
  */
 #define SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID 126
 

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -157,7 +157,8 @@ CFE_Status_t SC_AppInit(void)
     SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
 
     /* Initialize the SC housekeeping packet */
-    CFE_MSG_Init(&SC_OperData.HkPacket.TelemetryHeader.Msg, CFE_SB_ValueToMsgId(SC_HK_TLM_MID), sizeof(SC_HkTlm_t));
+    CFE_MSG_Init(CFE_MSG_PTR(SC_OperData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(SC_HK_TLM_MID),
+                 sizeof(SC_HkTlm_t));
 
     /* Select auto-exec RTS to start during first HK request */
     if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -152,12 +152,12 @@ CFE_Status_t SC_AppInit(void)
     SC_AppData.EnableHeaderUpdate = SC_PLATFORM_ENABLE_HEADER_UPDATE;
 
     /* Make sure nothing is running */
-    SC_AppData.NextProcNumber      = SC_NONE;
-    SC_AppData.NextCmdTime[SC_ATP] = SC_MAX_TIME;
-    SC_AppData.NextCmdTime[SC_RTP] = SC_MAX_TIME;
+    SC_AppData.NextProcNumber              = SC_Process_NONE;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
 
     /* Initialize the SC housekeeping packet */
-    CFE_MSG_Init(&SC_OperData.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(SC_HK_TLM_MID), sizeof(SC_HkTlm_t));
+    CFE_MSG_Init(&SC_OperData.HkPacket.TelemetryHeader.Msg, CFE_SB_ValueToMsgId(SC_HK_TLM_MID), sizeof(SC_HkTlm_t));
 
     /* Select auto-exec RTS to start during first HK request */
     if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)
@@ -196,10 +196,10 @@ CFE_Status_t SC_AppInit(void)
     }
 
     /* Must be able to subscribe to 1Hz wakeup command */
-    Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID), SC_OperData.CmdPipe);
+    Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID), SC_OperData.CmdPipe);
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(SC_INIT_SB_SUBSCRIBE_1HZ_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Software Bus subscribe to 1 Hz cycle returned: 0x%08X", (unsigned int)Result);
         return (Result);
     }
@@ -254,8 +254,8 @@ CFE_Status_t SC_InitTables(void)
     }
 
     /* ATP control block status table */
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_IDLE;
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_NO_ATS;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_NO_ATS;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = SC_INVALID_CMD_NUMBER;
 
     /* RTP control block status table */
@@ -267,7 +267,7 @@ CFE_Status_t SC_InitTables(void)
     {
         for (j = 0; j < SC_MAX_ATS_CMDS; j++)
         {
-            SC_OperData.AtsCmdStatusTblAddr[i][j] = SC_EMPTY;
+            SC_OperData.AtsCmdStatusTblAddr[i][j] = SC_Status_EMPTY;
         }
     }
 
@@ -276,7 +276,7 @@ CFE_Status_t SC_InitTables(void)
     {
         SC_OperData.RtsInfoTblAddr[i].NextCommandTime = SC_MAX_TIME;
         SC_OperData.RtsInfoTblAddr[i].NextCommandPtr  = 0;
-        SC_OperData.RtsInfoTblAddr[i].RtsStatus       = SC_EMPTY;
+        SC_OperData.RtsInfoTblAddr[i].RtsStatus       = SC_Status_EMPTY;
         SC_OperData.RtsInfoTblAddr[i].DisabledFlag    = true;
     }
 

--- a/fsw/src/sc_app.h
+++ b/fsw/src/sc_app.h
@@ -332,11 +332,11 @@ typedef struct
 
     bool EnableHeaderUpdate; /**< \brief whether to update headers in outgoing messages */
 
-    uint8           NextProcNumber;  /**< \brief the next command processor number */
-    SC_AbsTimeTag_t NextCmdTime[2];  /**< \brief The overall next command time  0 - ATP, 1- RTP*/
-    SC_AbsTimeTag_t CurrentTime;     /**< \brief this is the current time for SC */
-    uint16          AutoStartRTS;    /**< \brief Start selected auto-exec RTS after init */
-    uint16          AppendWordCount; /**< \brief Size of cmd entries in current Append ATS table */
+    SC_Process_Enum_t NextProcNumber;  /**< \brief the next command processor number */
+    SC_AbsTimeTag_t   NextCmdTime[2];  /**< \brief The overall next command time  0 - ATP, 1- RTP*/
+    SC_AbsTimeTag_t   CurrentTime;     /**< \brief this is the current time for SC */
+    uint16            AutoStartRTS;    /**< \brief Start selected auto-exec RTS after init */
+    uint16            AppendWordCount; /**< \brief Size of cmd entries in current Append ATS table */
 } SC_AppData_t;
 
 /************************************************************************

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -74,8 +74,9 @@ void SC_ProcessAtpCmd(void)
      ** 3.) The atp is currently EXECUTING
      */
 
-    if ((SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING) && (SC_AppData.NextProcNumber == SC_ATP) &&
-        (!SC_CompareAbsTime(SC_AppData.NextCmdTime[SC_ATP], SC_AppData.CurrentTime)))
+    if ((SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING) &&
+        (SC_AppData.NextProcNumber == SC_Process_ATP) &&
+        (!SC_CompareAbsTime(SC_AppData.NextCmdTime[SC_Process_ATP], SC_AppData.CurrentTime)))
     {
         /*
          ** Get a pointer to the next ats command
@@ -88,7 +89,7 @@ void SC_ProcessAtpCmd(void)
         /*
          ** Make sure the command has not been executed, skipped or has any other bad status
          */
-        if (SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] == SC_LOADED)
+        if (SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] == SC_Status_LOADED)
         {
             /*
              ** Make sure the command number matches what the command
@@ -141,13 +142,13 @@ void SC_ProcessAtpCmd(void)
                              ** Increment the counter and update the status for
                              ** this command
                              */
-                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_EXECUTED;
+                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_EXECUTED;
                             SC_OperData.HkPacket.Payload.AtsCmdCtr++;
                         }
                         else
                         { /* the switch failed for some reason */
 
-                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_DISTRIB;
+                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_FAILED_DISTRIB;
                             SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
                             SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
                             SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
@@ -161,12 +162,12 @@ void SC_ProcessAtpCmd(void)
                         if (Result == CFE_SUCCESS)
                         {
                             /* The command sent OK */
-                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_EXECUTED;
+                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_EXECUTED;
                             SC_OperData.HkPacket.Payload.AtsCmdCtr++;
                         }
                         else
                         { /* the command had Software Bus problems */
-                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_DISTRIB;
+                            SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_FAILED_DISTRIB;
                             SC_OperData.HkPacket.Payload.AtsCmdErrCtr++;
                             SC_OperData.HkPacket.Payload.LastAtsErrSeq = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
                             SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
@@ -199,7 +200,7 @@ void SC_ProcessAtpCmd(void)
                     SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                     /* update the command status index table */
-                    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_FAILED_CHECKSUM;
+                    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_FAILED_CHECKSUM;
 
                     if (SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false)
                     {
@@ -229,7 +230,7 @@ void SC_ProcessAtpCmd(void)
                 SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                 /* update the command status index table */
-                SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_SKIPPED;
+                SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_SKIPPED;
 
                 /* Mark this ATS for abortion */
                 AbortATS = true;
@@ -261,7 +262,7 @@ void SC_ProcessAtpCmd(void)
 
         if (AbortATS == true)
         {
-            if (SC_OperData.AtsCtrlBlckAddr->AtsNumber == SC_ATSA)
+            if (SC_OperData.AtsCtrlBlckAddr->AtsNumber == SC_AtsId_ATSA)
             {
                 TempAtsChar = 'A';
             }
@@ -304,16 +305,16 @@ void SC_ProcessRtpCommand(void)
     /*
      ** The following conditions must be met before a RTS command is executed:
      ** 1.) The next command time must be <= the current time
-     ** 2.) The next processor number must be SC_RTP
+     ** 2.) The next processor number must be SC_Process_RTP
      ** 3.) The RTS number in the RTP control block must be valid and
      ** 4.) the RTS must be EXECUTING
      */
 
     if ((SC_AppData.NextCmdTime[SC_AppData.NextProcNumber] <= SC_AppData.CurrentTime) &&
-        (SC_AppData.NextProcNumber == SC_RTP) && (SC_OperData.RtsCtrlBlckAddr->RtsNumber > 0) &&
+        (SC_AppData.NextProcNumber == SC_Process_RTP) && (SC_OperData.RtsCtrlBlckAddr->RtsNumber > 0) &&
         (SC_OperData.RtsCtrlBlckAddr->RtsNumber <= SC_NUMBER_OF_RTS) &&
         (SC_OperData.RtsInfoTblAddr[SC_RTS_NUM_TO_INDEX(SC_OperData.RtsCtrlBlckAddr->RtsNumber)].RtsStatus ==
-         SC_EXECUTING))
+         SC_Status_EXECUTING))
     {
         /*
          ** Count the command for the rate limiter
@@ -418,12 +419,12 @@ void SC_SendHkPacket(void)
     /*
      ** fill in the free bytes in each ATS
      */
-    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSA)] =
+    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_AtsId_ATSA)] =
         (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
-        (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_ATSA)].AtsSize * SC_BYTES_IN_WORD);
-    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_ATSB)] =
+        (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_AtsId_ATSA)].AtsSize * SC_BYTES_IN_WORD);
+    SC_OperData.HkPacket.Payload.AtpFreeBytes[SC_ATS_NUM_TO_INDEX(SC_AtsId_ATSB)] =
         (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
-        (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_ATSB)].AtsSize * SC_BYTES_IN_WORD);
+        (SC_OperData.AtsInfoTblAddr[SC_ATS_NUM_TO_INDEX(SC_AtsId_ATSB)].AtsSize * SC_BYTES_IN_WORD);
 
     /*
      **
@@ -431,13 +432,13 @@ void SC_SendHkPacket(void)
      **
      */
 
-    SC_OperData.HkPacket.Payload.AtsNumber = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
+    SC_OperData.HkPacket.Payload.CurrAtsId = SC_OperData.AtsCtrlBlckAddr->AtsNumber;
 
     SC_OperData.HkPacket.Payload.AtpState       = SC_OperData.AtsCtrlBlckAddr->AtpState;
     SC_OperData.HkPacket.Payload.AtpCmdNumber   = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
     SC_OperData.HkPacket.Payload.SwitchPendFlag = SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag;
 
-    SC_OperData.HkPacket.Payload.NextAtsTime = SC_AppData.NextCmdTime[SC_ATP];
+    SC_OperData.HkPacket.Payload.NextAtsTime = SC_AppData.NextCmdTime[SC_Process_ATP];
 
     /*
      ** Fill out the RTP control block information
@@ -445,7 +446,7 @@ void SC_SendHkPacket(void)
 
     SC_OperData.HkPacket.Payload.NumRtsActive = SC_OperData.RtsCtrlBlckAddr->NumRtsActive;
     SC_OperData.HkPacket.Payload.RtsNumber    = SC_OperData.RtsCtrlBlckAddr->RtsNumber;
-    SC_OperData.HkPacket.Payload.NextRtsTime  = SC_AppData.NextCmdTime[SC_RTP];
+    SC_OperData.HkPacket.Payload.NextRtsTime  = SC_AppData.NextCmdTime[SC_Process_RTP];
 
     /*
      ** Fill out the RTS status bit mask
@@ -465,7 +466,7 @@ void SC_SendHkPacket(void)
             SC_OperData.HkPacket.Payload.RtsDisabledStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
                 (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
         }
-        if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_EXECUTING)
+        if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_Status_EXECUTING)
         {
             SC_OperData.HkPacket.Payload.RtsExecutingStatus[i / SC_NUMBER_OF_RTS_IN_UINT16] |=
                 (1 << (i % SC_NUMBER_OF_RTS_IN_UINT16));
@@ -473,8 +474,8 @@ void SC_SendHkPacket(void)
     } /* end for */
 
     /* send the status packet */
-    CFE_SB_TimeStampMsg(&SC_OperData.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&SC_OperData.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(&SC_OperData.HkPacket.TelemetryHeader.Msg);
+    CFE_SB_TransmitMsg(&SC_OperData.HkPacket.TelemetryHeader.Msg, true);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -488,7 +489,7 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
     if (SC_AppData.AutoStartRTS != 0)
     {
         /* make sure the selected auto-exec RTS is enabled */
-        if (SC_OperData.RtsInfoTblAddr[SC_RTS_NUM_TO_INDEX(SC_AppData.AutoStartRTS)].RtsStatus == SC_LOADED)
+        if (SC_OperData.RtsInfoTblAddr[SC_RTS_NUM_TO_INDEX(SC_AppData.AutoStartRTS)].RtsStatus == SC_Status_LOADED)
         {
             SC_OperData.RtsInfoTblAddr[SC_RTS_NUM_TO_INDEX(SC_AppData.AutoStartRTS)].DisabledFlag = false;
         }
@@ -546,20 +547,20 @@ void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
             SC_ServiceSwitchPend();
         }
 
-        if (SC_AppData.NextProcNumber == SC_ATP)
+        if (SC_AppData.NextProcNumber == SC_Process_ATP)
         {
             SC_ProcessAtpCmd();
         }
         else
         {
-            if (SC_AppData.NextProcNumber == SC_RTP)
+            if (SC_AppData.NextProcNumber == SC_Process_RTP)
             {
                 SC_ProcessRtpCommand();
             }
         }
 
         SC_UpdateNextTime();
-        if ((SC_AppData.NextProcNumber == SC_NONE) ||
+        if ((SC_AppData.NextProcNumber == SC_Process_NONE) ||
             (SC_AppData.NextCmdTime[SC_AppData.NextProcNumber] > SC_AppData.CurrentTime))
         {
             SC_OperData.NumCmdsSec         = 0;

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -106,7 +106,7 @@ void SC_ProcessAtpCmd(void)
                 if (!SC_AppData.EnableHeaderUpdate)
                 {
                     /* If header update is NOT enabled, confirm this table entry has a valid checksum already */
-                    CFE_MSG_ValidateChecksum(&EntryPtr->Msg, &ChecksumValid);
+                    CFE_MSG_ValidateChecksum(CFE_MSG_PTR(EntryPtr->Msg), &ChecksumValid);
                 }
                 if (ChecksumValid)
                 {
@@ -128,8 +128,8 @@ void SC_ProcessAtpCmd(void)
                      **  SC immediately executes the switch command.
                      */
 
-                    CFE_MSG_GetMsgId(&EntryPtr->Msg, &MessageID);
-                    CFE_MSG_GetFcnCode(&EntryPtr->Msg, &CommandCode);
+                    CFE_MSG_GetMsgId(CFE_MSG_PTR(EntryPtr->Msg), &MessageID);
+                    CFE_MSG_GetFcnCode(CFE_MSG_PTR(EntryPtr->Msg), &CommandCode);
 
                     if (CommandCode == SC_SWITCH_ATS_CC && CFE_SB_MsgIdToValue(MessageID) == SC_CMD_MID)
                     {
@@ -157,7 +157,7 @@ void SC_ProcessAtpCmd(void)
                     }
                     else
                     {
-                        Result = CFE_SB_TransmitMsg(&EntryPtr->Msg, SC_AppData.EnableHeaderUpdate);
+                        Result = CFE_SB_TransmitMsg(CFE_MSG_PTR(EntryPtr->Msg), SC_AppData.EnableHeaderUpdate);
 
                         if (Result == CFE_SUCCESS)
                         {
@@ -339,7 +339,7 @@ void SC_ProcessRtpCommand(void)
         if (!SC_AppData.EnableHeaderUpdate)
         {
             /* If header update is NOT enabled, confirm this table entry has a valid checksum already */
-            CFE_MSG_ValidateChecksum(&EntryPtr->Msg, &ChecksumValid);
+            CFE_MSG_ValidateChecksum(CFE_MSG_PTR(EntryPtr->Msg), &ChecksumValid);
         }
         if (ChecksumValid)
         {
@@ -347,7 +347,7 @@ void SC_ProcessRtpCommand(void)
              ** Try Sending the command on the Software Bus
              */
 
-            Result = CFE_SB_TransmitMsg(&EntryPtr->Msg, SC_AppData.EnableHeaderUpdate);
+            Result = CFE_SB_TransmitMsg(CFE_MSG_PTR(EntryPtr->Msg), SC_AppData.EnableHeaderUpdate);
 
             if (Result == CFE_SUCCESS)
             {
@@ -474,8 +474,8 @@ void SC_SendHkPacket(void)
     } /* end for */
 
     /* send the status packet */
-    CFE_SB_TimeStampMsg(&SC_OperData.HkPacket.TelemetryHeader.Msg);
-    CFE_SB_TransmitMsg(&SC_OperData.HkPacket.TelemetryHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(SC_OperData.HkPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(SC_OperData.HkPacket.TelemetryHeader), true);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_dispatch.c
+++ b/fsw/src/sc_dispatch.c
@@ -109,7 +109,7 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
             }
             break;
 
-        case SC_1HZ_WAKEUP_MID:
+        case SC_ONEHZ_WAKEUP_MID:
             if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_OneHzWakeupCmd_t)))
             {
                 SC_OneHzWakeupCmd((const SC_OneHzWakeupCmd_t *)BufPtr);

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -110,7 +110,7 @@ void SC_LoadAts(uint16 AtsIndex)
                      SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] == SC_Status_EMPTY)
             {
                 /* get message size */
-                CFE_MSG_GetSize(&EntryPtr->Msg, &MessageSize);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &MessageSize);
 
                 /* if the length of the command is valid */
                 if (MessageSize >= SC_PACKET_MIN_SIZE && MessageSize <= SC_PACKET_MAX_SIZE)
@@ -404,12 +404,12 @@ bool SC_ParseRts(uint32 Buffer32[])
              */
             EntryPtr = (SC_RtsEntry_t *)&Buffer32[i];
 
-            CFE_MSG_GetSize(&EntryPtr->Msg, &CmdSize);
+            CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdSize);
 
             /* Add header size, round up to boundary, convert to index delta  */
             IndexDelta = (CmdSize + SC_RTS_HEADER_SIZE + SC_ROUND_UP_BYTES) / sizeof(Buffer32[0]);
 
-            CFE_MSG_GetMsgId(&EntryPtr->Msg, &MessageID);
+            CFE_MSG_GetMsgId(CFE_MSG_PTR(EntryPtr->Msg), &MessageID);
 
             if (!CFE_SB_IsValidMsgId(MessageID))
             {
@@ -557,7 +557,7 @@ void SC_UpdateAppend(void)
             }
             else
             {
-                CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
                 CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;
 
                 if ((CommandBytes < SC_PACKET_MIN_SIZE) || (CommandBytes > SC_PACKET_MAX_SIZE))
@@ -644,7 +644,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
         SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_LOADED;
 
         /* update entry index to point to the next entry */
-        CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+        CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
         CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;
         EntryIndex += (SC_ATS_HDR_NOPKT_WORDS + CommandWords);
     }
@@ -797,7 +797,7 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
     else
     {
         /* Start with the byte length of the command packet */
-        CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
+        CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CommandBytes);
 
         /* Convert packet byte length to word length (round up odd bytes) */
         CommandWords = (CommandBytes + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD;

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -107,7 +107,7 @@ void SC_LoadAts(uint16 AtsIndex)
             } /* else if the cmd number is valid and the command */
             /* has not already been loaded                     */
             else if (AtsCmdNum <= SC_MAX_ATS_CMDS &&
-                     SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] == SC_EMPTY)
+                     SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] == SC_Status_EMPTY)
             {
                 /* get message size */
                 CFE_MSG_GetSize(&EntryPtr->Msg, &MessageSize);
@@ -127,7 +127,8 @@ void SC_LoadAts(uint16 AtsIndex)
                         SC_AppData.AtsCmdIndexBuffer[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] = AtsEntryIndex;
 
                         /* set the command status to loaded in the command status table */
-                        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] = SC_LOADED;
+                        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(AtsCmdNum)] =
+                            SC_Status_LOADED;
 
                         /* increment the number of commands loaded */
                         SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands++;
@@ -320,7 +321,7 @@ void SC_InitAtsTables(uint16 AtsIndex)
     for (i = 0; i < SC_MAX_ATS_CMDS; i++)
     {
         SC_AppData.AtsCmdIndexBuffer[AtsIndex][i]    = SC_ERROR;
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][i] = SC_EMPTY;
+        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][i] = SC_Status_EMPTY;
         SC_AppData.AtsTimeIndexBuffer[AtsIndex][i]   = SC_INVALID_CMD_NUMBER;
     }
 
@@ -340,7 +341,7 @@ void SC_LoadRts(uint16 RtsIndex)
     if (RtsIndex < SC_NUMBER_OF_RTS)
     {
         /* Clear out the RTS info table */
-        SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus       = SC_LOADED;
+        SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus       = SC_Status_LOADED;
         SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr          = 0;
         SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr          = 0;
         SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr       = 0;
@@ -583,11 +584,12 @@ void SC_UpdateAppend(void)
     SC_OperData.HkPacket.Payload.AppendLoadCount++;
     SC_OperData.HkPacket.Payload.AppendEntryCount = EntryCount;
     SC_OperData.HkPacket.Payload.AppendByteCount  = EntryIndex * SC_BYTES_IN_ATS_APPEND_ENTRY;
-    SC_AppData.AppendWordCount            = EntryIndex;
+    SC_AppData.AppendWordCount                    = EntryIndex;
 
     CFE_EVS_SendEvent(SC_UPDATE_APPEND_EID, CFE_EVS_EventType_INFORMATION,
                       "Update Append ATS Table: load count = %d, command count = %d, byte count = %d",
-                      SC_OperData.HkPacket.Payload.AppendLoadCount, (int)EntryCount, (int)EntryIndex * SC_BYTES_IN_WORD);
+                      SC_OperData.HkPacket.Payload.AppendLoadCount, (int)EntryCount,
+                      (int)EntryIndex * SC_BYTES_IN_WORD);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -632,14 +634,14 @@ void SC_ProcessAppend(uint16 AtsIndex)
         CmdIndex = SC_ATS_CMD_NUM_TO_INDEX(EntryPtr->Header.CmdNumber);
 
         /* count only new commands, not replaced commands */
-        if (SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] == SC_EMPTY)
+        if (SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] == SC_Status_EMPTY)
         {
             SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands++;
         }
 
         /* update array of pointers to ats entries */
         SC_AppData.AtsCmdIndexBuffer[AtsIndex][CmdIndex]    = EntryIndex;
-        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_LOADED;
+        SC_OperData.AtsCmdStatusTblAddr[AtsIndex][CmdIndex] = SC_Status_LOADED;
 
         /* update entry index to point to the next entry */
         CFE_MSG_GetSize(&EntryPtr->Msg, &CommandBytes);
@@ -651,7 +653,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
     SC_BuildTimeIndexTable(AtsIndex);
 
     /* did we just append to an ats that was executing? */
-    if ((SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING) &&
+    if ((SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING) &&
         (SC_OperData.AtsCtrlBlckAddr->AtsNumber == (SC_ATS_INDEX_TO_NUM(AtsIndex))))
     {
         /*
@@ -661,7 +663,7 @@ void SC_ProcessAppend(uint16 AtsIndex)
         */
         if (SC_BeginAts(AtsIndex, 0))
         {
-            SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+            SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
         }
     }
 

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -70,7 +70,7 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
         if (SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false)
         {
             /* the requested RTS is not being used and is not empty */
-            if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED)
+            if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED)
             {
                 /*
                  ** Check the command length
@@ -86,7 +86,7 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
                     /*
                      **  Initialize the RTS info table entry
                      */
-                    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
+                    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_Status_EXECUTING;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr      = 0;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
@@ -191,10 +191,10 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
             /* make sure that RTS is not disabled, empty or executing */
             if (SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag == false)
             {
-                if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED)
+                if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED)
                 {
                     /* initialize the RTS info table entry */
-                    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
+                    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_Status_EXECUTING;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr      = 0;
                     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
@@ -311,7 +311,7 @@ void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
         for (RtsIndex = FirstIndex; RtsIndex <= LastIndex; RtsIndex++)
         {
             /* count the entries that were actually stopped */
-            if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING)
+            if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING)
             {
                 SC_KillRts(RtsIndex);
                 StopCount++;
@@ -513,12 +513,12 @@ void SC_KillRts(uint16 RtsIndex)
         CFE_EVS_SendEvent(SC_KILLRTS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR, "RTS kill error: invalid RTS index %d",
                           RtsIndex);
     }
-    else if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING)
+    else if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING)
     {
         /*
          ** Stop the RTS from executing
          */
-        SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus       = SC_LOADED;
+        SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus       = SC_Status_LOADED;
         SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime = SC_MAX_TIME;
 
         /*
@@ -551,9 +551,9 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Format the command packet to start the first RTS
          */
-        CFE_MSG_Init(&CmdPkt.CmdHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
+        CFE_MSG_Init(&CmdPkt.CommandHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
 
-        CFE_MSG_SetFcnCode(&CmdPkt.CmdHeader.Msg, SC_START_RTS_CC);
+        CFE_MSG_SetFcnCode(&CmdPkt.CommandHeader.Msg, SC_START_RTS_CC);
 
         /*
          ** Get the RTS ID to start.
@@ -563,7 +563,7 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Now send the command back to SC
          */
-        CFE_SB_TransmitMsg(&CmdPkt.CmdHeader.Msg, true);
+        CFE_SB_TransmitMsg(&CmdPkt.CommandHeader.Msg, true);
     }
     else
     {

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -551,9 +551,9 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Format the command packet to start the first RTS
          */
-        CFE_MSG_Init(&CmdPkt.CommandHeader.Msg, CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
+        CFE_MSG_Init(CFE_MSG_PTR(CmdPkt.CommandHeader), CFE_SB_ValueToMsgId(SC_CMD_MID), sizeof(CmdPkt));
 
-        CFE_MSG_SetFcnCode(&CmdPkt.CommandHeader.Msg, SC_START_RTS_CC);
+        CFE_MSG_SetFcnCode(CFE_MSG_PTR(CmdPkt.CommandHeader), SC_START_RTS_CC);
 
         /*
          ** Get the RTS ID to start.
@@ -563,7 +563,7 @@ void SC_AutoStartRts(uint16 RtsNumber)
         /*
          ** Now send the command back to SC
          */
-        CFE_SB_TransmitMsg(&CmdPkt.CommandHeader.Msg, true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdPkt.CommandHeader), true);
     }
     else
     {

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -168,7 +168,7 @@ void SC_GetNextRtsCommand(void)
             CmdOffset = SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr;
             EntryPtr  = (SC_RtsEntry_t *)&SC_OperData.RtsTblAddr[RtsIndex][CmdOffset];
 
-            CFE_MSG_GetSize(&EntryPtr->Msg, &CmdLength);
+            CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdLength);
             CmdLength += SC_RTS_HEADER_SIZE;
 
             /*
@@ -196,7 +196,7 @@ void SC_GetNextRtsCommand(void)
                 /*
                  ** get the length of the new command
                  */
-                CFE_MSG_GetSize(&EntryPtr->Msg, &CmdLength);
+                CFE_MSG_GetSize(CFE_MSG_PTR(EntryPtr->Msg), &CmdLength);
                 CmdLength += SC_RTS_HEADER_SIZE;
 
                 /*

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -72,7 +72,7 @@ void SC_GetNextRtsTime(void)
      */
     for (i = SC_NUMBER_OF_RTS - 1; i >= 0; i--)
     {
-        if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_EXECUTING)
+        if (SC_OperData.RtsInfoTblAddr[i].RtsStatus == SC_Status_EXECUTING)
         {
             if (SC_OperData.RtsInfoTblAddr[i].NextCommandTime <= NextTime)
             {
@@ -85,12 +85,12 @@ void SC_GetNextRtsTime(void)
     if (NextRts == SC_INVALID_RTS_INDEX)
     {
         SC_OperData.RtsCtrlBlckAddr->RtsNumber = SC_INVALID_RTS_NUMBER;
-        SC_AppData.NextCmdTime[SC_RTP]         = SC_MAX_TIME;
+        SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
     }
     else
     {
         SC_OperData.RtsCtrlBlckAddr->RtsNumber = NextRts + 1;
-        SC_AppData.NextCmdTime[SC_RTP]         = NextTime;
+        SC_AppData.NextCmdTime[SC_Process_RTP] = NextTime;
     } /* end if */
 }
 
@@ -109,14 +109,14 @@ void SC_UpdateNextTime(void)
     /*
      ** Start out with a default, no processors need to run next
      */
-    SC_AppData.NextProcNumber = SC_NONE;
+    SC_AppData.NextProcNumber = SC_Process_NONE;
 
     /*
      ** Check to see if the ATP needs to schedule commands
      */
-    if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING)
+    if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING)
     {
-        SC_AppData.NextProcNumber = SC_ATP;
+        SC_AppData.NextProcNumber = SC_Process_ATP;
     }
     /*
      ** Last, check to see if there is an RTS that needs to schedule commands
@@ -130,9 +130,9 @@ void SC_UpdateNextTime(void)
          ** the RTP time is less than the ATP time. Otherwise
          ** the ATP has priority
          */
-        if (SC_AppData.NextCmdTime[SC_RTP] < SC_AppData.NextCmdTime[SC_ATP])
+        if (SC_AppData.NextCmdTime[SC_Process_RTP] < SC_AppData.NextCmdTime[SC_Process_ATP])
         {
-            SC_AppData.NextProcNumber = SC_RTP;
+            SC_AppData.NextProcNumber = SC_Process_RTP;
         }
     } /* end if */
 }
@@ -160,7 +160,7 @@ void SC_GetNextRtsCommand(void)
         /*
          ** Find out if the RTS is EXECUTING or just STARTED
          */
-        if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING)
+        if (SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING)
         {
             /*
              ** Get the information needed to find the next command
@@ -315,7 +315,7 @@ void SC_GetNextAtsCommand(void)
     uint16         CmdIndex;  /* ats command array index */
     SC_AtsEntry_t *EntryPtr;
 
-    if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING)
+    if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING)
     {
         /*
          ** Get the information that is needed to find the next command
@@ -335,8 +335,8 @@ void SC_GetNextAtsCommand(void)
             /* update the next command time */
             CmdIndex =
                 SC_AppData.AtsCmdIndexBuffer[AtsIndex][SC_ATS_CMD_NUM_TO_INDEX(SC_OperData.AtsCtrlBlckAddr->CmdNumber)];
-            EntryPtr                       = (SC_AtsEntry_t *)&SC_OperData.AtsTblAddr[AtsIndex][CmdIndex];
-            SC_AppData.NextCmdTime[SC_ATP] = SC_GetAtsEntryTime(&EntryPtr->Header);
+            EntryPtr                               = (SC_AtsEntry_t *)&SC_OperData.AtsTblAddr[AtsIndex][CmdIndex];
+            SC_AppData.NextCmdTime[SC_Process_ATP] = SC_GetAtsEntryTime(&EntryPtr->Header);
         }
         else
         { /* the end is near... of the ATS buffer that is */
@@ -353,17 +353,17 @@ void SC_GetNextAtsCommand(void)
 
         } /* end if */
     }
-    else if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING)
+    else if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_STARTING)
     {
         /*
-         ** The SC_STARTING state is entered when an ATS inline
+         ** The SC_Status_STARTING state is entered when an ATS inline
          ** switch has occurred and there are no commands to
          ** execute in the same second that the switch occurs.
-         ** The state is transitioned here to SC_EXECUTING to
+         ** The state is transitioned here to SC_Status_EXECUTING to
          ** commence execution of the new ATS on the next 1Hz
          ** command processing cycle.
          */
-        SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+        SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     } /* end if ATS is EXECUTING*/
 }

--- a/fsw/src/sc_verify.h
+++ b/fsw/src/sc_verify.h
@@ -189,8 +189,8 @@
 
 #ifndef SC_CONT_ON_FAILURE_START
 #error SC_CONT_ON_FAILURE_START must be defined!
-#elif ((SC_CONT_ON_FAILURE_START != true) && (SC_CONT_ON_FAILURE_START != false))
-#error SC_CONT_ON_FAILURE_START must be either true or false!
+#elif ((SC_CONT_ON_FAILURE_START != SC_AtsCont_TRUE) && (SC_CONT_ON_FAILURE_START != SC_AtsCont_FALSE))
+#error SC_CONT_ON_FAILURE_START must be either SC_AtsCont_TRUE or SC_AtsCont_FALSE!
 #endif
 
 #ifndef SC_TIME_TO_USE

--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -95,16 +95,16 @@ typedef union
 /* Used designated intializers to be verbose, modify as needed/desired */
 SC_AtsTable1_t SC_Ats1 = {
     /* 1 */
-    .ats.hdr1.CmdNumber  = 1,
-    .ats.hdr1.TimeTag_MS = SC_CMD1_TIME >> 16,
-    .ats.hdr1.TimeTag_LS = SC_CMD1_TIME & 0xFFFF,
-    .ats.cmd1.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
+    .ats.hdr1.CmdNumber     = 1,
+    .ats.hdr1.TimeTag_MS    = SC_CMD1_TIME >> 16,
+    .ats.hdr1.TimeTag_LS    = SC_CMD1_TIME & 0xFFFF,
+    .ats.cmd1.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
     .ats.hdr2.CmdNumber  = 2,
     .ats.hdr2.TimeTag_MS = SC_CMD2_TIME >> 16,
     .ats.hdr2.TimeTag_LS = SC_CMD2_TIME & 0xFFFF,
-    .ats.cmd2.CmdHeader =
+    .ats.cmd2.CommandHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS1_CKSUM),
     .ats.cmd2.Payload.RtsId = 1,
 
@@ -112,14 +112,15 @@ SC_AtsTable1_t SC_Ats1 = {
     .ats.hdr3.CmdNumber  = 3,
     .ats.hdr3.TimeTag_MS = SC_CMD3_TIME >> 16,
     .ats.hdr3.TimeTag_LS = SC_CMD3_TIME & 0xFFFF,
-    .ats.cmd3.CmdHeader  = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
+    .ats.cmd3.CommandHeader =
+        CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS1_CKSUM),
     .ats.cmd3.Payload.RtsId = 1,
 
     /* 4 */
     .ats.hdr4.CmdNumber  = 4,
     .ats.hdr4.TimeTag_MS = SC_CMD4_TIME >> 16,
     .ats.hdr4.TimeTag_LS = SC_CMD4_TIME & 0xFFFF,
-    .ats.cmd4.CmdHeader =
+    .ats.cmd4.CommandHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd4), SC_RESET_COUNTERS_CC, SC_RESET_COUNTERS_CKSUM)};
 
 /* Macro for table structure */

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -78,18 +78,19 @@ typedef union
 /* Used designated intializers to be verbose, modify as needed/desired */
 SC_RtsTable001_t SC_Rts001 = {
     /* 1 */
-    .rts.hdr1.TimeTag   = 0,
-    .rts.cmd1.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
+    .rts.hdr1.TimeTag       = 0,
+    .rts.cmd1.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
     .rts.hdr2.TimeTag = 5,
-    .rts.cmd2.CmdHeader =
+    .rts.cmd2.CommandHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS2_CKSUM),
     .rts.cmd2.Payload.RtsId = 2,
 
     /* 3 */
-    .rts.hdr3.TimeTag   = 5,
-    .rts.cmd3.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
+    .rts.hdr3.TimeTag = 5,
+    .rts.cmd3.CommandHeader =
+        CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
     .rts.cmd3.Payload.RtsId = 2};
 
 /* Macro for table structure */

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -72,16 +72,16 @@ typedef union
 /* Used designated intializers to be verbose, modify as needed/desired */
 SC_RtsTable002_t SC_Rts002 = {
     /* 1 */
-    .rts.hdr1.TimeTag   = 0,
-    .rts.cmd1.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
+    .rts.hdr1.TimeTag       = 0,
+    .rts.cmd1.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .rts.hdr2.TimeTag   = 5,
-    .rts.cmd2.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
+    .rts.hdr2.TimeTag       = 5,
+    .rts.cmd2.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 3 */
-    .rts.hdr3.TimeTag   = 5,
-    .rts.cmd3.CmdHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM)};
+    .rts.hdr3.TimeTag       = 5,
+    .rts.cmd3.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM)};
 
 /* Macro for table structure */
 CFE_TBL_FILEDEF(SC_Rts002, SC.RTS_TBL002, SC Example RTS_TBL002, sc_rts002.tbl)

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -146,10 +146,10 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
     memset(&Expected_SC_OperData, 0, sizeof(Expected_SC_OperData));
     memset(&Expected_SC_AppData, 0, sizeof(Expected_SC_AppData));
 
-    Expected_SC_AppData.NextProcNumber      = SC_NONE;
-    Expected_SC_AppData.NextCmdTime[SC_ATP] = SC_MAX_TIME;
-    Expected_SC_AppData.NextCmdTime[SC_RTP] = SC_MAX_TIME;
-    Expected_SC_AppData.AutoStartRTS        = RTS_ID_AUTO_POWER_ON;
+    Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
+    Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
+    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
+    Expected_SC_AppData.AutoStartRTS                = RTS_ID_AUTO_POWER_ON;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -168,7 +168,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
     Expected_SC_OperData.AtsCmdStatusHandle[0] = 0;
     Expected_SC_OperData.AtsCmdStatusHandle[1] = 0;
 
-    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
+    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_AtsCont_TRUE;
 
     UtAssert_MemCmp(&SC_OperData.CmdPipe, &Expected_SC_OperData.CmdPipe, sizeof(Expected_SC_OperData.CmdPipe), "2");
     UtAssert_MemCmp(&SC_OperData.AtsInfoHandle, &Expected_SC_OperData.AtsInfoHandle,
@@ -210,12 +210,12 @@ void SC_AppInit_Test_Nominal(void)
     memset(&Expected_SC_OperData, 0, sizeof(Expected_SC_OperData));
     memset(&Expected_SC_AppData, 0, sizeof(Expected_SC_AppData));
 
-    Expected_SC_AppData.NextProcNumber      = SC_NONE;
-    Expected_SC_AppData.NextCmdTime[SC_ATP] = SC_MAX_TIME;
-    Expected_SC_AppData.NextCmdTime[SC_RTP] = SC_MAX_TIME;
-    Expected_SC_AppData.AutoStartRTS        = RTS_ID_AUTO_PROCESSOR;
+    Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
+    Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
+    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
+    Expected_SC_AppData.AutoStartRTS                = RTS_ID_AUTO_PROCESSOR;
 
-    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = 1;
+    Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_AtsCont_TRUE;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -299,14 +299,14 @@ void SC_AppInit_Test_SBSubscribeHKError(void)
 void SC_AppInit_Test_SubscribeTo1HzError(void)
 {
     /* Set CFE_SB_Subscribe to return -1 on the 2nd call in order to generate error message
-     * SC_INIT_SB_SUBSCRIBE_1HZ_ERR_EID */
+     * SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -1);
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_AppInit(), -1);
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_SB_SUBSCRIBE_1HZ_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -72,14 +72,14 @@ void SC_StartAtsCmd_Test_NominalA(void)
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
@@ -94,14 +94,14 @@ void SC_StartAtsCmd_Test_NominalB(void)
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_STARTATS_CMD_INF_EID);
@@ -120,7 +120,7 @@ void SC_StartAtsCmd_Test_CouldNotStart(void)
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_IDLE;
 
     /* Set to cause SC_BeginAts to return false, in order to reach block starting with "could not start the ats" */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
@@ -145,7 +145,7 @@ void SC_StartAtsCmd_Test_NoCommandsA(void)
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 1;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
@@ -167,7 +167,7 @@ void SC_StartAtsCmd_Test_NoCommandsB(void)
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId            = 2;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
@@ -188,7 +188,7 @@ void SC_StartAtsCmd_Test_InUse(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
@@ -209,7 +209,7 @@ void SC_StartAtsCmd_Test_InvalidAtsId(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 99;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
@@ -230,7 +230,7 @@ void SC_StartAtsCmd_Test_InvalidAtsIdZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     UT_CmdBuf.StartAtsCmd.Payload.AtsId   = 0;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartAtsCmd(&UT_CmdBuf.StartAtsCmd));
@@ -250,7 +250,7 @@ void SC_StopAtsCmd_Test_NominalA(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
@@ -270,7 +270,7 @@ void SC_StopAtsCmd_Test_NominalB(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSB;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StopAtsCmd(&UT_CmdBuf.StopAtsCmd));
@@ -317,7 +317,7 @@ void SC_BeginAts_Test_Nominal(void)
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0],
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 0, "SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 0");
-    UtAssert_True(SC_AppData.NextCmdTime[SC_ATP] == 0, "SC_AppData.NextCmdTime[SC_ATP] == 0");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_ATP] == 0, "SC_AppData.NextCmdTime[SC_Process_ATP] == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_ERR_SKP_DBG_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -340,8 +340,8 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
     UtAssert_BOOL_FALSE(SC_BeginAts(AtsIndex, TimeOffset));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ALL_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -378,20 +378,22 @@ void SC_KillAts_Test(void)
 
     /* Verify results */
     UtAssert_True(SC_OperData.AtsInfoTblAddr[0].AtsUseCtr == 1, "SC_OperData.AtsInfoTblAddr[0].AtsUseCtr == 1");
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE");
-    UtAssert_True(SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_ATP] == SC_MAX_TIME");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_IDLE,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_IDLE");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_ATP] == SC_MAX_TIME,
+                  "SC_AppData.NextCmdTime[SC_Process_ATP] == SC_MAX_TIME");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_SwitchAtsCmd_Test_Nominal(void)
 {
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
     UT_SetDeferredRetcode(UT_KEY(SC_ToggleAtsIndex), 1, 1);
@@ -410,12 +412,12 @@ void SC_SwitchAtsCmd_Test_Nominal(void)
 
 void SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded(void)
 {
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
 
     /* Execute the function being tested */
@@ -432,7 +434,7 @@ void SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded(void)
 
 void SC_SwitchAtsCmd_Test_AtpIdle(void)
 {
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
@@ -460,7 +462,7 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
@@ -470,8 +472,8 @@ void SC_ServiceSwitchPend_Test_NominalA(void)
     UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -488,7 +490,7 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 2;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
@@ -498,8 +500,8 @@ void SC_ServiceSwitchPend_Test_NominalB(void)
     UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -516,7 +518,7 @@ void SC_ServiceSwitchPend_Test_AtsEmpty(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 0;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 0;
 
@@ -580,7 +582,7 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
@@ -588,7 +590,8 @@ void SC_ServiceSwitchPend_Test_AtsNotStarted(void)
     UtAssert_VOIDCALL(SC_ServiceSwitchPend());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE, "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_IDLE,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_IDLE");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
                   "SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false");
 
@@ -612,8 +615,8 @@ void SC_InlineSwitch_Test_NominalA(void)
     UtAssert_BOOL_TRUE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_STARTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_STARTING");
 
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -639,8 +642,8 @@ void SC_InlineSwitch_Test_NominalB(void)
     UtAssert_BOOL_TRUE(SC_InlineSwitch());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING,
-                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_STARTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_STARTING,
+                  "SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_STARTING");
 
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag == false,
@@ -709,12 +712,12 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_LOADED;
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1]   = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_Status_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1]   = SC_Status_LOADED;
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]     = 1;
     SC_AppData.AtsTimeIndexBuffer[AtsIndex][1]     = 2;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber         = 2;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
@@ -722,10 +725,10 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_LOADED,
-                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_LOADED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_Status_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_Status_LOADED,
+                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_Status_LOADED");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][1],
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1, "SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1");
@@ -752,9 +755,9 @@ void SC_JumpAtsCmd_Test_AllCommandsSkipped(void)
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_Status_LOADED;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 1;
 
     /* Execute the function being tested */
@@ -775,7 +778,7 @@ void SC_JumpAtsCmd_Test_NoRunningAts(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_JumpAtsCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
@@ -802,20 +805,20 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     UT_SC_StartAtsRq_CompareHookRunCount = 0;
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHook3, NULL);
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_SKIPPED;
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1]   = SC_SKIPPED;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0]   = SC_Status_SKIPPED;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1]   = SC_Status_SKIPPED;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber         = 1;
-    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState          = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[0].NumberOfCommands = 2;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_JumpAtsCmd(&UT_CmdBuf.JumpAtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_SKIPPED");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] == SC_Status_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[AtsIndex][1] == SC_Status_SKIPPED");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0],
                   "SC_OperData.AtsCtrlBlckAddr->CmdNumber == SC_AppData.AtsTimeIndexBuffer[AtsIndex][0]");
     UtAssert_True(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1, "SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr == 1");
@@ -834,14 +837,13 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueAtsOnFailureCmd_t), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
-    UT_CmdBuf.ContinueAtsOnFailureCmd.Payload.ContinueState = true;
+    UT_CmdBuf.ContinueAtsOnFailureCmd.Payload.ContinueState = SC_AtsCont_TRUE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ContinueAtsOnFailureCmd(&UT_CmdBuf.ContinueAtsOnFailureCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == true,
-                  "SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == true");
+    UtAssert_BOOL_TRUE(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag);
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -54,7 +54,7 @@ uint8 SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount;
 int32 Ut_SC_UpdateNextTimeHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
     if (SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount++)
-        SC_AppData.NextProcNumber = SC_NONE;
+        SC_AppData.NextProcNumber = SC_Process_NONE;
 
     return 0;
 }
@@ -68,13 +68,13 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextProcNumber             = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_AppData.EnableHeaderUpdate = true;
@@ -97,8 +97,8 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -112,13 +112,13 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextProcNumber             = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_AppData.EnableHeaderUpdate = true;
@@ -141,8 +141,8 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -156,13 +156,13 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextProcNumber             = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Set return value for CFE_TIME_Compare to make SC_CompareAbsTime return false, to satisfy first if-statement of
@@ -186,8 +186,8 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_DISTRIB,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_DISTRIB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == 1, "SC_OperData.HkPacket.Payload.LastAtsErrSeq == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
@@ -203,15 +203,15 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_AppData.EnableHeaderUpdate = true;
@@ -231,10 +231,10 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_DISTRIB,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_DISTRIB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
@@ -251,15 +251,15 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSB;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
     SC_AppData.EnableHeaderUpdate = true;
@@ -279,10 +279,10 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_DISTRIB,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_DISTRIB");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_FAILED_DISTRIB,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_DISTRIB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_DIST_ERR_EID);
@@ -300,15 +300,15 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
@@ -332,11 +332,11 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
-                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_CHECKSUM,
+                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -353,15 +353,15 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSB;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = false;
@@ -385,11 +385,11 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM,
-                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_FAILED_CHECKSUM,
+                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -406,15 +406,15 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = true;
@@ -438,11 +438,11 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_FAILED_CHECKSUM,
-                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_FAILED_CHECKSUM");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_FAILED_CHECKSUM,
+                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_FAILED_CHECKSUM");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_CHKSUM_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -455,15 +455,15 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 3;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Execute the function being tested */
@@ -472,11 +472,11 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_MSMTCH_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -490,15 +490,15 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[1][0];
     Entry->CmdNumber = 3;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSB;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSB;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
     /* Execute the function being tested */
@@ -507,11 +507,11 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSB");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSB");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED,
-                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_SKIPPED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_SKIPPED,
+                  "SC_OperData.AtsCmdStatusTblAddr[1][0] == SC_Status_SKIPPED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_MSMTCH_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_ATS_ABT_ERR_EID);
@@ -525,12 +525,12 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -541,8 +541,8 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA,
-                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_ATSA");
+    UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA,
+                  "SC_OperData.HkPacket.Payload.LastAtsErrSeq == SC_AtsId_ATSA");
     UtAssert_True(SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1, "SC_OperData.HkPacket.Payload.LastAtsErrCmd == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ATS_SKP_ERR_EID);
@@ -556,12 +556,12 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -584,12 +584,12 @@ void SC_ProcessAtpCmd_Test_NextProcNumber(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_NONE;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_NONE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -610,12 +610,12 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EMPTY;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EMPTY;
 
-    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_ATSA;
+    SC_OperData.AtsCtrlBlckAddr->AtsNumber = SC_AtsId_ATSA;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
     SC_AppData.AtsCmdIndexBuffer[0][0] = 0;
@@ -638,13 +638,13 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextProcNumber             = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     SC_AppData.EnableHeaderUpdate = true;
@@ -666,19 +666,19 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
-    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED,
-                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_EXECUTED");
+    UtAssert_True(SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED,
+                  "SC_OperData.AtsCmdStatusTblAddr[0][0] == SC_Status_EXECUTED");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRtpCommand_Test_Nominal(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     SC_AppData.EnableHeaderUpdate = true;
 
@@ -697,11 +697,11 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
 void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     SC_AppData.EnableHeaderUpdate = true;
 
@@ -728,11 +728,11 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 {
     bool ChecksumValid;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     SC_AppData.EnableHeaderUpdate = false;
 
@@ -758,11 +758,11 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
 void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 1;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 1;
     SC_AppData.CurrentTime                                                           = 0;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -773,11 +773,11 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 
 void SC_ProcessRtpCommand_Test_ProcNumber(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_NONE;
+    SC_AppData.NextProcNumber                                                        = SC_Process_NONE;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -788,9 +788,9 @@ void SC_ProcessRtpCommand_Test_ProcNumber(void)
 
 void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]         = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_RTP;
+    SC_AppData.NextProcNumber              = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 0;
 
     /* RtsNumber > 0 will be false so nothing should happen, branch coverage */
@@ -802,11 +802,11 @@ void SC_ProcessRtpCommand_Test_RtsNumberZero(void)
 
 void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_NUMBER_OF_RTS + 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -817,11 +817,11 @@ void SC_ProcessRtpCommand_Test_RtsNumberHigh(void)
 
 void SC_ProcessRtpCommand_Test_RtsStatus(void)
 {
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EMPTY;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EMPTY;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
@@ -866,7 +866,7 @@ void SC_SendHkPacket_Test(void)
     for (i = 0; i < SC_NUMBER_OF_RTS - 1; i++)
     {
         SC_OperData.RtsInfoTblAddr[i].DisabledFlag = true;
-        SC_OperData.RtsInfoTblAddr[i].RtsStatus    = SC_EXECUTING;
+        SC_OperData.RtsInfoTblAddr[i].RtsStatus    = SC_Status_EXECUTING;
     }
 
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].DisabledFlag = 0;
@@ -906,7 +906,7 @@ void SC_SendHkPacket_Test(void)
                       (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) -
                           (SC_OperData.AtsInfoTblAddr[1].AtsSize * SC_BYTES_IN_WORD),
                   "SC_OperData.HkPacket.Payload.AtpFreeBytes[1] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AtsNumber == 17, "SC_OperData.HkPacket.Payload.AtsNumber == 17");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CurrAtsId == 17, "SC_OperData.HkPacket.Payload.CurrAtsId == 17");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtpState == 18, "SC_OperData.HkPacket.Payload.AtpState == 18");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtpCmdNumber == 19, "SC_OperData.HkPacket.Payload.AtpCmdNumber == 19");
     UtAssert_True(SC_OperData.HkPacket.Payload.SwitchPendFlag == 0, "SC_OperData.HkPacket.Payload.SwitchPendFlag == 0");
@@ -962,7 +962,7 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRts(void)
 void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 {
     SC_AppData.AutoStartRTS                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS - 1].RtsStatus = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[SC_AppData.AutoStartRTS - 1].RtsStatus = SC_Status_LOADED;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_SendHkCmd(&UT_CmdBuf.SendHkCmd));
@@ -977,8 +977,8 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 void SC_ProcessRequest_Test_OneHzWakeupNONE(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
-    SC_AppData.NextProcNumber                   = SC_NONE;
-    SC_AppData.NextCmdTime[SC_ATP]              = 0;
+    SC_AppData.NextProcNumber                   = SC_Process_NONE;
+    SC_AppData.NextCmdTime[SC_Process_ATP]      = 0;
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
@@ -993,8 +993,8 @@ void SC_ProcessRequest_Test_OneHzWakeupNONE(void)
 void SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
-    SC_AppData.NextProcNumber                   = SC_NONE;
-    SC_AppData.NextCmdTime[SC_ATP]              = 0;
+    SC_AppData.NextProcNumber                   = SC_Process_NONE;
+    SC_AppData.NextCmdTime[SC_Process_ATP]      = 0;
     SC_AppData.CurrentTime                      = 0;
 
     /* Execute the function being tested */
@@ -1009,8 +1009,8 @@ void SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending(void)
 void SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
-    SC_AppData.NextProcNumber                   = SC_ATP;
-    SC_AppData.NextCmdTime[SC_ATP]              = 1000;
+    SC_AppData.NextProcNumber                   = SC_Process_ATP;
+    SC_AppData.NextCmdTime[SC_Process_ATP]      = 1000;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));
@@ -1034,15 +1034,15 @@ void SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextProcNumber             = SC_RTP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING; /* Causes switch to ATP */
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_OperData.NumCmdsSec                = 3;
+    SC_AppData.NextProcNumber              = SC_Process_RTP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING; /* Causes switch to ATP */
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_OperData.NumCmdsSec                 = 3;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
     /* Execute the function being tested */
@@ -1056,11 +1056,11 @@ void SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds(void)
 {
     SC_AppData.EnableHeaderUpdate = true;
 
-    SC_AppData.NextProcNumber             = SC_RTP;
-    SC_AppData.NextCmdTime[SC_RTP]        = 0;
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_OperData.NumCmdsSec                = 1000;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextProcNumber              = SC_Process_RTP;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_OperData.NumCmdsSec                 = 1000;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_OneHzWakeupCmd(&UT_CmdBuf.OneHzWakeupCmd));

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -102,7 +102,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, sizeof(CmdPacket)));
+    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket.CommandHeader), sizeof(CmdPacket)));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 0);
@@ -122,7 +122,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket.CommandHeader), 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
@@ -144,7 +144,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(CFE_MSG_PTR(CmdPacket.CommandHeader), 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -102,7 +102,7 @@ void SC_VerifyCmdLength_Test_Nominal(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, sizeof(CmdPacket)));
+    UtAssert_BOOL_TRUE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, sizeof(CmdPacket)));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 0);
@@ -122,7 +122,7 @@ void SC_VerifyCmdLength_Test_LenError(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
@@ -144,7 +144,7 @@ void SC_VerifyCmdLength_Test_LenErrorNotMID(void)
     UT_SC_Dispatch_SetMsgSize(MsgSize);
 
     /* Execute the function being tested */
-    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CmdHeader.Msg, 999));
+    UtAssert_BOOL_FALSE(SC_VerifyCmdLength(&CmdPacket.CommandHeader.Msg, 999));
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
@@ -217,10 +217,10 @@ void SC_ProcessRequest_Test_SendHkCmdInvalidLength(void)
 void SC_ProcessRequest_Test_OneHzWakeupNominal(void)
 {
     /**
-     **  Test case: SC_1HZ_WAKEUP_MID
+     **  Test case: SC_ONEHZ_WAKEUP_MID
      **/
 
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
 
     UT_SC_Dispatch_SetMsgId(TestMsgId);
     UT_SC_Dispatch_SetFcnCode(0);
@@ -237,10 +237,10 @@ void SC_ProcessRequest_Test_OneHzWakeupNominal(void)
 void SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength(void)
 {
     /**
-     **  Test case: SC_1HZ_WAKEUP_MID
+     **  Test case: SC_ONEHZ_WAKEUP_MID
      **/
 
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_1HZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
 
     UT_SC_Dispatch_SetMsgId(TestMsgId);
     UT_SC_Dispatch_SetFcnCode(0);

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -292,7 +292,7 @@ void SC_LoadAts_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], 0);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -308,7 +308,7 @@ void SC_LoadAts_Test_CmdRunOffEndOfBuffer(void)
     SC_LoadAts(AtsIndex);
 
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -324,7 +324,7 @@ void SC_LoadAts_Test_CmdLengthInvalid(void)
     SC_LoadAts(AtsIndex);
 
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -340,7 +340,7 @@ void SC_LoadAts_Test_CmdLengthZero(void)
     SC_LoadAts(AtsIndex);
 
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -356,7 +356,7 @@ void SC_LoadAts_Test_CmdNumberInvalid(void)
     SC_LoadAts(AtsIndex);
 
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -386,7 +386,7 @@ void SC_LoadAts_Test_AtsBufferTooSmall(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -401,7 +401,7 @@ void SC_LoadAts_Test_AtsEmpty(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands);
     UtAssert_ZERO(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -420,7 +420,7 @@ void SC_LoadAts_Test_LoadExactlyBufferLength(void)
 
     /* Verify results */
     UtAssert_INT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], 0);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, Entry->CmdNumber);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, SC_ATS_BUFF_SIZE32);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -441,7 +441,7 @@ void SC_LoadAts_Test_CmdNotEmpty(void)
 
     /* Verify results */
     UtAssert_UINT32_EQ(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0], SC_ERROR);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_EMPTY);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_EMPTY);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 0);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 0);
 
@@ -625,7 +625,6 @@ void SC_LoadRts_Test_Nominal(void)
     UT_SC_SetMsgId(CFE_SB_INVALID_MSG_ID);
     UT_SC_GetRtsTable(RtsIndex);
 
-
     /* Execute the function being tested */
     SC_LoadRts(RtsIndex);
 
@@ -774,10 +773,8 @@ void SC_UpdateAppend_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendEntryCount, 1);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendEntryCount, 1);
     UtAssert_UINT32_EQ(SC_AppData.AppendWordCount, (SC_ATS_HEADER_SIZE + UT_SC_NOMINAL_CMD_SIZE) / SC_BYTES_IN_WORD);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -802,10 +799,8 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendEntryCount, ExpectedCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendEntryCount, ExpectedCount);
     UtAssert_UINT32_EQ(SC_AppData.AppendWordCount, LastPtr - FirstPtr);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -824,10 +819,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooLow(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_ZERO(SC_OperData.HkPacket.Payload.
-AppendEntryCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_ZERO(SC_OperData.HkPacket.Payload.AppendEntryCount);
     UtAssert_ZERO(SC_AppData.AppendWordCount);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -846,10 +839,8 @@ void SC_UpdateAppend_Test_InvalidCmdLengthTooHigh(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_ZERO(SC_OperData.HkPacket.Payload.
-AppendEntryCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_ZERO(SC_OperData.HkPacket.Payload.AppendEntryCount);
     UtAssert_ZERO(SC_AppData.AppendWordCount);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -871,10 +862,8 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendEntryCount, ExpectedCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendEntryCount, ExpectedCount);
     UtAssert_UINT32_EQ(SC_AppData.AppendWordCount, SC_APPEND_BUFF_SIZE32);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -893,10 +882,8 @@ void SC_UpdateAppend_Test_CmdNumberZero(void)
     UtAssert_VOIDCALL(SC_UpdateAppend());
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_ZERO(SC_OperData.HkPacket.Payload.
-AppendEntryCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_ZERO(SC_OperData.HkPacket.Payload.AppendEntryCount);
     UtAssert_ZERO(SC_AppData.AppendWordCount);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -915,10 +902,8 @@ void SC_UpdateAppend_Test_CmdNumberTooHigh(void)
     SC_UpdateAppend();
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.
-AppendLoadCount, 1);
-    UtAssert_ZERO(SC_OperData.HkPacket.Payload.
-AppendEntryCount);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AppendLoadCount, 1);
+    UtAssert_ZERO(SC_OperData.HkPacket.Payload.AppendEntryCount);
     UtAssert_ZERO(SC_AppData.AppendWordCount);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -936,11 +921,10 @@ void SC_ProcessAppend_Test(void)
     TailPtr = UT_SC_GetAppendTable();
     UT_SC_AppendSingleAtsEntry(&TailPtr, 1, UT_SC_NOMINAL_CMD_SIZE);
 
-    SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.Payload.
-AppendEntryCount = 1;
+    SC_AppData.AppendWordCount                    = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
 
     /* restart ATS */
@@ -953,8 +937,8 @@ AppendEntryCount = 1;
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 1);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 1);
     UtAssert_ZERO(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0]);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_EXECUTING);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_Status_EXECUTING);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -969,12 +953,11 @@ void SC_ProcessAppend_Test_CmdLoaded(void)
     TailPtr = UT_SC_GetAppendTable();
     UT_SC_AppendSingleAtsEntry(&TailPtr, 1, UT_SC_NOMINAL_CMD_SIZE);
 
-    SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.Payload.
-AppendEntryCount = 1;
+    SC_AppData.AppendWordCount                    = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
-    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_LOADED;
-    SC_OperData.AtsCtrlBlckAddr->AtpState        = SC_EXECUTING;
+    SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0] = SC_Status_LOADED;
+    SC_OperData.AtsCtrlBlckAddr->AtpState        = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber       = 1;
 
     /* Execute the function being tested */
@@ -984,8 +967,8 @@ AppendEntryCount = 1;
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 1);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 0);
     UtAssert_ZERO(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0]);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_EXECUTING);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_Status_EXECUTING);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1000,11 +983,10 @@ void SC_ProcessAppend_Test_NotExecuting(void)
     TailPtr = UT_SC_GetAppendTable();
     UT_SC_AppendSingleAtsEntry(&TailPtr, 1, UT_SC_NOMINAL_CMD_SIZE);
 
-    SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.Payload.
-AppendEntryCount = 1;
+    SC_AppData.AppendWordCount                    = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_IDLE;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
 
     /* Execute the function being tested */
@@ -1014,8 +996,8 @@ AppendEntryCount = 1;
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 1);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 1);
     UtAssert_ZERO(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0]);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_IDLE);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_Status_IDLE);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1030,11 +1012,10 @@ void SC_ProcessAppend_Test_AtsNumber(void)
     TailPtr = UT_SC_GetAppendTable();
     UT_SC_AppendSingleAtsEntry(&TailPtr, 1, UT_SC_NOMINAL_CMD_SIZE);
 
-    SC_AppData.AppendWordCount            = 1;
-    SC_OperData.HkPacket.Payload.
-AppendEntryCount = 1;
+    SC_AppData.AppendWordCount                    = 1;
+    SC_OperData.HkPacket.Payload.AppendEntryCount = 1;
 
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 0;
 
     /* Execute the function being tested */
@@ -1044,8 +1025,8 @@ AppendEntryCount = 1;
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].AtsSize, 1);
     UtAssert_UINT32_EQ(SC_OperData.AtsInfoTblAddr[AtsIndex].NumberOfCommands, 1);
     UtAssert_ZERO(SC_AppData.AtsCmdIndexBuffer[AtsIndex][0]);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_LOADED);
-    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_EXECUTING);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCmdStatusTblAddr[AtsIndex][0], SC_Status_LOADED);
+    UtAssert_UINT32_EQ(SC_OperData.AtsCtrlBlckAddr->AtpState, SC_Status_EXECUTING);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1245,10 +1226,14 @@ void UtTest_Setup(void)
     UtTest_Add(SC_LoadAts_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_Nominal");
     UtTest_Add(SC_LoadAts_Test_CmdRunOffEndOfBuffer, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_LoadAts_Test_CmdRunOffEndOfBuffer");
-    UtTest_Add(SC_LoadAts_Test_CmdLengthInvalid, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_CmdLengthInvalid");
-    UtTest_Add(SC_LoadAts_Test_CmdLengthZero, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_CmdLengthZero");
-    UtTest_Add(SC_LoadAts_Test_CmdNumberInvalid, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_CmdNumberInvalid");
-    UtTest_Add(SC_LoadAts_Test_AtsBufferTooSmall, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_AtsBufferTooSmall");
+    UtTest_Add(SC_LoadAts_Test_CmdLengthInvalid, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_LoadAts_Test_CmdLengthInvalid");
+    UtTest_Add(SC_LoadAts_Test_CmdLengthZero, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_LoadAts_Test_CmdLengthZero");
+    UtTest_Add(SC_LoadAts_Test_CmdNumberInvalid, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_LoadAts_Test_CmdNumberInvalid");
+    UtTest_Add(SC_LoadAts_Test_AtsBufferTooSmall, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_LoadAts_Test_AtsBufferTooSmall");
     UtTest_Add(SC_LoadAts_Test_AtsEmpty, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadAts_Test_AtsEmpty");
     UtTest_Add(SC_LoadAts_Test_LoadExactlyBufferLength, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_LoadAts_Test_LoadExactlyBufferLength");
@@ -1271,7 +1256,8 @@ void UtTest_Setup(void)
     UtTest_Add(SC_LoadRts_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadRts_Test_Nominal");
     UtTest_Add(SC_LoadRts_Test_InvalidIndex, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_LoadRts_Test_InvalidIndex");
     UtTest_Add(SC_ParseRts_Test_EndOfFile, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_ParseRts_Test_EndOfFile");
-    UtTest_Add(SC_ParseRts_Test_InvalidMsgId, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_ParseRts_Test_InvalidMsgId");
+    UtTest_Add(SC_ParseRts_Test_InvalidMsgId, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_ParseRts_Test_InvalidMsgId");
     UtTest_Add(SC_ParseRts_Test_LengthErrorTooShort, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_ParseRts_Test_LengthErrorTooShort");
     UtTest_Add(SC_ParseRts_Test_LengthErrorTooLong, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
@@ -1291,28 +1277,35 @@ void UtTest_Setup(void)
                "SC_UpdateAppend_Test_InvalidCmdLengthTooLow");
     UtTest_Add(SC_UpdateAppend_Test_InvalidCmdLengthTooHigh, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_UpdateAppend_Test_InvalidCmdLengthTooHigh");
-    UtTest_Add(SC_UpdateAppend_Test_EndOfBuffer, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_UpdateAppend_Test_EndOfBuffer");
+    UtTest_Add(SC_UpdateAppend_Test_EndOfBuffer, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_UpdateAppend_Test_EndOfBuffer");
     UtTest_Add(SC_UpdateAppend_Test_CmdNumberZero, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_UpdateAppend_Test_CmdNumberZero");
     UtTest_Add(SC_UpdateAppend_Test_CmdNumberTooHigh, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_UpdateAppend_Test_CmdNumberTooHigh");
     UtTest_Add(SC_ProcessAppend_Test, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_ProcessAppend_Test");
-    UtTest_Add(SC_ProcessAppend_Test_CmdLoaded, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_ProcessAppend_Test_CmdLoaded");
+    UtTest_Add(SC_ProcessAppend_Test_CmdLoaded, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessAppend_Test_CmdLoaded");
     UtTest_Add(SC_ProcessAppend_Test_NotExecuting, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_ProcessAppend_Test_NotExecuting");
-    UtTest_Add(SC_ProcessAppend_Test_AtsNumber, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_ProcessAppend_Test_AtsNumber");
+    UtTest_Add(SC_ProcessAppend_Test_AtsNumber, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessAppend_Test_AtsNumber");
     UtTest_Add(SC_ProcessAppend_Test_InvalidIndex, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_ProcessAppend_Test_InvalidIndex");
-    UtTest_Add(SC_VerifyAtsTable_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_VerifyAtsTable_Test_Nominal");
+    UtTest_Add(SC_VerifyAtsTable_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_VerifyAtsTable_Test_Nominal");
     UtTest_Add(SC_VerifyAtsTable_Test_InvalidEntry, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_VerifyAtsTable_Test_InvalidEntry");
-    UtTest_Add(SC_VerifyAtsTable_Test_EmptyTable, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_VerifyAtsTable_Test_EmptyTable");
-    UtTest_Add(SC_VerifyAtsEntry_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_VerifyAtsEntry_Test_Nominal");
+    UtTest_Add(SC_VerifyAtsTable_Test_EmptyTable, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_VerifyAtsTable_Test_EmptyTable");
+    UtTest_Add(SC_VerifyAtsEntry_Test_Nominal, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_VerifyAtsEntry_Test_Nominal");
     UtTest_Add(SC_VerifyAtsEntry_Test_EndOfBuffer, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_VerifyAtsEntry_Test_EndOfBuffer");
     UtTest_Add(SC_VerifyAtsEntry_Test_InvalidCmdNumber, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_VerifyAtsEntry_Test_InvalidCmdNumber");
-    UtTest_Add(SC_VerifyAtsEntry_Test_BufferFull, UT_SC_Loads_Test_Setup, SC_Test_TearDown, "SC_VerifyAtsEntry_Test_BufferFull");
+    UtTest_Add(SC_VerifyAtsEntry_Test_BufferFull, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
+               "SC_VerifyAtsEntry_Test_BufferFull");
     UtTest_Add(SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow, UT_SC_Loads_Test_Setup, SC_Test_TearDown,
                "SC_VerifyAtsEntry_Test_InvalidCmdLengthTooLow");
     UtTest_Add(SC_VerifyAtsEntry_Test_InvalidCmdLengthTooHigh, UT_SC_Loads_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -55,7 +55,7 @@ void SC_StartRtsCmd_Test_Nominal(void)
     UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_LOADED;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
      * big" */
@@ -67,8 +67,8 @@ void SC_StartRtsCmd_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0");
@@ -98,7 +98,7 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     Entry->TimeTag = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr       = 0;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
@@ -111,8 +111,8 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0");
@@ -149,7 +149,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_LOADED;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
      * big" */
@@ -177,7 +177,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_LOADED;
 
     /* Set message size in order to satisfy if-statement after comment "Make sure the command is big enough, but not too
      * big" */
@@ -204,7 +204,7 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
     UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = false;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_IDLE;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
@@ -225,7 +225,7 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
     UT_CmdBuf.StartRtsCmd.Payload.RtsId = 1;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag = true;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus    = SC_Status_LOADED;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_StartRtsCmd(&UT_CmdBuf.StartRtsCmd));
@@ -263,7 +263,7 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
 {
     uint8 RtsIndex = 0;
 
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_LOADED;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_Status_LOADED;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr    = 0;
 
     UT_CmdBuf.StartRtsGrpCmd.Payload.FirstRtsId = 1;
@@ -273,8 +273,8 @@ void SC_StartRtsGrpCmd_Test_Nominal(void)
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0");
@@ -385,7 +385,7 @@ void SC_StartRtsGrpCmd_Test_DisabledFlag(void)
     uint8 RtsIndex = 0;
 
     SC_OperData.RtsInfoTblAddr[RtsIndex].DisabledFlag   = true;
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
@@ -419,7 +419,7 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
 {
     uint8 RtsIndex = 0;
 
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus      = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[RtsIndex].UseCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr         = 0;
     SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandPtr = 0;
@@ -431,8 +431,8 @@ void SC_StartRtsGrpCmd_Test_RtsStatus(void)
     UtAssert_VOIDCALL(SC_StartRtsGrpCmd(&UT_CmdBuf.StartRtsGrpCmd));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_EXECUTING");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_EXECUTING");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0, "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdCtr == 0");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].CmdErrCtr == 0");
@@ -513,7 +513,7 @@ void SC_StopRtsGrpCmd_Test_NotExecuting(void)
 {
     uint8 RtsIndex = 0;
 
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_Status_EXECUTING;
 
     UT_CmdBuf.StopRtsGrpCmd.Payload.FirstRtsId = 1;
     UT_CmdBuf.StopRtsGrpCmd.Payload.LastRtsId  = 1;
@@ -945,15 +945,15 @@ void SC_KillRts_Test(void)
 {
     uint8 RtsIndex = 0;
 
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_Status_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_KillRts(RtsIndex));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
@@ -965,15 +965,15 @@ void SC_KillRts_Test_NoActiveRts(void)
 {
     uint8 RtsIndex = 0;
 
-    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus = SC_Status_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->NumRtsActive      = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_KillRts(RtsIndex));
 
     /* Verify results */
-    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED,
-                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_LOADED");
+    UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED,
+                  "SC_OperData.RtsInfoTblAddr[RtsIndex].RtsStatus == SC_Status_LOADED");
     UtAssert_True(SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME,
                   "SC_OperData.RtsInfoTblAddr[RtsIndex].NextCommandTime == SC_MAX_TIME");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -56,7 +56,7 @@ int32 SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook(void *UserObj, int32 StubRetcod
 
 void SC_GetNextRtsTime_Test_Nominal(void)
 {
-    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = SC_MAX_TIME;
 
     /* Execute the function being tested */
@@ -84,17 +84,18 @@ void SC_GetNextRtsTime_Test_InvalidRtsNumber(void)
     /* Verify results */
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->RtsNumber == SC_INVALID_RTS_NUMBER,
                   "SC_OperData.RtsCtrlBlckAddr->RtsNumber == SC_INVALID_RTS_NUMBER");
-    UtAssert_True(SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME, "SC_AppData.NextCmdTime[SC_RTP] == SC_MAX_TIME");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_TIME,
+                  "SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_TIME");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextRtsTime_Test_RtsPriority(void)
 {
-    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = SC_MAX_TIME;
 
-    SC_OperData.RtsInfoTblAddr[1].RtsStatus       = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[1].RtsStatus       = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[1].NextCommandTime = SC_MAX_TIME - 1;
 
     /* Execute the function being tested */
@@ -109,29 +110,29 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
 
 void SC_UpdateNextTime_Test_Atp(void)
 {
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
+    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_ATP, "SC_AppData.NextProcNumber == SC_Process_ATP");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_UpdateNextTime_Test_Atp2(void)
 {
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_EXECUTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = SC_NUMBER_OF_RTS + 1;
-    SC_AppData.NextCmdTime[SC_RTP]         = 0;
-    SC_AppData.NextCmdTime[SC_ATP]         = 10;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 10;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_ATP, "SC_AppData.NextProcNumber == SC_ATP");
+    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_ATP, "SC_AppData.NextProcNumber == SC_Process_ATP");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -139,17 +140,17 @@ void SC_UpdateNextTime_Test_Atp2(void)
 void SC_UpdateNextTime_Test_Rtp(void)
 {
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 10;
-    SC_AppData.NextCmdTime[SC_RTP]         = 0;
-    SC_AppData.NextCmdTime[SC_ATP]         = 10;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 10;
 
-    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[0].RtsStatus       = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[0].NextCommandTime = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_UpdateNextTime());
 
     /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_RTP, "SC_AppData.NextProcNumber == SC_RTP");
+    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_RTP, "SC_AppData.NextProcNumber == SC_Process_RTP");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -157,10 +158,10 @@ void SC_UpdateNextTime_Test_Rtp(void)
 void SC_UpdateNextTime_Test_RtpAtpPriority(void)
 {
     SC_OperData.RtsCtrlBlckAddr->RtsNumber = 0;
-    SC_AppData.NextCmdTime[SC_RTP]         = 0;
-    SC_AppData.NextCmdTime[SC_ATP]         = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
 
-    SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].RtsStatus       = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].RtsStatus       = SC_Status_EXECUTING;
     SC_OperData.RtsInfoTblAddr[SC_NUMBER_OF_RTS - 1].NextCommandTime = 1;
 
     /* Execute the function being tested */
@@ -174,11 +175,11 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 {
     size_t MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
@@ -215,11 +216,11 @@ void SC_GetNextRtsCommand_Test_RtsNumberMax(void)
 {
     size_t MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_NUMBER_OF_RTS;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
@@ -242,9 +243,9 @@ void SC_GetNextRtsCommand_Test_RtsNumberOverMax(void)
 {
     size_t MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                 = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]         = 0;
     SC_AppData.CurrentTime                         = 1;
-    SC_AppData.NextProcNumber                      = SC_RTP;
+    SC_AppData.NextProcNumber                      = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber         = SC_NUMBER_OF_RTS + 1;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands = 1;
 
@@ -268,11 +269,11 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 {
     size_t MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_NUMBER_OF_RTS;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_IDLE;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_IDLE;
     SC_OperData.AtsInfoTblAddr[1].NumberOfCommands                                   = 1;
 
     /* Give the packet the minimum possible size, to ensure that (CmdOffset < SC_RTS_HDR_WORDS) is met */
@@ -297,11 +298,11 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
     size_t               MsgSize1;
     size_t               MsgSize2;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[0][0];
 
@@ -346,11 +347,11 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
     size_t               MsgSize1;
     size_t               MsgSize2;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[0][0];
 
@@ -395,11 +396,11 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
     size_t               MsgSize1;
     size_t               MsgSize2;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_LAST_RTS_WITH_EVENTS;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS - 1][0];
 
@@ -434,11 +435,11 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
     size_t               MsgSize1;
     size_t               MsgSize2;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_LAST_RTS_WITH_EVENTS + 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS][0];
 
@@ -471,11 +472,11 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[0][0];
 
@@ -507,11 +508,11 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
     SC_RtsEntryHeader_t *Entry;
     size_t               MsgSize;
 
-    SC_AppData.NextCmdTime[SC_RTP]                                                   = 0;
+    SC_AppData.NextCmdTime[SC_Process_RTP]                                           = 0;
     SC_AppData.CurrentTime                                                           = 1;
-    SC_AppData.NextProcNumber                                                        = SC_RTP;
+    SC_AppData.NextProcNumber                                                        = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->RtsNumber                                           = SC_LAST_RTS_WITH_EVENTS + 1;
-    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_EXECUTING;
+    SC_OperData.RtsInfoTblAddr[SC_OperData.RtsCtrlBlckAddr->RtsNumber - 1].RtsStatus = SC_Status_EXECUTING;
 
     Entry = (SC_RtsEntryHeader_t *)&SC_OperData.RtsTblAddr[SC_LAST_RTS_WITH_EVENTS][0];
 
@@ -539,7 +540,7 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 
 void SC_GetNextAtsCommand_Test_Starting(void)
 {
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_STARTING;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_STARTING;
 
     /* Execute the function being tested */
     /* NOTE: Calling SC_ProcessRtpCommand instead of SC_GetNextRtsCommand - SC_ProcessRtpCommand calls
@@ -547,15 +548,15 @@ void SC_GetNextAtsCommand_Test_Starting(void)
     UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_EXECUTING,
-                  "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_EXECUTING");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING,
+                  "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_Status_EXECUTING");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_GetNextAtsCommand_Test_Idle(void)
 {
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_IDLE;
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_IDLE;
 
     /* Execute the function being tested */
     /* NOTE: Calling SC_ProcessRtpCommand instead of SC_GetNextRtsCommand - SC_ProcessRtpCommand calls
@@ -563,8 +564,8 @@ void SC_GetNextAtsCommand_Test_Idle(void)
     UtAssert_VOIDCALL(SC_GetNextAtsCommand());
 
     /* Verify results */
-    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_IDLE,
-                  "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_IDLE");
+    UtAssert_True(SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_IDLE,
+                  "SC_OperData.AtsCtrlBlckAddr -> AtpState == SC_Status_IDLE");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -576,19 +577,19 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_AppData.AtsTimeIndexBuffer[0][0]    = 1;
     SC_AppData.AtsTimeIndexBuffer[0][1]    = 2;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
-    SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 100;
+    SC_OperData.AtsInfoTblAddr[SC_Process_ATP].NumberOfCommands = 100;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_GetNextAtsCommand());
@@ -596,7 +597,7 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
     /* Verify results */
     UtAssert_INT32_EQ(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr, 1);
     UtAssert_INT32_EQ(SC_OperData.AtsCtrlBlckAddr->CmdNumber, SC_AppData.AtsTimeIndexBuffer[0][1]);
-    UtAssert_INT32_EQ(SC_AppData.NextCmdTime[SC_ATP], 0);
+    UtAssert_INT32_EQ(SC_AppData.NextCmdTime[SC_Process_ATP], 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -608,18 +609,18 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 2;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 0;
 
-    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[0][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[0][0]    = 0;
 
-    SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 0;
+    SC_OperData.AtsInfoTblAddr[SC_Process_ATP].NumberOfCommands = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_GetNextAtsCommand());
@@ -636,18 +637,18 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
     Entry            = (SC_AtsEntryHeader_t *)&SC_OperData.AtsTblAddr[0][0];
     Entry->CmdNumber = 1;
 
-    SC_AppData.NextCmdTime[SC_ATP]        = 0;
-    SC_AppData.CurrentTime                = 1;
-    SC_AppData.NextProcNumber             = SC_ATP;
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_EXECUTING;
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 1;
+    SC_AppData.NextProcNumber              = SC_Process_ATP;
+    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->AtsNumber = 1;
     SC_OperData.AtsCtrlBlckAddr->CmdNumber = 0;
 
-    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_LOADED;
+    SC_OperData.AtsCmdStatusTblAddr[1][0] = SC_Status_LOADED;
     SC_AppData.AtsCmdIndexBuffer[1][0]    = 0;
 
-    SC_OperData.AtsInfoTblAddr[SC_ATP].NumberOfCommands = 0;
+    SC_OperData.AtsInfoTblAddr[SC_Process_ATP].NumberOfCommands = 0;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_GetNextAtsCommand());


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
First commit: updates all symbol names to adhere to the naming conventions from CFE.  This is basically a search and replace, to make names compliant.  
Fixes #113

Second commit: Apply the `CFE_MSG_PTR()` macro to do type conversions on messages. 
Fixes #123

**Testing performed**
Build and run SC and all tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
These two fixes are combined into a single PR as the second one is affected by the name changes in the first one.  These would conflict if done in separate PRs.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
