### PR TITLE
Fix #119, consistent ID reports in events and logs

### DIFF
--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -78,7 +78,7 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
                     SC_OperData.HkPacket.Payload.CmdCtr++;
 
                     CFE_EVS_SendEvent(SC_STARTATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                      "ATS %c Execution Started", (AtsIndex ? 'B' : 'A'));
+                                      "ATS %c Execution Started", SC_IDX_AS_CHAR(AtsIndex));
                 }
                 else
                 { /* could not start the ats, all commands were skipped */
@@ -93,7 +93,7 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
             { /* the ats didn't have any commands in it */
 
                 CFE_EVS_SendEvent(SC_STARTATS_CMD_NOT_LDED_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Start ATS Rejected: ATS %c Not Loaded", (AtsIndex ? 'B' : 'A'));
+                                  "Start ATS Rejected: ATS %c Not Loaded", SC_IDX_AS_CHAR(AtsIndex));
 
                 /* increment the command request error counter */
                 SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -129,8 +129,7 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
 {
-    char  TempAtsChar = ' ';
-    int32 Result      = SC_ERROR;
+    int32 Result = SC_ERROR;
 
     /*
      ** Check if the ATS ID is valid
@@ -140,21 +139,10 @@ void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
         Result = CFE_SUCCESS;
     }
 
-    if (SC_OperData.AtsCtrlBlckAddr->CurrAtsNum == SC_AtsId_ATSA)
-    {
-        TempAtsChar = 'A';
-    }
-    else
-    {
-        if (SC_OperData.AtsCtrlBlckAddr->CurrAtsNum == SC_AtsId_ATSB)
-        {
-            TempAtsChar = 'B';
-        }
-    }
-
     if (Result == CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(SC_STOPATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "ATS %c stopped", TempAtsChar);
+        CFE_EVS_SendEvent(SC_STOPATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "ATS %c stopped",
+                          SC_IDX_AS_CHAR(SC_AtsNumToIndex(SC_OperData.AtsCtrlBlckAddr->CurrAtsNum)));
     }
     else
     {
@@ -192,7 +180,7 @@ bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_BEGINATS_INVLD_INDEX_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Begin ATS error: invalid ATS index %d", AtsIndex);
+                          "Begin ATS error: invalid ATS index %u", SC_IDX_AS_UINT(AtsIndex));
         return false;
     }
 
@@ -407,8 +395,8 @@ void SC_ServiceSwitchPend(void)
                     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
                     CFE_EVS_SendEvent(SC_ATS_SERVICE_SWTCH_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                      "ATS Switched from %c to %c", (OldAtsIndex ? 'B' : 'A'),
-                                      (NewAtsIndex ? 'B' : 'A'));
+                                      "ATS Switched from %c to %c", SC_IDX_AS_CHAR(OldAtsIndex),
+                                      SC_IDX_AS_CHAR(NewAtsIndex));
 
                 } /* end if */
             }
@@ -470,7 +458,7 @@ bool SC_InlineSwitch(void)
             SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_STARTING;
 
             CFE_EVS_SendEvent(SC_ATS_INLINE_SWTCH_INF_EID, CFE_EVS_EventType_INFORMATION, "ATS Switched from %c to %c",
-                              (OldAtsIndex ? 'B' : 'A'), (NewAtsIndex ? 'B' : 'A'));
+                              SC_IDX_AS_CHAR(OldAtsIndex), SC_IDX_AS_CHAR(NewAtsIndex));
 
             /*
              **  Update the command counter and return code
@@ -583,7 +571,7 @@ void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
             {
                 /* jump time is less than or equal to this list entry */
                 CFE_EVS_SendEvent(SC_JUMPATS_CMD_LIST_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Jump Cmd: Jump time less than or equal to list entry %d", CmdIndex);
+                                  "Jump Cmd: Jump time less than or equal to list entry %u", SC_IDX_AS_UINT(CmdIndex));
                 break;
             }
         }
@@ -660,7 +648,7 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_CONT_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Continue ATS On Failure command  failed, invalid state: %d", State);
+                          "Continue ATS On Failure command  failed, invalid state: %lu", (unsigned long)State);
     }
     else
     {
@@ -668,8 +656,8 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
 
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_CONT_CMD_DEB_EID, CFE_EVS_EventType_DEBUG, "Continue-ATS-On-Failure command, State: %d",
-                          State);
+        CFE_EVS_SendEvent(SC_CONT_CMD_DEB_EID, CFE_EVS_EventType_DEBUG, "Continue-ATS-On-Failure command, State: %lu",
+                          (unsigned long)State);
     }
 }
 
@@ -704,7 +692,7 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_TGT_ERR_EID, CFE_EVS_EventType_ERROR, "Append ATS %c error: ATS table is empty",
-                          'A' + AtsIndex);
+                          SC_IDX_AS_CHAR(AtsIndex));
     }
     else if (SC_OperData.HkPacket.Payload.AppendEntryCount == 0)
     {
@@ -712,7 +700,7 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_SRC_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Append ATS %c error: Append table is empty", 'A' + AtsIndex);
+                          "Append ATS %c error: Append table is empty", SC_IDX_AS_CHAR(AtsIndex));
     }
     else if ((AtsInfoPtr->AtsSize + SC_AppData.AppendWordCount) > SC_ATS_BUFF_SIZE32)
     {
@@ -720,8 +708,9 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_FIT_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Append ATS %c error: ATS size = %d, Append size = %d, ATS buffer = %d", 'A' + AtsIndex,
-                          (int)AtsInfoPtr->AtsSize, SC_AppData.AppendWordCount, SC_ATS_BUFF_SIZE32);
+                          "Append ATS %c error: ATS size = %d, Append size = %d, ATS buffer = %d",
+                          SC_IDX_AS_CHAR(AtsIndex), (int)AtsInfoPtr->AtsSize, SC_AppData.AppendWordCount,
+                          SC_ATS_BUFF_SIZE32);
     }
     else
     {
@@ -735,7 +724,7 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
         CFE_EVS_SendEvent(SC_APPEND_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Append ATS %c command: %d ATS entries appended", 'A' + AtsIndex,
+                          "Append ATS %c command: %d ATS entries appended", SC_IDX_AS_CHAR(AtsIndex),
                           SC_OperData.HkPacket.Payload.AppendEntryCount);
     }
 }

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -58,7 +58,6 @@ void SC_ProcessAtpCmd(void)
     SC_AtsIndex_t                 AtsIndex; /* ATS selection index */
     SC_CommandIndex_t             CmdIndex; /* ATS command index */
     CFE_Status_t                  Result;
-    char                          TempAtsChar;
     bool                          AbortATS = false;
     SC_AtsEntry_t *               EntryPtr;
     CFE_SB_MsgId_t                MessageID   = CFE_SB_INVALID_MSG_ID;
@@ -174,8 +173,8 @@ void SC_ProcessAtpCmd(void)
                             SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
                             CFE_EVS_SendEvent(SC_ATS_DIST_ERR_EID, CFE_EVS_EventType_ERROR,
-                                              "ATS Command Distribution Failed, Cmd Number: %d, SB returned: 0x%08X",
-                                              EntryPtr->Header.CmdNumber, (unsigned int)Result);
+                                              "ATS Command Distribution Failed, Cmd Number: %u, SB returned: 0x%08X",
+                                              SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber), (unsigned int)Result);
 
                             /* Mark this ATS for abortion */
                             AbortATS = true;
@@ -188,7 +187,8 @@ void SC_ProcessAtpCmd(void)
                      ** Send an event message to report the invalid command status
                      */
                     CFE_EVS_SendEvent(SC_ATS_CHKSUM_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "ATS Command Failed Checksum: Command #%d Skipped", EntryPtr->Header.CmdNumber);
+                                      "ATS Command Failed Checksum: Command #%u Skipped",
+                                      SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber));
                     /*
                      ** Increment the ATS error counter
                      */
@@ -217,8 +217,9 @@ void SC_ProcessAtpCmd(void)
                  */
 
                 CFE_EVS_SendEvent(SC_ATS_MSMTCH_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "ATS Command Number Mismatch: Command Skipped, expected: %d received: %d",
-                                  (int)SC_CommandIndexToNum(CmdIndex), EntryPtr->Header.CmdNumber);
+                                  "ATS Command Number Mismatch: Command Skipped, expected: %u received: %u",
+                                  SC_IDNUM_AS_UINT(SC_CommandIndexToNum(CmdIndex)),
+                                  SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber));
                 /*
                  ** Increment the ATS error counter
                  */
@@ -263,16 +264,7 @@ void SC_ProcessAtpCmd(void)
 
         if (AbortATS == true)
         {
-            if (SC_OperData.AtsCtrlBlckAddr->CurrAtsNum == SC_AtsId_ATSA)
-            {
-                TempAtsChar = 'A';
-            }
-            else
-            {
-                TempAtsChar = 'B';
-            }
-
-            CFE_EVS_SendEvent(SC_ATS_ABT_ERR_EID, CFE_EVS_EventType_ERROR, "ATS %c Aborted", TempAtsChar);
+            CFE_EVS_SendEvent(SC_ATS_ABT_ERR_EID, CFE_EVS_EventType_ERROR, "ATS %c Aborted", SC_IDX_AS_CHAR(AtsIndex));
 
             /* Stop the ATS from executing */
             SC_KillAts();
@@ -371,8 +363,8 @@ void SC_ProcessRtpCommand(void)
                  ** Send an event message to report the invalid command status
                  */
                 CFE_EVS_SendEvent(SC_RTS_DIST_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "RTS %03d Command Distribution Failed: RTS Stopped. SB returned 0x%08X",
-                                  (int)SC_OperData.RtsCtrlBlckAddr->CurrRtsNum, (unsigned int)Result);
+                                  "RTS %03u Command Distribution Failed: RTS Stopped. SB returned 0x%08X",
+                                  SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum), (unsigned int)Result);
 
                 SC_OperData.HkPacket.Payload.RtsCmdErrCtr++;
                 RtsInfoPtr->CmdErrCtr++;
@@ -393,8 +385,8 @@ void SC_ProcessRtpCommand(void)
              ** Send an event message to report the invalid command status
              */
             CFE_EVS_SendEvent(SC_RTS_CHKSUM_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "RTS %03d Command Failed Checksum: RTS Stopped",
-                              (int)SC_OperData.RtsCtrlBlckAddr->CurrRtsNum);
+                              "RTS %03u Command Failed Checksum: RTS Stopped",
+                              SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum));
             /*
             ** Update the RTS command error counter and last RTS error info
             */

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -66,7 +66,7 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex)
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_LOADATS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR, "ATS load error: invalid ATS index %d",
-                          AtsIndex);
+                          SC_IDX_AS_UINT(AtsIndex));
         return;
     }
 
@@ -189,7 +189,7 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex)
     if ((Result == CFE_SUCCESS) && (AtsInfoPtr->NumberOfCommands > 0))
     {
         /* record the size of the load in the ATS info table */
-        AtsInfoPtr->AtsSize = AtsEntryIndex; /* size in 32-bit WORDS */
+        AtsInfoPtr->AtsSize = SC_IDX_AS_UINT(AtsEntryIndex); /* size in 32-bit WORDS */
 
         /* build the time index table */
         SC_BuildTimeIndexTable(AtsIndex);
@@ -216,7 +216,7 @@ void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_BUILD_TIME_IDXTBL_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Build time index table error: invalid ATS index %d", AtsIndex);
+                          "Build time index table error: invalid ATS index %u", SC_IDX_AS_UINT(AtsIndex));
         return;
     }
 
@@ -259,7 +259,7 @@ void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex, uint32 Lis
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_INSERTATS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "ATS insert error: invalid ATS index %d", AtsIndex);
+                          "ATS insert error: invalid ATS index %u", SC_IDX_AS_UINT(AtsIndex));
         return;
     }
 
@@ -340,7 +340,7 @@ void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_INIT_ATSTBL_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "ATS table init error: invalid ATS index %d", AtsIndex);
+                          "ATS table init error: invalid ATS index %u", SC_IDX_AS_UINT(AtsIndex));
         return;
     }
 
@@ -390,7 +390,7 @@ void SC_LoadRts(SC_RtsIndex_t RtsIndex)
     else
     {
         CFE_EVS_SendEvent(SC_LOADRTS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "RTS table init error: invalid RTS index %d", RtsIndex);
+                          "RTS table init error: invalid RTS index %u", SC_IDX_AS_UINT(RtsIndex));
         return;
     }
 } /* SC_LoadRts */
@@ -648,7 +648,7 @@ void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
     if (!SC_AtsIndexIsValid(AtsIndex))
     {
         CFE_EVS_SendEvent(SC_PROCESS_APPEND_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "ATS process append error: invalid ATS index %d", AtsIndex);
+                          "ATS process append error: invalid ATS index %u", SC_IDX_AS_UINT(AtsIndex));
         return;
     }
 
@@ -823,8 +823,8 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
         Result = SC_ERROR;
 
         CFE_EVS_SendEvent(SC_VERIFY_ATS_NUM_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Verify ATS Table error: invalid command number: buf index = %d, cmd num = %d",
-                          (int)EntryIndex, EntryPtr->Header.CmdNumber);
+                          "Verify ATS Table error: invalid command number: buf index = %d, cmd num = %u",
+                          (int)EntryIndex, SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber));
     }
     else if ((EntryIndex + SC_ATS_HDR_WORDS) > BufferWords)
     {
@@ -832,8 +832,8 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
         Result = SC_ERROR;
 
         CFE_EVS_SendEvent(SC_VERIFY_ATS_END_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Verify ATS Table error: buffer full: buf index = %d, cmd num = %d, buf words = %d",
-                          (int)EntryIndex, EntryPtr->Header.CmdNumber, (int)BufferWords);
+                          "Verify ATS Table error: buffer full: buf index = %d, cmd num = %u, buf words = %d",
+                          (int)EntryIndex, SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber), (int)BufferWords);
     }
     else
     {
@@ -849,8 +849,8 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
             Result = SC_ERROR;
 
             CFE_EVS_SendEvent(SC_VERIFY_ATS_PKT_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Verify ATS Table error: invalid length: buf index = %d, cmd num = %d, pkt len = %d",
-                              (int)EntryIndex, EntryPtr->Header.CmdNumber, (int)CommandBytes);
+                              "Verify ATS Table error: invalid length: buf index = %d, cmd num = %u, pkt len = %d",
+                              (int)EntryIndex, SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber), (int)CommandBytes);
         }
         else if ((EntryIndex + SC_ATS_HDR_NOPKT_WORDS + CommandWords) > BufferWords)
         {
@@ -858,8 +858,8 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
             Result = SC_ERROR;
 
             CFE_EVS_SendEvent(SC_VERIFY_ATS_BUF_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Verify ATS Table error: buffer overflow: buf index = %d, cmd num = %d, pkt len = %d",
-                              (int)EntryIndex, EntryPtr->Header.CmdNumber, (int)CommandBytes);
+                              "Verify ATS Table error: buffer overflow: buf index = %d, cmd num = %u, pkt len = %d",
+                              (int)EntryIndex, SC_IDNUM_AS_UINT(EntryPtr->Header.CmdNumber), (int)CommandBytes);
         }
         else if (SC_OperData.AtsDupTestArray[SC_CommandNumToIndex(EntryPtr->Header.CmdNumber)] != SC_DUP_TEST_UNUSED)
         {

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -111,20 +111,20 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
                     if (Cmd->Payload.RtsNum <= SC_LAST_RTS_WITH_EVENTS)
                     {
                         CFE_EVS_SendEvent(SC_RTS_START_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                          "RTS Number %03d Started", RtsNum);
+                                          "RTS Number %03u Started", SC_IDNUM_AS_UINT(RtsNum));
                     }
                     else
                     {
-                        CFE_EVS_SendEvent(SC_STARTRTS_CMD_DBG_EID, CFE_EVS_EventType_DEBUG, "Start RTS #%d command",
-                                          RtsNum);
+                        CFE_EVS_SendEvent(SC_STARTRTS_CMD_DBG_EID, CFE_EVS_EventType_DEBUG, "Start RTS #%u command",
+                                          SC_IDNUM_AS_UINT(RtsNum));
                     }
                 }
                 else
                 { /* the length field of the 1st cmd was bad */
                     CFE_EVS_SendEvent(
                         SC_STARTRTS_CMD_INVLD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Start RTS %03d Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %d",
-                        RtsNum, (int)CmdLength);
+                        "Start RTS %03u Rejected: Invld Len Field for 1st Cmd in Sequence. Invld Cmd Length = %lu",
+                        SC_IDNUM_AS_UINT(RtsNum), (unsigned long)CmdLength);
 
                     SC_OperData.HkPacket.Payload.CmdErrCtr++;
                     SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
@@ -135,8 +135,8 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
             { /* Cannot use the RTS now */
 
                 CFE_EVS_SendEvent(SC_STARTRTS_CMD_NOT_LDED_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Start RTS %03d Rejected: RTS Not Loaded or In Use, Status: %d", Cmd->Payload.RtsNum,
-                                  RtsInfoPtr->RtsStatus);
+                                  "Start RTS %03u Rejected: RTS Not Loaded or In Use, Status: %lu",
+                                  SC_IDNUM_AS_UINT(Cmd->Payload.RtsNum), (unsigned long)RtsInfoPtr->RtsStatus);
 
                 SC_OperData.HkPacket.Payload.CmdErrCtr++;
                 SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
@@ -146,7 +146,7 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
         else
         { /* the RTS is disabled */
             CFE_EVS_SendEvent(SC_STARTRTS_CMD_DISABLED_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Start RTS %03d Rejected: RTS Disabled", RtsNum);
+                              "Start RTS %03u Rejected: RTS Disabled", SC_IDNUM_AS_UINT(RtsNum));
 
             SC_OperData.HkPacket.Payload.CmdErrCtr++;
             SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
@@ -155,7 +155,7 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
     else
     { /* the rts id is invalid */
         CFE_EVS_SendEvent(SC_STARTRTS_CMD_INVALID_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Start RTS %03d Rejected: Invalid RTS ID", RtsNum);
+                          "Start RTS %03u Rejected: Invalid RTS ID", SC_IDNUM_AS_UINT(RtsNum));
 
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
         SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
@@ -218,8 +218,8 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
                 { /* Cannot use the RTS now */
                     CFE_EVS_SendEvent(
                         SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Start RTS group error: rejected RTS ID %03d, RTS Not Loaded or In Use, Status: %d",
-                        SC_RtsIndexToNum(RtsIndex), RtsInfoPtr->RtsStatus);
+                        "Start RTS group error: rejected RTS ID %03u, RTS Not Loaded or In Use, Status: %lu",
+                        SC_IDNUM_AS_UINT(SC_RtsIndexToNum(RtsIndex)), (unsigned long)RtsInfoPtr->RtsStatus);
 
                     SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
@@ -228,8 +228,8 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
             else
             { /* the RTS is disabled */
                 CFE_EVS_SendEvent(SC_STARTRTSGRP_CMD_DISABLED_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Start RTS group error: rejected RTS ID %03d, RTS Disabled",
-                                  SC_RtsIndexToNum(RtsIndex));
+                                  "Start RTS group error: rejected RTS ID %03u, RTS Disabled",
+                                  SC_IDNUM_AS_UINT(SC_RtsIndexToNum(RtsIndex)));
 
                 SC_OperData.HkPacket.Payload.RtsActiveErrCtr++;
 
@@ -238,14 +238,15 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
 
         /* success */
         CFE_EVS_SendEvent(SC_STARTRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Start RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstRtsNum, LastRtsNum,
-                          (int)StartCount);
+                          "Start RTS group: FirstID=%u, LastID=%u, Modified=%d", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum), (int)StartCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_STARTRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Start RTS group error: FirstID=%d, LastID=%d", FirstRtsNum, LastRtsNum);
+                          "Start RTS group error: FirstID=%u, LastID=%u", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum));
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
@@ -273,14 +274,15 @@ void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
 
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_STOPRTS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "RTS %03d Aborted", RtsNum);
+        CFE_EVS_SendEvent(SC_STOPRTS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "RTS %03u Aborted",
+                          SC_IDNUM_AS_UINT(RtsNum));
     }
     else
     { /* the specified RTS is invalid */
 
         /* the rts id is invalid */
-        CFE_EVS_SendEvent(SC_STOPRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Stop RTS %03d rejected: Invalid RTS ID",
-                          RtsNum);
+        CFE_EVS_SendEvent(SC_STOPRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Stop RTS %03u rejected: Invalid RTS ID",
+                          SC_IDNUM_AS_UINT(RtsNum));
 
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
@@ -326,14 +328,15 @@ void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
 
         /* success */
         CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Stop RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstRtsNum, LastRtsNum,
-                          (int)StopCount);
+                          "Stop RTS group: FirstID=%u, LastID=%u, Modified=%d", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum), (int)StopCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_STOPRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Stop RTS group error: FirstID=%d, LastID=%d", FirstRtsNum, LastRtsNum);
+                          "Stop RTS group error: FirstID=%u, LastID=%u", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum));
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
@@ -364,12 +367,13 @@ void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
         /* update the command status */
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_DISABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Disabled RTS %03d", RtsNum);
+        CFE_EVS_SendEvent(SC_DISABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Disabled RTS %03u",
+                          SC_IDNUM_AS_UINT(RtsNum));
     }
     else
     { /* it is not a valid RTS id */
-        CFE_EVS_SendEvent(SC_DISRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Disable RTS %03d Rejected: Invalid RTS ID",
-                          RtsNum);
+        CFE_EVS_SendEvent(SC_DISRTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Disable RTS %03u Rejected: Invalid RTS ID",
+                          SC_IDNUM_AS_UINT(RtsNum));
 
         /* update the command error status */
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -415,14 +419,15 @@ void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
 
         /* success */
         CFE_EVS_SendEvent(SC_DISRTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Disable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstRtsNum, LastRtsNum,
-                          (int)DisableCount);
+                          "Disable RTS group: FirstID=%u, LastID=%u, Modified=%d", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum), (int)DisableCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_DISRTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Disable RTS group error: FirstID=%d, LastID=%d", FirstRtsNum, LastRtsNum);
+                          "Disable RTS group error: FirstID=%u, LastID=%u", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum));
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
@@ -453,12 +458,12 @@ void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
         /* update the command status */
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_ENABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Enabled RTS %03d", RtsNum);
+        CFE_EVS_SendEvent(SC_ENABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Enabled RTS %03u", SC_IDNUM_AS_UINT(RtsNum));
     }
     else
     { /* it is not a valid RTS id */
-        CFE_EVS_SendEvent(SC_ENARTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Enable RTS %03d Rejected: Invalid RTS ID",
-                          RtsNum);
+        CFE_EVS_SendEvent(SC_ENARTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Enable RTS %03u Rejected: Invalid RTS ID",
+                          SC_IDNUM_AS_UINT(RtsNum));
 
         /* update the command error status */
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
@@ -505,14 +510,15 @@ void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
 
         /* success */
         CFE_EVS_SendEvent(SC_ENARTSGRP_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Enable RTS group: FirstID=%d, LastID=%d, Modified=%d", FirstRtsNum, LastRtsNum,
-                          (int)EnableCount);
+                          "Enable RTS group: FirstID=%u, LastID=%u, Modified=%d", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum), (int)EnableCount);
         SC_OperData.HkPacket.Payload.CmdCtr++;
     }
     else
     { /* error */
         CFE_EVS_SendEvent(SC_ENARTSGRP_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Enable RTS group error: FirstID=%d, LastID=%d", FirstRtsNum, LastRtsNum);
+                          "Enable RTS group error: FirstID=%u, LastID=%u", SC_IDNUM_AS_UINT(FirstRtsNum),
+                          SC_IDNUM_AS_UINT(LastRtsNum));
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
     }
 }
@@ -531,8 +537,8 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex)
     /* validate RTS array index */
     if (!SC_RtsIndexIsValid(RtsIndex))
     {
-        CFE_EVS_SendEvent(SC_KILLRTS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR, "RTS kill error: invalid RTS index %d",
-                          RtsIndex);
+        CFE_EVS_SendEvent(SC_KILLRTS_INV_INDEX_ERR_EID, CFE_EVS_EventType_ERROR, "RTS kill error: invalid RTS index %u",
+                          SC_IDX_AS_UINT(RtsIndex));
     }
     else if (RtsInfoPtr->RtsStatus == SC_Status_EXECUTING)
     {
@@ -589,6 +595,6 @@ void SC_AutoStartRts(SC_RtsNum_t RtsNum)
     else
     {
         CFE_EVS_SendEvent(SC_AUTOSTART_RTS_INV_ID_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "RTS autostart error: invalid RTS ID %d", RtsNum);
+                          "RTS autostart error: invalid RTS ID %u", SC_IDNUM_AS_UINT(RtsNum));
     }
 }

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -252,8 +252,8 @@ void SC_GetNextRtsCommand(void)
                              */
                             SC_KillRts(RtsIndex);
                             CFE_EVS_SendEvent(SC_RTS_LNGTH_ERR_EID, CFE_EVS_EventType_ERROR,
-                                              "Cmd Runs passed end of table, RTS %03d Aborted",
-                                              SC_OperData.RtsCtrlBlckAddr->CurrRtsNum);
+                                              "Cmd Runs passed end of table, RTS %03u Aborted",
+                                              SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum));
 
                         } /* end if the command runs off the end of the buffer */
                     }
@@ -269,8 +269,8 @@ void SC_GetNextRtsCommand(void)
                         /* Stop the RTS from executing */
                         SC_KillRts(RtsIndex);
                         CFE_EVS_SendEvent(SC_RTS_CMD_LNGTH_ERR_EID, CFE_EVS_EventType_ERROR,
-                                          "Invalid Length Field in RTS Command, RTS %03d Aborted. Length: %u, Max: %d",
-                                          SC_OperData.RtsCtrlBlckAddr->CurrRtsNum,
+                                          "Invalid Length Field in RTS Command, RTS %03u Aborted. Length: %u, Max: %d",
+                                          SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum),
                                           (unsigned int)(CmdLength - (uint16)SC_RTS_HEADER_SIZE), SC_PACKET_MAX_SIZE);
 
                     } /* end if the command length is invalid */
@@ -286,7 +286,8 @@ void SC_GetNextRtsCommand(void)
                     if (SC_RtsNumHasEvent(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum))
                     {
                         CFE_EVS_SendEvent(SC_RTS_COMPL_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                          "RTS %03d Execution Completed", SC_OperData.RtsCtrlBlckAddr->CurrRtsNum);
+                                          "RTS %03u Execution Completed",
+                                          SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum));
                     }
                 }
             }
@@ -297,7 +298,8 @@ void SC_GetNextRtsCommand(void)
                 if (SC_RtsNumHasEvent(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum))
                 {
                     CFE_EVS_SendEvent(SC_RTS_COMPL_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                      "RTS %03d Execution Completed", SC_OperData.RtsCtrlBlckAddr->CurrRtsNum);
+                                      "RTS %03u Execution Completed",
+                                      SC_IDNUM_AS_UINT(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum));
                 }
 
             } /* end if */
@@ -357,7 +359,7 @@ void SC_GetNextAtsCommand(void)
             /* stop the ATS */
             SC_KillAts();
             CFE_EVS_SendEvent(SC_ATS_COMPL_INF_EID, CFE_EVS_EventType_INFORMATION, "ATS %c Execution Completed",
-                              (AtsIndex ? 'B' : 'A'));
+                              SC_IDX_AS_CHAR(AtsIndex));
 
             /* stop any switch that is pending */
             /* because we just ran out of commands and are stopping the ATS */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Use the same format specifiers and conversion methods when indicating ATS/RTS IDs and indices in logs.  RTS identified by number, ATS identified by letter (A/B).

Fixes #119

**Testing performed**
Build and run all tests

**Expected behavior changes**
Possible minor changes to the text associated with some log messages/events. (consistency now, where there was not consistency before)

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
