### PR TITLE
Fix #120, clean up remainder of ATS A/B direct indexing

### DIFF
--- a/fsw/src/sc_utils.c
+++ b/fsw/src/sc_utils.c
@@ -158,5 +158,11 @@ SC_AtsIndex_t SC_ToggleAtsIndex(void)
 {
     SC_AtsIndex_t CurrAtsIndex = SC_AtsNumToIndex(SC_OperData.AtsCtrlBlckAddr->CurrAtsNum);
 
-    return (1 - CurrAtsIndex);
+    SC_IDX_INCREMENT(CurrAtsIndex);
+    if (!SC_AtsIndexIsValid(CurrAtsIndex))
+    {
+        CurrAtsIndex = SC_ATS_IDX_C(0);
+    }
+
+    return CurrAtsIndex;
 }

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -988,12 +988,12 @@ void SC_SendHkPacket_Test(void)
                   "SC_OperData.HkPacket.Payload.AppendEntryCount == 14");
     UtAssert_True(SC_OperData.HkPacket.Payload.AppendLoadCount == 16,
                   "SC_OperData.HkPacket.Payload.AppendLoadCount == 16");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AtpFreeBytes[0] ==
-                      (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) - (SC_GetAtsInfoObject(0)->AtsSize * SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.Payload.AtpFreeBytes[0] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
-    UtAssert_True(SC_OperData.HkPacket.Payload.AtpFreeBytes[1] ==
-                      (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD) - (SC_GetAtsInfoObject(1)->AtsSize * SC_BYTES_IN_WORD),
-                  "SC_OperData.HkPacket.Payload.AtpFreeBytes[1] == (SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD)");
+
+    for (i = 0; i < SC_NUMBER_OF_ATS; i++)
+    {
+        UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AtpFreeBytes[i], SC_ATS_BUFF_SIZE32 * SC_BYTES_IN_WORD);
+    }
+
     UtAssert_UINT8_EQ(SC_OperData.HkPacket.Payload.CurrAtsId, 17);
     SC_Assert_CmdStatus(SC_OperData.HkPacket.Payload.AtpState, 18);
     UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.AtpCmdNumber, 19);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Addresses the remainder of cases where the code assumed there will only be 2 ATS objects, and was indexing/accessing them directly.

The ToogleAtsIndex() function will now round-robin (this is equivalent if there are 2).  Any other ATS access should be in a loop over SC_NUMBER_OF_ATS.

Fixes #120

**Testing performed**
Build and run all tests with NUMBER_OF_ATS set to 2 as usual.  
Also tested compilation when setting NUMBER_OF_ATS to 3.  This compiled, but did not test functionality of this config.

**Expected behavior changes**
More robust implementation, in case someone wants to increase NUMBER_OF_ATS.

**System(s) tested on**
Debian

**Additional context**
Not sure if the requirements permit anything other than 2 here - there seems to be an underlying assumption of strict A/B double buffering pattern with ATS.  Still, even if its always 2 - a loop avoids repeated code and possible differences in how the 2 buffers are handled, while also being more robust just in case someone finds a use case for a triple-buffer.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
