### PR TITLE
Fix #136, Remove duplicate `target_include_directories` cmake command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ set(APP_TABLE_FILES
 
 add_cfe_tables(sc ${APP_TABLE_FILES})
 
-# This permits direct access to public headers in the fsw/inc directory
-target_include_directories(sc PUBLIC fsw/inc)
-
 # If UT is enabled, then add the tests from the subdirectory
 # Note that this is an app, and therefore does not provide
 # stub functions, as other entities would not typically make

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ predetermined times. SC supports both Absolute Time tagged command Sequences
 (ATSs) and multiple Relative Time tagged command Sequences (RTSs). The 
 purpose of ATS commands is to be able to specify commands to be executed at a 
 specific time.  The purpose of Relative Time Sequence commands is to be able 
-to specify commands to be executed at a relative times.
+to specify commands to be executed at a relative time.
 
 The SC application is written in C and depends on the cFS Operating System 
 Abstraction Layer (OSAL) and cFE components. There is additional SC application 

--- a/config/default_sc_internal_cfg.h
+++ b/config/default_sc_internal_cfg.h
@@ -151,7 +151,7 @@
  *
  *  \par Limits:
  *       This parameter must be greater than zero and less than or equal to
- *       CFE_SB_MAX_PIPE_DEPTH.
+ *       OS_QUEUE_MAX_DEPTH.
  */
 #define SC_PIPE_DEPTH 12
 

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -258,7 +258,7 @@ void SC_ProcessAtpCmd(void)
             SC_OperData.HkPacket.Payload.LastAtsErrCmd = SC_OperData.AtsCtrlBlckAddr->CmdNumber;
 
             /* Do Not Mark this ATS for abortion. The command could be marked as EXECUTED
-               if we alerady jumped back in time */
+               if we already jumped back in time */
 
         } /* end if */
 

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -71,7 +71,7 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex)
     }
 
     /*
-     ** Initialize all structrures
+     ** Initialize all structures
      */
     SC_InitAtsTables(AtsIndex);
 

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -563,7 +563,7 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Start an RTS on initilization                                   */
+/* Start an RTS on initialization                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SC_AutoStartRts(SC_RtsNum_t RtsNum)

--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -92,7 +92,7 @@ typedef union
 /* Helper macro to get size of structure elements */
 #define SC_MEMBER_SIZE(member) (sizeof(((SC_AtsStruct1_t *)0)->member))
 
-/* Used designated intializers to be verbose, modify as needed/desired */
+/* Used designated initializers to be verbose, modify as needed/desired */
 SC_AtsTable1_t SC_Ats1 = {
     /* 1 */
     .ats.hdr1.CmdNumber     = SC_COMMAND_NUM_INITIALIZER(1),

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -75,7 +75,7 @@ typedef union
 /* Helper macro to get size of structure elements */
 #define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct001_t *)0)->member))
 
-/* Used designated intializers to be verbose, modify as needed/desired */
+/* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable001_t SC_Rts001 = {
     /* 1 */
     .rts.hdr1.TimeTag       = 0,

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -69,7 +69,7 @@ typedef union
 /* Helper macro to get size of structure elements */
 #define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct002_t *)0)->member))
 
-/* Used designated intializers to be verbose, modify as needed/desired */
+/* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable002_t SC_Rts002 = {
     /* 1 */
     .rts.hdr1.TimeTag       = 0,

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -371,7 +371,7 @@ void SC_BeginAts_Test_AllCommandsSkipped(void)
     AtsCmdNumRec->CmdNum         = SC_COMMAND_NUM_C(1);
     AtsInfoPtr->NumberOfCommands = 1;
 
-    /* Set to cause all commnds to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
+    /* Set to cause all commands to be skipped, to generate error message SC_ATS_SKP_ALL_ERR_EID */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 
     /* Execute the function being tested */
@@ -744,7 +744,7 @@ void SC_InlineSwitch_Test_AllCommandsSkipped(void)
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
 
-    /* Set to cause all commnds to be skipped, to reach block starting with comment "all of the commands in the new ats
+    /* Set to cause all commands to be skipped, to reach block starting with comment "all of the commands in the new ats
      * were skipped" */
     UT_SetHookFunction(UT_KEY(CFE_TIME_Compare), UT_SC_StartAtsRq_CompareHookAgreaterthanB, NULL);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #136 
  - Removes duplicate `target_include_directories` cmake command
  - Fix various typos

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt