### PR TITLE
Fix #142, Standardize command responses

### DIFF
--- a/config/default_sc_fcncodes.h
+++ b/config/default_sc_fcncodes.h
@@ -238,7 +238,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdCtr will increment
- *       - The #SC_DISABLE_RTS_DEB_EID will be sent
+ *       - The #SC_DISABLE_RTS_INF_EID will be sent
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -269,7 +269,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdCtr will increment
- *       - The #SC_ENABLE_RTS_DEB_EID will be sent
+ *       - The #SC_ENABLE_RTS_INF_EID will be sent
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -362,7 +362,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdCtr will increment
- *       - The #SC_CONT_CMD_DEB_EID will be sent
+ *       - The #SC_CONT_CMD_INF_EID will be sent
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -414,13 +414,13 @@
 /**
  * \brief SC Continue ATS On Failure Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *  This event message is issued when the #SC_CONTINUE_ATS_ON_FAILURE_CC command was received and
  *  the state was changed successfully
  */
-#define SC_CONT_CMD_DEB_EID 43
+#define SC_CONT_CMD_INF_EID 43
 
 /**
  * \brief SC ATS Command Skipped Checksum Failed Event ID
@@ -503,10 +503,11 @@
 /**
  * \brief SC Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
- *  This event message is issued when the #SC_RESET_COUNTERS_CC command was received
+ *  This event message is issued when the #SC_RESET_COUNTERS_CC command was
+ * received
  */
 #define SC_RESET_INF_EID 51
 
@@ -751,12 +752,13 @@
 /**
  * \brief SC Disable RTS Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
- *  This event message is issued when a #SC_DISABLE_RTS_CC command was received, and executed successfully
+ *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
+ * and executed successfully
  */
-#define SC_DISABLE_RTS_DEB_EID 80
+#define SC_DISABLE_RTS_INF_EID 80
 
 /**
  * \brief SC Disable RTS Rejected RTS ID Invalid Event ID
@@ -772,12 +774,13 @@
 /**
  * \brief SC Enable RTS Command ID Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
- *  This event message is issued when a #SC_ENABLE_RTS_CC command was received, and executed successfully
+ *  This event message is issued when a #SC_ENABLE_RTS_CC command was received,
+ * and executed successfully
  */
-#define SC_ENABLE_RTS_DEB_EID 82
+#define SC_ENABLE_RTS_INF_EID 82
 
 /**
  * \brief SC Enable RTS Rejected RTS ID Invalid Event ID

--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -656,7 +656,8 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
 
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_CONT_CMD_DEB_EID, CFE_EVS_EventType_DEBUG, "Continue-ATS-On-Failure command, State: %lu",
+        CFE_EVS_SendEvent(SC_CONT_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Continue-ATS-On-Failure command, State: %lu",
                           (unsigned long)State);
     }
 }

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -59,12 +59,12 @@ void SC_ProcessAtpCmd(void)
     SC_CommandIndex_t             CmdIndex; /* ATS command index */
     CFE_Status_t                  Result;
     bool                          AbortATS = false;
-    SC_AtsEntry_t *               EntryPtr;
+    SC_AtsEntry_t                *EntryPtr;
     CFE_SB_MsgId_t                MessageID   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t             CommandCode = 0;
     bool                          ChecksumValid;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec; /* ATS entry location in table */
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
 
     /*
      ** The following conditions must be met before the ATS command will be
@@ -289,7 +289,7 @@ void SC_ProcessAtpCmd(void)
 
 void SC_ProcessRtpCommand(void)
 {
-    SC_RtsEntry_t *    EntryPtr;  /* a pointer to an RTS entry header */
+    SC_RtsEntry_t     *EntryPtr;  /* a pointer to an RTS entry header */
     SC_RtsIndex_t      RtsIndex;  /* the RTS index for the cmd */
     SC_EntryOffset_t   CmdOffset; /* the location of the cmd    */
     CFE_Status_t       Result;
@@ -518,7 +518,7 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
 
 void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
 {
-    CFE_EVS_SendEvent(SC_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(SC_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset counters command");
 
     SC_OperData.HkPacket.Payload.CmdCtr          = 0;
     SC_OperData.HkPacket.Payload.CmdErrCtr       = 0;
@@ -656,6 +656,8 @@ void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
         CFE_EVS_SendEvent(SC_TABLE_MANAGE_ID_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Table manage command packet error: table ID = %d", (int)TableID);
     }
+
+    // No success/informational event is sent for this command intentionally, to avoid the risk of flooding.
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -706,8 +708,8 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
 {
     CFE_Status_t     Result;
     CFE_TBL_Handle_t TblHandle;
-    uint32 **        TblAddr;
-    void *           TblPtrNew;
+    uint32         **TblAddr;
+    void            *TblPtrNew;
 
     switch (type)
     {
@@ -772,5 +774,4 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
                               "ATS Append table manage process error: Result = 0x%X", (unsigned int)Result);
         }
     }
-
 } /* End SC_ManageTable() */

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -367,8 +367,8 @@ void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
         /* update the command status */
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_DISABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Disabled RTS %03u",
-                          SC_IDNUM_AS_UINT(RtsNum));
+        CFE_EVS_SendEvent(SC_DISABLE_RTS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Disabled RTS %03u", SC_IDNUM_AS_UINT(RtsNum));
     }
     else
     { /* it is not a valid RTS id */
@@ -458,7 +458,8 @@ void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
         /* update the command status */
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_ENABLE_RTS_DEB_EID, CFE_EVS_EventType_DEBUG, "Enabled RTS %03u", SC_IDNUM_AS_UINT(RtsNum));
+        CFE_EVS_SendEvent(SC_ENABLE_RTS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Enabled RTS %03u", SC_IDNUM_AS_UINT(RtsNum));
     }
     else
     { /* it is not a valid RTS id */

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -952,7 +952,8 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UtAssert_BOOL_TRUE(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag);
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_CONT_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -974,7 +975,8 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
                   "SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag == false");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_DEB_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_CONT_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -634,7 +634,8 @@ void SC_DisableRtsCmd_Test_Nominal(void)
     UtAssert_True(RtsInfoPtr->DisabledFlag == true, "RtsInfoPtr->DisabledFlag == true");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_DISABLE_RTS_DEB_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_DISABLE_RTS_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -802,7 +803,8 @@ void SC_EnableRtsCmd_Test_Nominal(void)
     UtAssert_True(RtsInfoPtr->DisabledFlag == false, "RtsInfoPtr->DisabledFlag == false");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_ENABLE_RTS_DEB_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_ENABLE_RTS_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #142 
  - Changes `SC_RESET_DEB_EID`, `SC_DISABLE_RTS_DEB_EID`, `SC_ENABLE_RTS_DEB_EID` & `SC_CONT_CMD_DEB_EID` to `INFORMATION` type
  ~- Adds new event (`SC_TABLE_MANAGE_INF_EID`) and required logic to the `SC_ManageTableCmd` and `SC_ManageTable` functions in order to return a success event when no errors were encountered during processing (either from the SC functions or passed through from cFE functions)~
  ~- Updates nominal manage table tests to include a check for `SC_TABLE_MANAGE_INF_EID`~
Note: the issue requested the addition of an event for the `SC_MANAGE_TABLE_CC` command, but given the risk of flooding, and the fact that issuing an event for table processing is out-of-family with the open-source cFS apps, it has not been included in this pull request.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Success event will be issued if no errors are encountered during processing of the `SC_MANAGE_TABLE_CC` command.

**System(s) tested on**
Debian GNU/Linux 12 (bookworm)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt