### PR TITLE
Fix #84, Seconds to Wakeup Count

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@
 ## Introduction
 
 The Stored Command application (SC) is a core Flight System (cFS) application 
-that is a plug in to the Core Flight Executive (cFE) component of the cFS.  
-  
+that is a plug in to the Core Flight Executive (cFE) component of the cFS.
+
 The SC application allows a system to be autonomously commanded
-using sequences of commands that are loaded to SC. Each command has a time tag 
-associated with it, permitting the command to be released for distribution at 
-predetermined times. SC supports both Absolute Time tagged command Sequences 
-(ATSs) and multiple Relative Time tagged command Sequences (RTSs). The 
-purpose of ATS commands is to be able to specify commands to be executed at a 
-specific time.  The purpose of Relative Time Sequence commands is to be able 
-to specify commands to be executed at a relative time.
+using sequences of commands that are loaded into SC. Each command has a time tag
+or wakeup count associated with it, permitting the command to be released for
+distribution at predetermined times or wakeup counts. SC supports both
+Absolute Time tagged command Sequences (ATSs) and multiple Relative Time tagged
+command Sequences (RTSs). The purpose of ATS commands is to be able to specify
+commands to be executed at a specific time. The purpose of Relative Time
+Sequence commands is to be able to specify commands to be executed at a
+relative wakeup count.
 
 The SC application is written in C and depends on the cFS Operating System 
 Abstraction Layer (OSAL) and cFE components. There is additional SC application 

--- a/config/default_sc_internal_cfg.h
+++ b/config/default_sc_internal_cfg.h
@@ -71,19 +71,19 @@
 #define SC_PLATFORM_ENABLE_HEADER_UPDATE false
 
 /**
- * \brief  Max number of commands per second
+ * \brief  Max number of commands per wakeup
  *
  *  \par Description:
  *       Maximum number of commands that can be sent out by SC
- *       in any given second.
+ *       in any given wakeup cycle.
  *
  *  \par Limits:
  *       This parameter can't be larger than an unsigned 16 bit
- *       integer (65535), but should be kepoot relatively small to
+ *       integer (65535), but should be kept relatively small to
  *       avoid SC hogging the CPU
  *
  */
-#define SC_MAX_CMDS_PER_SEC 8
+#define SC_MAX_CMDS_PER_WAKEUP 8
 
 /**
  * \brief Max buffer size for an ATS in uint16s

--- a/config/default_sc_internal_cfg.h
+++ b/config/default_sc_internal_cfg.h
@@ -342,7 +342,7 @@
  * \brief Defines the TIME SC should use for its commands
  *
  *  \par Description:
- *       This parameter defines what type of time SC should use for sending uot its commands
+ *       This parameter defines what type of time SC should use for sending out its commands
  *
  *  \par Limits:
  *       Must be SC_TimeRef_USE_CFE_TIME, SC_TimeRef_USE_TAI, or SC_TimeRef_USE_UTC */

--- a/config/default_sc_msgdefs.h
+++ b/config/default_sc_msgdefs.h
@@ -101,6 +101,7 @@ typedef uint8 SC_Process_Enum_t;
 #endif
 
 #define SC_MAX_TIME 0xFFFFFFFF /**< \brief Maximum time in SC */
+#define SC_MAX_WAKEUP_CNT 0xFFFFFFFF /**< \brief Maximum wakeup count in SC */
 
 /**
  * Enumeration for ATS identifiers
@@ -216,7 +217,7 @@ typedef struct
     uint16      AppendLoadCount;  /**< \brief Total number of Append ATS table loads */
     uint32      AtpCmdNumber;     /**< \brief Current command number */
     uint32      AtpFreeBytes[SC_NUMBER_OF_ATS]; /**< \brief Free Bytes in each ATS  */
-    uint32      NextRtsTime;                    /**< \brief Next RTS cmd Absolute Time */
+    uint32      NextRtsWakeupCnt;               /**< \brief Next RTS Command Absolute Wakeup Count */
     uint32      NextAtsTime;                    /**< \brief Next ATS Command Time (seconds) */
 
     uint16 RtsExecutingStatus[(SC_NUMBER_OF_RTS + (SC_NUMBER_OF_RTS_IN_UINT16 - 1)) / SC_NUMBER_OF_RTS_IN_UINT16];

--- a/config/default_sc_msgids.h
+++ b/config/default_sc_msgids.h
@@ -31,7 +31,7 @@
 
 #define SC_CMD_MID          (0x18A9) /**< \brief Msg ID for cmds to SC   */
 #define SC_SEND_HK_MID      (0x18AA) /**< \brief Msg ID to request SC HK */
-#define SC_ONEHZ_WAKEUP_MID (0x18AB) /**< \brief Msg ID to receive the 1Hz */
+#define SC_WAKEUP_MID       (0x18AB) /**< \brief Msg ID to receive the wakeup command */
 
 /**\}*/
 
@@ -46,7 +46,8 @@
 
 /* Compatibility identifiers - in case existing SCH table(s) use the old wakeup MID define */
 #ifndef SC_OMIT_DEPRECATED
-#define SC_1HZ_WAKEUP_MID SC_ONEHZ_WAKEUP_MID
+#define SC_1HZ_WAKEUP_MID SC_WAKEUP_MID
+#define SC_ONEHZ_WAKEUP_MID SC_WAKEUP_MID
 #endif
 
 #endif

--- a/config/default_sc_msgstruct.h
+++ b/config/default_sc_msgstruct.h
@@ -122,14 +122,14 @@ typedef struct
 } SC_SendHkCmd_t;
 
 /**
- *  \brief 1Hz Wakeup Command
+ *  \brief Wakeup Command
  *
- *  For command details see #SC_ONEHZ_WAKEUP_MID
+ *  For command details see #SC_WAKEUP_MID
  */
 typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Header */
-} SC_OneHzWakeupCmd_t;
+} SC_WakeupCmd_t;
 
 /**
  *  \brief No operation Command

--- a/config/default_sc_tbldefs.h
+++ b/config/default_sc_tbldefs.h
@@ -60,9 +60,9 @@
 typedef uint32 SC_AbsTimeTag_t;
 
 /**
- *  \brief Relative time tag for RTC's
+ *  \brief Relative wakeup count
  */
-typedef uint32 SC_RelTimeTag_t;
+typedef uint32 SC_RelWakeupCount_t;
 
 /**
  *  \brief ATS Table Entry Header Type
@@ -97,12 +97,12 @@ typedef struct
  */
 typedef struct
 {
-    SC_RelTimeTag_t TimeTag; /**< \brief Relative time tag */
+    SC_RelWakeupCount_t WakeupCount; /**< \brief Relative wakeup count */
 
     /*
      * Note: the command packet data is variable length,
      *       the command packet header (not shown here),
-     *       comes directly after Time tag.
+     *       comes directly after WakeupCount.
      */
 } SC_RtsEntryHeader_t;
 

--- a/docs/dox_src/cfs_sc.dox
+++ b/docs/dox_src/cfs_sc.dox
@@ -116,11 +116,11 @@
 
   \section SC Design Overview
 
-  The CFS Stored Command application is driven off of the 1Hz packet from the
-  Scheduler Application. When the 1Hz is received, SC looks to see if there are
+  The CFS Stored Command application is driven off of the wakeup command packet from the
+  Scheduler Application. When the wakeup command is received, SC looks to see if there are
   stored commands to execute (in the ATS and the RTS's). If there are commands
-  to be executed in this second, SC will execute them up until
-  #SC_MAX_CMDS_PER_SEC commands are executed. SC is also driven off of the
+  to be executed in this wakeup, SC will execute them up until
+  #SC_MAX_CMDS_PER_WAKEUP commands are executed. SC is also driven off of the
   housekeeping request packet from the Scheduler Application. When SC receives
   the HK request, it processes the request, sends out the housekeeping packet,
   and looks for table updates to the load/dump tables that SC maintains. SC is
@@ -310,7 +310,7 @@
   CFS Stored Command requires that two message ID's be put in the CFS Scheduler
   table for proper operation. Those message ID's are #SC_SEND_HK_MID, which
   should be sent out at the housekeeping request interval, and
-  #SC_ONEHZ_WAKEUP_MID, which needs to be sent out every second.
+  #SC_WAKEUP_MID.
 
   CFS Stored Command generates telemetry when it receives the housekeeping
   request. Its telemetry message ID is #SC_HK_TLM_MID.
@@ -446,15 +446,15 @@
 
   <H2>Over-scheduling the Stored Command Application</H2>
 
-  Another way to stress SC is to send out many commands in one second from many
-  sequences. For ATS commands, set the time tags to the same second. For RTS
-  commands, set the relative wakeup counts to zero. As noted earlier, SC will
-  send out the commands as fast as possible up to a certain number of commands
-  per second. With this in mind, it is possible to pack the ATSs and a few RTSs with
-  commands that want to go out in the same second. When all of these sequences
-  are run, SC will get behind in sending out the commands. SC will keep going
-  until all of the commands are executed, but do not expect "to the second"
-  execution accuracy.
+  Another way to stress SC is to send out many commands in one wakeup cycle
+  from many sequences. For ATS commands, set the time tags to the same second.
+  For RTS commands, set the relative wakeup counts to zero. As noted earlier,
+  SC will send out the commands as fast as possible up to a certain number of
+  commands per wakeup. With this in mind, it is possible to pack the ATSs and
+  a few RTSs with commands that want to go out in the same wakeup. When all of
+  these sequences are run, SC will get behind in sending out the commands. SC
+  will keep going until all of the commands are executed, but do not expect
+  "to the second" execution accuracy.
 
   <H2>Unsorted ATS Loads</H2>
 
@@ -476,30 +476,31 @@
   the switch command could be sent. Figure 4.6 shows the overlapping buffer
   concept with the ATSs. As mentioned earlier, the ATP can execute commands
   with the same time tag. Because the resolution of the time tag only goes
-  down to one second, in order to execute more than one command in one second,
-  the commands should have the same time tag. Now suppose that the ATP receives
-  the command to Switch ATSs while one ATS is in the middle of sending 8
-  commands out with the same time tag, and only 5 of these commands were
-  sent out before the buffer is switched (assuming a switch command coming
-  from the ground, not the internal switch command). At first glance this
-  seems to work because the other ATS buffer has an overlap with the same 8
-  commands that want to go out in one second. This is where a problem occurs:
-  when the new ATS is started, the ATP will walk down the list of commands
-  until it finds a command with a time tag that is greater than or equal to
-  the current time tag. Because the resolution of the time tags only goes
-  down to a second, the ATP will execute all 8 commands in that one second,
-  causing 5 of the eight commands to be sent out twice. In order to solve the
-  problem of the ATS Switch sending out duplicate commands, the Switch ATS
-  command received from the ground causes a wait condition until it is "safe"
-  to switch the ATS buffer. So, when the Switch ATS command is received by the
-  ATP, the command is validated and then a SWITCH_PEND flag is set. When it
-  becomes safe for the ATS to switch (i.e. at a 1 second boundary in UTC Time),
-  the switch will be serviced. This method assures that sending the Switch ATS
-  command from the ground will not cause any duplicate commands to be sent
-  out to the data system, nor any missed commands. Note that all of this
-  switch logic only comes into use when there are multiple commands per second.
-  The safe switch will wait until all commands during the current second have
-  been sent out, then it will switch. If there are no commands with the same
+  down to one second, in order to have more than one command go out in the
+  same second, the commands should have the same time tag. Now suppose that
+  the ATP receives the command to Switch ATSs while one ATS is in the middle
+  of sending 8 commands out with the same time tag, and only 5 of these
+  commands were sent out before the buffer is switched (assuming a switch
+  command coming from the ground, not the internal switch command). At first
+  glance this seems to work because the other ATS buffer has an overlap with
+  the same 8 commands that want to go out in one second. This is where a
+  problem occurs: when the new ATS is started, the ATP will walk down the
+  list of commands until it finds a command with a time tag that is greater
+  than or equal to the current time tag. Because the resolution of the time
+  tags only goes down to a second, the ATP will execute all 8 commands in
+  that one second, causing 5 of the eight commands to be sent out twice.
+  In order to solve the problem of the ATS Switch sending out duplicate
+  commands, the Switch ATS command received from the ground causes a wait
+  condition until it is "safe" to switch the ATS buffer. So, when the
+  Switch ATS command is received by the ATP, the command is validated and
+  then a SWITCH_PEND flag is set. When it becomes safe for the ATS to
+  switch (i.e. at a 1 second boundary in UTC Time), the switch will be
+  serviced. This method assures that sending the Switch ATS command from
+  the ground will not cause any duplicate commands to be sent out to the
+  data system, nor any missed commands. Note that all of this switch logic
+  only comes into use when there are multiple commands per second. The safe
+  switch will wait until all commands during the current second have been
+  sent out, then it will switch. If there are no commands with the same
   time tag in the overlap region (including the switch command) this logic
   does not get used. In either case, the switch can be performed without
   sending any duplicate commands to be sent out. There are certain conditions

--- a/docs/dox_src/cfs_sc.dox
+++ b/docs/dox_src/cfs_sc.dox
@@ -107,12 +107,12 @@
 /**
   \page cfsscovr CFS Stored Command Overview
 
-  The CFS Stored Command appliaction allows the spacecraft to be commanded
+  The CFS Stored Command application allows the spacecraft to be commanded
   using sequences of commands that are loaded from the ground. Each
-  command has a time tag associated with it, permitting the command to be
-  released for distribution at predetermined times. SC supports both Absolute
-  Time tagged command Sequences (ATSs) and multiple Relative Time tagged
-  command Sequences (RTSs).
+  command has a time tag or wakeup count associated with it, permitting the command to be
+  released for distribution at predetermined times or wakeup counts. SC supports both Absolute
+  Time tagged command Sequences (ATSs) and multiple Relative Time tagged command Sequences (RTSs),
+  where RTSs use wakeup counts instead of time tags.
 
   \section SC Design Overview
 
@@ -243,7 +243,7 @@
   <H2>Relative Time Processor (RTP)</H2>
 
   When the sequence is started, the RTP reads the delay of the first command.
-  After the amount of seconds listed in the delay, the RTP will fetch the
+  After the amount of wakeup counts listed in the delay, the RTP will fetch the
   command, check the checksum of the command, and send the command out to the
   data system. The RTP will then fetch the next command in the sequence and
   determine when this command needs to execute.
@@ -273,12 +273,12 @@
   a priority associated with it. The priority is assigned by the buffer number.
   In other words, RTS buffer 1 has the highest priority and the last RTS buffer
   has the lowest priority. This priority only comes into play when there is more
-  than one RTS that has commands to be executed in the SAME SECOND. For example,
-  if RTS 1 has a command to go out at 12:00:01 and RTS 50 has 8 commands to go
-  out at 12:00:00, all 8 commands from RTS 50 will be executed before RTS 1
-  executes it's command. However, if the 8 commands from RTS 50 are scheduled to
-  go out at 12:00:01, then the command from RTS 1 will be sent first, followed
-  by 7 commands from RTS 50. At 12:00:02, the 8th command from RTS 50 will be
+  than one RTS that has commands to be executed on the same wakeup count. For example,
+  if RTS 1 has a command to go out on the 103rd wakeup of SC and RTS 50 has 8 commands to go
+  out on the 102nd wakeup, all 8 commands from RTS 50 will be executed before RTS 1
+  executes its command. However, if the 8 commands from RTS 50 are scheduled to
+  go out on the 103rd wakeup, then the command from RTS 1 will be sent first, followed
+  by 7 commands from RTS 50. On the 104th wakeup, the 8th command from RTS 50 will be
   sent.
 
   <H2>RTP Error Handling</H2>
@@ -305,7 +305,7 @@
   \page cfsscdg CFS Stored Command Deployment Guide
 
   While the SC application does not require a great deal of work for platform
-  deployment, the following are some general guidlines.
+  deployment, the following are some general guidelines.
 
   CFS Stored Command requires that two message ID's be put in the CFS Scheduler
   table for proper operation. Those message ID's are #SC_SEND_HK_MID, which
@@ -427,18 +427,19 @@
   two hours. If SC is conifured to use TAI time, and the ATS is started, and the
   leap seconds are changed, SC time will not be affected.
 
-  The effect of adjusting time on Relative Time Sequences is a little more
-  complicated. As mentioned in the Scheduling section, the next RTS command for
-  each sequence actually has an absolute time associated with it. With this
-  absolute time, it is possible for SC to know when to send out each RTS
-  command. From the Absolute time a delay time is computed, which is used to
-  tell SC how long to delay. When time is adjusted on an RTS, the command that
-  is currently waiting to execute gets "thrown off". Depending on the time
-  adjustment, the command could go out sooner or later than expected. Once the
-  "current" command is out, however, the remaining commands in the sequence will
-  execute as scheduled because they are relative to the previous command.
+  RTSs, on the other hand, use wakeup counts instead of time tags, meaning
+  commands are scheduled based on the number of wakeups since the previous
+  command. Each command in an RTS is associated with a relative wakeup count,
+  and this value determines when the command will execute relative to the last
+  executed command. For example, if a command is scheduled to execute after 2
+  wakeups, the system will calculate the absolute wakeup count by adding 2 to
+  the current absolute wakeup count. The command will execute at that absolute
+  wakeup count, regardless of any adjustments to the system time. This means
+  that time shifts are not expected to affect the time at which the commands
+  are executed, since they are based on wakeup counts rather than specific
+  time values.
 
-  The point of this discussion is that SC will not react well to time changes.
+  Despite this, time adjustments can introduce risks or unintended behaviors.
   It is recommended that SC be idle during large time adjustments (1 second or
   greater). Small adjustments can be tolerated if there is not an exact second
   tolerance for every command being executed.
@@ -446,12 +447,10 @@
   <H2>Over-scheduling the Stored Command Application</H2>
 
   Another way to stress SC is to send out many commands in one second from many
-  sequences. The time tags for both ATS commands and RTS commands have one
-  second resolution. However, there is a way to send multiple commands in one
-  second. For ATS commands, set the time tags to the same second. For RTS
-  commands, set the delays to zero. As noted earlier, SC will send out the
-  commands as fast as possible up to a certain number of commands per second.
-  With this in mind, it is possible to pack the ATSs and a few RTSs with
+  sequences. For ATS commands, set the time tags to the same second. For RTS
+  commands, set the relative wakeup counts to zero. As noted earlier, SC will
+  send out the commands as fast as possible up to a certain number of commands
+  per second. With this in mind, it is possible to pack the ATSs and a few RTSs with
   commands that want to go out in the same second. When all of these sequences
   are run, SC will get behind in sending out the commands. SC will keep going
   until all of the commands are executed, but do not expect "to the second"

--- a/docs/sc_FunctionalRequirements.csv
+++ b/docs/sc_FunctionalRequirements.csv
@@ -29,16 +29,16 @@ b)       Invalid command lengths
 c)       Commands that run off of the end of the table
 d)       Command number",SC application needs to validate the table to ensure gross errors are caught.  cFE Table Services handles the ground interface to tables. 
 SC2002,SC2002,SC shall allocate <PLATFORM_DEFINED> Relative Time-tagged Sequences (RTSs) with each capable of storing <PLATFORM_DEFINED>  bytes of stored command data.,Specifies the limits for table sizing purposes.
-SC2002.1,SC2002.1,SC shall resolve time to a wakeup count for Relative Time Command Sequences (RTS).,To address the bug where RTS commands could be delayed when the 1 Hz wakeup occurs near a second rollover.
+SC2002.1,SC2002.1,SC shall track a wakeup count for Relative Time Command Sequences (RTS).,
 SC2002.2,SC2002.2,SC shall accept variable length packed RTS commands within the <PLATFORM_DEFINED> byte relative time-tagged sequences.,
 SC2002.3,SC2002.3,"Each individual command within the sequence shall consist of:
 a)       A relative wakeup count
-b)       A variable length command, with a maximum length of <PLATFORM_DEFINED> bytes",Each command within an RTS needs to contain a wakeup count.
+b)       A variable length command",
 SC2003,SC2003,"Upon receipt of a table update indication for an RTS Table, SC shall set the RTS status to DISABLED.","Since the RTS definition table does not include a default state, safer to assume disabled."
 SC2004,SC2004,"SC shall execute commands in the ATS table in ascending order, based upon the time-tag of the commands, regardless of the order in which the commands are stored in the ATS table.","Allows flexibility in ground system tools and load generation (command location within an ATS doesn’t matter; Time matters)."
-SC2005,SC2005,SC shall execute no more than <PLATFORM_DEFINED> commands per second from all currently executing RTS tables and/or ATS tables.,Provides bounds on SC processing.
-SC2005.1,SC2005.1,"SC shall defer execution of pending RTS commands, when the combined execution count, of ATS and RTS, exceeds the command per second limit.",
-SC2005.2,SC2005.2,SC shall allow up to the maximum number of defined RTSs to be active concurrently.,RTSs can run concurrently. The limitation is the number of commands that can be sent in one second.
+SC2005,SC2005,SC shall execute no more than <PLATFORM_DEFINED> commands per wakeup cycle from all currently executing RTS tables and/or ATS tables.,Provides bounds on SC processing.
+SC2005.1,SC2005.1,"SC shall defer execution of pending RTS commands, when the combined execution count, of ATS and RTS, exceeds the command per wakeup limit.",
+SC2005.2,SC2005.2,SC shall allow up to the maximum number of defined RTSs to be active concurrently.,RTSs can run concurrently. The limitation is the number of commands that can be sent in one wakeup cycle.
 SC2006,SC2006,SC shall execute the RTSs in priority order based on the RTS number where RTS #1 has the highest priority.,"Provides a known order to the processing of RTSs so that missions can organize the RTSs appropriately.
 "
 SC2007,SC2007,SC shall define <PLATFORM_DEFINED> bytes of storage for an ATS Append Table.,
@@ -73,7 +73,7 @@ a)       Stop processing the currently executing ATS
 b)       Set the state of that ATS to IDLE",Note that the Stop ATS can be contained in the ATS.
 SC3001.1,SC3001.1,"If no ATS is executing, SC shall increment the Valid Command Counter.",
 SC3002,SC3002,"Upon receipt of a Switch ATS Command, SC shall
-a )       Terminate the processing of the current ATS table after processing all of the commands within the current second
+a)       Terminate the processing of the current ATS table after processing all of the commands within the current second
 b)       Start processing of the alternate ATS table",Allows the ground to chain ATS tables.
 SC3002.1,SC3002.1,SC shall begin processing the first ATS command after the next 1 second occurs containing a time which is greater-than-or-equal-to the current time.,Allows ATS tables to overlap each other so that the ground can switch at anytime. Need to wait until the next second occurs to ensure that the overlapping in ATSs doesn’t cause the same commands to be executed twice.
 SC3002.2,SC3002.2,SC shall mark all ATS commands with time less-than the current time as SKIPPED and an event message shall be generated.,Provides the ground knowledge of which commands were not processed (skipped).
@@ -95,7 +95,7 @@ c) The RTS, or range of RTS, table(s) has been Loaded",Method for starting an RT
 SC4000.1,SC4000.1,"If the conditions are met, SC shall issue an event message indicating the RTS started if the RTS number is less than <PLATFORM_DEFINED> RTS number.","Provides the ground an indication that an RTS started.
 Having a config parameter allows a range of RTSs to be specified such that no event message is sent."
 SC4000.2,SC4000.2,"If the conditions are not met, SC shall reject the command and send an event message.",Ground needs to know if an RTS was not executed.
-SC4001,SC4001,"SC shall dispatch commands within the RTS table, in position order, as the relative wakeup count specified in the RTS command expires.",RTS contain relative wakeup counts between commands.
+SC4001,SC4001,"SC shall dispatch commands within the RTS table, in position order, as the relative wakeup count specified in the RTS command elapses.",RTS contain relative wakeup counts between commands.
 SC4001.1,SC4001.1,The wakeup count shall be interpreted as the number of wakeup events to delay relative to the previous RTS command dispatched from that RTS table.,
 SC4001.2,SC4001.2,"For the first command in an RTS table, the delay shall be relative to the receipt of the RTS Start Command.",Provides the ability to delay the executing of the first command.
 SC4001.3,SC4001.3,"Prior to the dispatch of each individual RTS command, SC shall verify the validity of the following command parameters:
@@ -135,7 +135,7 @@ p)       RTS table activation count
 q)       RTS table activation error count
 r)        Number of active RTSs
 s)       Identifier of the next RTS table to dispatch a command
-t)        Wakeup count the next RTS command is due to be dispatched
+t)        Wakeup count delay after which the next RTS command is due to be dispatched
 u)       Execution status for each RTS table
 v)       Enable status for each RTS table
 w)      Identifier of the RTS table for which the most recent RTS command dispatch error occurred
@@ -164,7 +164,7 @@ p)       RTS table activation count
 q)       RTS table activation error count
 r)        Number of active RTSs
 s)       Identifier of the next RTS table to dispatch a command
-t)        Wakup count the next RTS command is due to be dispatched
+t)        Wakeup count delay after which the next RTS command is due to be dispatched
 u)       Execution status for each RTS table - IDLE
 v)       Status for each RTS table - DISABLED
 w)      Identifier of the RTS table for which the most recent RTS command dispatch error occurred

--- a/docs/sc_FunctionalRequirements.csv
+++ b/docs/sc_FunctionalRequirements.csv
@@ -29,11 +29,11 @@ b)       Invalid command lengths
 c)       Commands that run off of the end of the table
 d)       Command number",SC application needs to validate the table to ensure gross errors are caught.  cFE Table Services handles the ground interface to tables. 
 SC2002,SC2002,SC shall allocate <PLATFORM_DEFINED> Relative Time-tagged Sequences (RTSs) with each capable of storing <PLATFORM_DEFINED>  bytes of stored command data.,Specifies the limits for table sizing purposes.
-SC2002.1,SC2002.1,SC shall resolve time to 1 second for Relative Time Command Sequences (RTS).,Heritage missions have shown that this is adequate resolution.
+SC2002.1,SC2002.1,SC shall resolve time to a wakeup count for Relative Time Command Sequences (RTS).,To address the bug where RTS commands could be delayed when the 1 Hz wakeup occurs near a second rollover.
 SC2002.2,SC2002.2,SC shall accept variable length packed RTS commands within the <PLATFORM_DEFINED> byte relative time-tagged sequences.,
 SC2002.3,SC2002.3,"Each individual command within the sequence shall consist of:
-a)       Time tag with a one second resolution
-b)       A variable length command, with a maximum length of <PLATFORM_DEFINED> bytes",Each command within an RTS needs to contain a time with a one second resolution.
+a)       A relative wakeup count
+b)       A variable length command, with a maximum length of <PLATFORM_DEFINED> bytes",Each command within an RTS needs to contain a wakeup count.
 SC2003,SC2003,"Upon receipt of a table update indication for an RTS Table, SC shall set the RTS status to DISABLED.","Since the RTS definition table does not include a default state, safer to assume disabled."
 SC2004,SC2004,"SC shall execute commands in the ATS table in ascending order, based upon the time-tag of the commands, regardless of the order in which the commands are stored in the ATS table.","Allows flexibility in ground system tools and load generation (command location within an ATS doesn’t matter; Time matters)."
 SC2005,SC2005,SC shall execute no more than <PLATFORM_DEFINED> commands per second from all currently executing RTS tables and/or ATS tables.,Provides bounds on SC processing.
@@ -95,9 +95,9 @@ c) The RTS, or range of RTS, table(s) has been Loaded",Method for starting an RT
 SC4000.1,SC4000.1,"If the conditions are met, SC shall issue an event message indicating the RTS started if the RTS number is less than <PLATFORM_DEFINED> RTS number.","Provides the ground an indication that an RTS started.
 Having a config parameter allows a range of RTSs to be specified such that no event message is sent."
 SC4000.2,SC4000.2,"If the conditions are not met, SC shall reject the command and send an event message.",Ground needs to know if an RTS was not executed.
-SC4001,SC4001,"SC shall dispatch commands within the RTS table, in position order, as the relative time-tag specified in the RTS command expires.",RTS contain relative times between commands.
-SC4001.1,SC4001.1,The time-tag shall be interpreted as the number of seconds to delay relative to the previous RTS command dispatched from that RTS table.,
-SC4001.2,SC4001.2,"For the first command in an RTS table, the delay time shall be relative to the receipt of the RTS Start Command.",Provides the ability to delay the executing of the first command.
+SC4001,SC4001,"SC shall dispatch commands within the RTS table, in position order, as the relative wakeup count specified in the RTS command expires.",RTS contain relative wakeup counts between commands.
+SC4001.1,SC4001.1,The wakeup count shall be interpreted as the number of wakeup events to delay relative to the previous RTS command dispatched from that RTS table.,
+SC4001.2,SC4001.2,"For the first command in an RTS table, the delay shall be relative to the receipt of the RTS Start Command.",Provides the ability to delay the executing of the first command.
 SC4001.3,SC4001.3,"Prior to the dispatch of each individual RTS command, SC shall verify the validity of the following command parameters:
 a)       RTS command length
 b)       Embedded command Data Integrity Check Value",Basic verification that the RTS is not corrupt.
@@ -135,7 +135,7 @@ p)       RTS table activation count
 q)       RTS table activation error count
 r)        Number of active RTSs
 s)       Identifier of the next RTS table to dispatch a command
-t)        Time the next RTS command is due to be dispatched
+t)        Wakeup count the next RTS command is due to be dispatched
 u)       Execution status for each RTS table
 v)       Enable status for each RTS table
 w)      Identifier of the RTS table for which the most recent RTS command dispatch error occurred
@@ -164,7 +164,7 @@ p)       RTS table activation count
 q)       RTS table activation error count
 r)        Number of active RTSs
 s)       Identifier of the next RTS table to dispatch a command
-t)        Time the next RTS command is due to be dispatched
+t)        Wakup count the next RTS command is due to be dispatched
 u)       Execution status for each RTS table - IDLE
 v)       Status for each RTS table - DISABLED
 w)      Identifier of the RTS table for which the most recent RTS command dispatch error occurred

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -75,15 +75,15 @@
 #define SC_INIT_SB_SUBSCRIBE_HK_ERR_EID 4
 
 /**
- * \brief SC 1Hz Cycle Message Subscribe Failed Event ID
+ * \brief SC Wakeup Cycle Message Subscribe Failed Event ID
  *
  *  \par Type: ERROR
  *
  *  \par Cause:
- *  This event message is issued when #CFE_SB_Subscribe to the 1 Hz
- *  Request packet fails
+ *  This event message is issued when #CFE_SB_Subscribe to the wakeup
+ *  request packet fails
  */
-#define SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID 5
+#define SC_INIT_SB_SUBSCRIBE_ERR_EID 5
 
 /**
  * \brief HS Command Message Subscribe Failed Event ID

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -202,12 +202,12 @@ CFE_Status_t SC_AppInit(void)
         return Result;
     }
 
-    /* Must be able to subscribe to 1Hz wakeup command */
-    Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID), SC_OperData.CmdPipe);
+    /* Must be able to subscribe to wakeup command */
+    Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SC_WAKEUP_MID), SC_OperData.CmdPipe);
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Software Bus subscribe to 1 Hz cycle returned: 0x%08X", (unsigned int)Result);
+        CFE_EVS_SendEvent(SC_INIT_SB_SUBSCRIBE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Software Bus subscribe to wakeup cycle returned: 0x%08X", (unsigned int)Result);
         return Result;
     }
 

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -160,7 +160,7 @@ CFE_Status_t SC_AppInit(void)
     /* SAD: SC_Process_ATP is 0, within the valid index range of NextCmdTime array, which has 2 elements */
     SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
     /* SAD: SC_Process_RTP is 1, within the valid index range of NextCmdTime array, which has 2 elements */
-    SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
+    SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_WAKEUP_CNT;
 
     /* Initialize the SC housekeeping packet */
     CFE_MSG_Init(CFE_MSG_PTR(SC_OperData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(SC_HK_TLM_MID),
@@ -287,7 +287,7 @@ CFE_Status_t SC_InitTables(void)
     {
         RtsInfoPtr = SC_GetRtsInfoObject(SC_RTS_IDX_C(i));
 
-        RtsInfoPtr->NextCommandTime = SC_MAX_TIME;
+        RtsInfoPtr->NextCommandTgtWakeup = SC_MAX_WAKEUP_CNT;
         RtsInfoPtr->NextCommandPtr  = SC_ENTRY_OFFSET_FIRST;
         RtsInfoPtr->RtsStatus       = SC_Status_EMPTY;
         RtsInfoPtr->DisabledFlag    = true;

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -145,7 +145,7 @@ CFE_Status_t SC_AppInit(void)
     memset(&SC_AppData, 0, sizeof(SC_AppData));
 
     /* Number of ATS and RTS commands already executed this second */
-    SC_OperData.NumCmdsSec = 0;
+    SC_OperData.NumCmdsWakeup = 0;
 
     /* Continue ATS execution if ATS command checksum fails */
     SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_CONT_ON_FAILURE_START;
@@ -155,8 +155,6 @@ CFE_Status_t SC_AppInit(void)
     /* assign the time ref accessor from the compile-time option */
     SC_AppData.TimeRef = SC_LookupTimeAccessor(SC_TIME_TO_USE);
 
-    /* Make sure nothing is running */
-    SC_AppData.NextProcNumber = SC_Process_NONE;
     /* SAD: SC_Process_ATP is 0, within the valid index range of NextCmdTime array, which has 2 elements */
     SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
     /* SAD: SC_Process_RTP is 1, within the valid index range of NextCmdTime array, which has 2 elements */

--- a/fsw/src/sc_app.h
+++ b/fsw/src/sc_app.h
@@ -89,13 +89,13 @@ typedef struct
  */
 typedef struct
 {
-    SC_Status_Enum_t RtsStatus;       /**< \brief status of the RTS */
-    bool             DisabledFlag;    /**< \brief disabled/enabled flag */
-    uint8            CmdCtr;          /**< \brief Cmds executed in current rts */
-    uint8            CmdErrCtr;       /**< \brief errs in current RTS */
-    SC_AbsTimeTag_t  NextCommandTime; /**< \brief next command time for RTS */
-    SC_EntryOffset_t NextCommandPtr;  /**< \brief where next rts cmd is */
-    uint16           UseCtr;          /**< \brief how many times RTS is run */
+    SC_Status_Enum_t RtsStatus;            /**< \brief status of the RTS */
+    bool             DisabledFlag;         /**< \brief disabled/enabled flag */
+    uint8            CmdCtr;               /**< \brief Cmds executed in current rts */
+    uint8            CmdErrCtr;            /**< \brief errs in current RTS */
+    uint32           NextCommandTgtWakeup; /**< \brief target wakeup count for next RTS command */
+    SC_EntryOffset_t NextCommandPtr;       /**< \brief where next rts cmd is */
+    uint16           UseCtr;               /**< \brief how many times RTS is run */
 } SC_RtsInfoEntry_t;
 
 /**
@@ -368,11 +368,12 @@ typedef struct
 
     bool EnableHeaderUpdate; /**< \brief whether to update headers in outgoing messages */
 
-    SC_Process_Enum_t NextProcNumber;  /**< \brief the next command processor number */
-    SC_AbsTimeTag_t   NextCmdTime[2];  /**< \brief The overall next command time  0 - ATP, 1- RTP*/
-    SC_AbsTimeTag_t   CurrentTime;     /**< \brief this is the current time for SC */
-    SC_RtsNum_t       AutoStartRTS;    /**< \brief Start selected auto-exec RTS after init */
-    uint16            AppendWordCount; /**< \brief Size of cmd entries in current Append ATS table */
+    SC_Process_Enum_t NextProcNumber;     /**< \brief the next command processor number */
+    uint32            NextCmdTime[2];     /**< \brief The overall next command time for ATP (0) and command wakeup count for RTP (1) */
+    SC_AbsTimeTag_t   CurrentTime;        /**< \brief this is the current time for SC */
+    uint32            CurrentWakeupCount; /**< \brief this is the current wakeup count for SC */
+    SC_RtsNum_t       AutoStartRTS;       /**< \brief Start selected auto-exec RTS after init */
+    uint16            AppendWordCount;    /**< \brief Size of cmd entries in current Append ATS table */
 } SC_AppData_t;
 
 /************************************************************************

--- a/fsw/src/sc_app.h
+++ b/fsw/src/sc_app.h
@@ -322,7 +322,7 @@ typedef struct
 
     int32 AtsDupTestArray[SC_MAX_ATS_CMDS]; /**< \brief ATS test for duplicate cmd numbers  */
 
-    uint16 NumCmdsSec; /**< \brief the num of cmds that have gone out in a one second period */
+    uint16 NumCmdsWakeup; /**< \brief the num of cmds that have gone out in this wakeup cycle */
 
     SC_HkTlm_t HkPacket; /**< \brief SC Housekeeping structure */
 } SC_OperData_t;
@@ -368,7 +368,6 @@ typedef struct
 
     bool EnableHeaderUpdate; /**< \brief whether to update headers in outgoing messages */
 
-    SC_Process_Enum_t NextProcNumber;     /**< \brief the next command processor number */
     uint32            NextCmdTime[2];     /**< \brief The overall next command time for ATP (0) and command wakeup count for RTP (1) */
     SC_AbsTimeTag_t   CurrentTime;        /**< \brief this is the current time for SC */
     uint32            CurrentWakeupCount; /**< \brief this is the current wakeup count for SC */

--- a/fsw/src/sc_cmds.c
+++ b/fsw/src/sc_cmds.c
@@ -543,8 +543,6 @@ void SC_WakeupCmd(const SC_WakeupCmd_t *Cmd)
      */
     while (SC_OperData.NumCmdsWakeup < SC_MAX_CMDS_PER_WAKEUP)
     {
-        SC_GetNextRtsTime();
-
         CurrentNumCmds = SC_OperData.NumCmdsWakeup;
 
         /*
@@ -559,6 +557,8 @@ void SC_WakeupCmd(const SC_WakeupCmd_t *Cmd)
 
         if (CurrentNumCmds == SC_OperData.NumCmdsWakeup)
         {
+            SC_GetNextRtsTime();
+            
             SC_ProcessRtpCommand();
         }
         

--- a/fsw/src/sc_cmds.h
+++ b/fsw/src/sc_cmds.h
@@ -153,7 +153,7 @@ void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd);
 void SC_SendHkPacket(void);
 
 void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd);
-void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd);
+void SC_WakeupCmd(const SC_WakeupCmd_t *Cmd);
 
 /**
  * \brief Process an ATS Command

--- a/fsw/src/sc_dispatch.c
+++ b/fsw/src/sc_dispatch.c
@@ -109,10 +109,10 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
             }
             break;
 
-        case SC_ONEHZ_WAKEUP_MID:
-            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_OneHzWakeupCmd_t)))
+        case SC_WAKEUP_MID:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_WakeupCmd_t)))
             {
-                SC_OneHzWakeupCmd((const SC_OneHzWakeupCmd_t *)BufPtr);
+                SC_WakeupCmd((const SC_WakeupCmd_t *)BufPtr);
             }
             break;
 

--- a/fsw/src/sc_loads.c
+++ b/fsw/src/sc_loads.c
@@ -377,12 +377,12 @@ void SC_LoadRts(SC_RtsIndex_t RtsIndex)
         /* Clear out the RTS info table */
         RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
-        RtsInfoPtr->RtsStatus       = SC_Status_LOADED;
-        RtsInfoPtr->UseCtr          = 0;
-        RtsInfoPtr->CmdCtr          = 0;
-        RtsInfoPtr->CmdErrCtr       = 0;
-        RtsInfoPtr->NextCommandTime = 0;
-        RtsInfoPtr->NextCommandPtr  = SC_ENTRY_OFFSET_FIRST;
+        RtsInfoPtr->RtsStatus            = SC_Status_LOADED;
+        RtsInfoPtr->UseCtr               = 0;
+        RtsInfoPtr->CmdCtr               = 0;
+        RtsInfoPtr->CmdErrCtr            = 0;
+        RtsInfoPtr->NextCommandTgtWakeup = 0;
+        RtsInfoPtr->NextCommandPtr       = SC_ENTRY_OFFSET_FIRST;
 
         /* Make sure the RTS is disabled */
         RtsInfoPtr->DisabledFlag = true;
@@ -449,7 +449,7 @@ bool SC_ParseRts(uint32 Buffer32[])
 
             if (!CFE_SB_IsValidMsgId(MessageID))
             {
-                if (EntryPtr->Header.TimeTag == 0)
+                if (EntryPtr->Header.WakeupCount == 0)
                 {
                     Done = true; /* assumed end of file */
                 }

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -95,10 +95,10 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
                     RtsInfoPtr->UseCtr++;
 
                     /*
-                     ** Get the absolute time for the RTSs next_cmd_time
-                     ** using the current time and the relative time tag.
+                     ** Get the absolute wakeup count for the RTS's next_command_tgt_wakeup
+                     ** using the current wakeup count and the relative wakeup count.
                      */
-                    RtsInfoPtr->NextCommandTime = SC_ComputeAbsTime(RtsEntryPtr->TimeTag);
+                    RtsInfoPtr->NextCommandTgtWakeup = SC_ComputeAbsWakeup(RtsEntryPtr->WakeupCount);
 
                     /*
                      ** Last, Increment some global counters associated with the
@@ -203,9 +203,9 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
                     RtsInfoPtr->NextCommandPtr = SC_ENTRY_OFFSET_FIRST;
                     RtsInfoPtr->UseCtr++;
 
-                    /* get absolute time for 1st cmd in the RTS */
-                    RtsInfoPtr->NextCommandTime =
-                        SC_ComputeAbsTime(SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST)->Header.TimeTag);
+                    /* get absolute wakeup count for 1st cmd in the RTS */
+                    RtsInfoPtr->NextCommandTgtWakeup =
+                        SC_ComputeAbsWakeup(SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST)->Header.WakeupCount);
 
                     /* maintain counters associated with starting RTS */
                     SC_OperData.RtsCtrlBlckAddr->NumRtsActive++;
@@ -547,7 +547,7 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex)
         ** Stop the RTS from executing
         */
         RtsInfoPtr->RtsStatus       = SC_Status_LOADED;
-        RtsInfoPtr->NextCommandTime = SC_MAX_TIME;
+        RtsInfoPtr->NextCommandTgtWakeup = SC_MAX_WAKEUP_CNT;
 
         /*
         ** Note: the rest of the fields are left alone

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -375,7 +375,7 @@ void SC_GetNextAtsCommand(void)
          ** switch has occurred and there are no commands to
          ** execute in the same second that the switch occurs.
          ** The state is transitioned here to SC_Status_EXECUTING to
-         ** commence execution of the new ATS on the next 1Hz
+         ** commence execution of the new ATS on the next wakeup
          ** command processing cycle.
          */
         SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;

--- a/fsw/src/sc_state.c
+++ b/fsw/src/sc_state.c
@@ -98,49 +98,6 @@ void SC_GetNextRtsTime(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Decides whether an RTS or ATS command gets scheduled next       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SC_UpdateNextTime(void)
-{
-    /*
-     ** First, find out which RTS needs to run next
-     */
-    SC_GetNextRtsTime();
-
-    /*
-     ** Start out with a default, no processors need to run next
-     */
-    SC_AppData.NextProcNumber = SC_Process_NONE;
-
-    /*
-     ** Check to see if the ATP needs to schedule commands
-     */
-    if (SC_OperData.AtsCtrlBlckAddr->AtpState == SC_Status_EXECUTING)
-    {
-        SC_AppData.NextProcNumber = SC_Process_ATP;
-    }
-    /*
-     ** Last, check to see if there is an RTS that needs to schedule commands
-     ** This is determined by the RTS number in the RTP control block
-     ** If it is zero, there is no RTS that needs to run
-     */
-    if (SC_RtsNumIsValid(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum))
-    {
-        /*
-         ** If the RTP needs to send commands, only send them if
-         ** the ATP doesn't - the ATP has priority
-         */
-
-        if (SC_AppData.NextProcNumber != SC_Process_ATP) 
-        {
-            SC_AppData.NextProcNumber = SC_Process_RTP;
-        }
-    } /* end if */
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
 /* Gets the next RTS Command                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_state.h
+++ b/fsw/src/sc_state.h
@@ -43,18 +43,6 @@
 void SC_GetNextRtsTime(void);
 
 /**
- * \brief Decides whether the ATS or RTS runs next
- *
- *  \par Description
- *         This function compares the next command times for the RTS
- *         and the ATS and decides which one to schedule next.
- *
- *  \par Assumptions, External Events, and Notes:
- *        None
- */
-void SC_UpdateNextTime(void);
-
-/**
  * \brief Gets the next RTS command to run
  *
  *  \par Description

--- a/fsw/src/sc_state.h
+++ b/fsw/src/sc_state.h
@@ -19,22 +19,23 @@
 
 /**
  * @file
- *   This file contains functions to handle getting the next time of
- *   commands for the ATP and RTP  as well as updating the time for
- *   Stored Command.
+ *   This file contains functions to handle getting the next time
+ *   or wakeup count of commands for the ATP and RTP, as well as
+ *   updating the time for Stored Command.
  */
+
 #ifndef SC_STATE_H
 #define SC_STATE_H
 
 #include "cfe.h"
 
 /**
- * \brief Gets the next time for an RTS command to run
+ * \brief Gets the next wakeup count for an RTS command to run
  *
  *  \par Description
  *         This function searches the RTS info table to find
- *         the next RTS that needs to run based on the time that the
- *         rts needs to run and it's priority.
+ *         the next RTS that needs to run based on the wakeup
+ *         count that the RTS needs to run and it's priority.
  *
  *  \par Assumptions, External Events, and Notes:
  *        None

--- a/fsw/src/sc_utils.c
+++ b/fsw/src/sc_utils.c
@@ -100,7 +100,7 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
 /* Compute Absolute time from relative time                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
+SC_AbsTimeTag_t SC_ComputeAbsTime(uint32 RelTime)
 {
     CFE_TIME_SysTime_t AbsoluteTimeWSubs;
     CFE_TIME_SysTime_t RelTimeWSubs;
@@ -120,6 +120,16 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
 
     /* We don't need subseconds */
     return ResultTimeWSubs.Seconds;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Compute absolute wakeup count from relative wakeup count        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+uint32 SC_ComputeAbsWakeup(uint32 RelWakeup)
+{
+    return SC_AppData.CurrentWakeupCount + RelWakeup;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/sc_utils.h
+++ b/fsw/src/sc_utils.h
@@ -68,7 +68,7 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry);
  *
  *  \return The absolute time tag
  */
-SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime);
+SC_AbsTimeTag_t SC_ComputeAbsTime(uint32 RelTime);
 
 /**
  * \brief Computes an absolute wakeup count from a relative wakeup count

--- a/fsw/src/sc_utils.h
+++ b/fsw/src/sc_utils.h
@@ -71,6 +71,23 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry);
 SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime);
 
 /**
+ * \brief Computes an absolute wakeup count from a relative wakeup count
+ *
+ *  \par Description
+ *       This function computes an absolute wakeup count based on the
+ *       current wakeup count and the relative wakeup count passed into
+ *       the function
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        None
+ *
+ *  \param [in]        RelWakeup        The relative wakeup count to compute from
+ *
+ *  \return The absolute wakeup count
+ */
+uint32 SC_ComputeAbsWakeup(uint32 RelWakeup);
+
+/**
  * \brief Compares absolute time
  *
  *  \par Description

--- a/fsw/src/sc_verify.h
+++ b/fsw/src/sc_verify.h
@@ -36,12 +36,12 @@
  * Macro Definitions
  *************************************************************************/
 
-#ifndef SC_MAX_CMDS_PER_SEC
-#error SC_MAX_CMDS_PER_SEC must be defined!
-#elif (SC_MAX_CMDS_PER_SEC > 65535)
-#error SC_MAX_CMDS_PER_SEC cannot be greater than 65535!
-#elif (SC_MAX_CMDS_PER_SEC < 1)
-#error SC_MAX_CMDS_PER_SEC cannot be less than 1!
+#ifndef SC_MAX_CMDS_PER_WAKEUP
+#error SC_MAX_CMDS_PER_WAKEUP must be defined!
+#elif (SC_MAX_CMDS_PER_WAKEUP > 65535)
+#error SC_MAX_CMDS_PER_WAKEUP cannot be greater than 65535!
+#elif (SC_MAX_CMDS_PER_WAKEUP < 1)
+#error SC_MAX_CMDS_PER_WAKEUP cannot be less than 1!
 #endif
 
 #ifndef SC_NUMBER_OF_RTS

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -29,9 +29,9 @@
  * This source file creates a sample RTS table that contains only
  * the following commands that are scheduled as follows:
  *
- * SC NOOP command, execution time relative to start of RTS = 0
- * SC Enable RTS #2 command, execution time relative to prev cmd = 5
- * SC Start RTS #2 command, execution time relative to prev cmd = 5
+ * SC NOOP command, execution wakeup count relative to start of RTS = 0
+ * SC Enable RTS #2 command, execution wakeup count relative to prev cmd = 5
+ * SC Start RTS #2 command, execution wakeup count relative to prev cmd = 5
  */
 
 #include "cfe.h"
@@ -78,17 +78,17 @@ typedef union
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable001_t SC_Rts001 = {
     /* 1 */
-    .rts.hdr1.TimeTag       = 0,
+    .rts.hdr1.WakeupCount = 0,
     .rts.cmd1.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .rts.hdr2.TimeTag = 5,
+    .rts.hdr2.WakeupCount = 5,
     .rts.cmd2.CommandHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_ENABLE_RTS_CC, SC_ENABLE_RTS2_CKSUM),
     .rts.cmd2.Payload.RtsNum = SC_RTS_NUM_INITIALIZER(2),
 
     /* 3 */
-    .rts.hdr3.TimeTag = 5,
+    .rts.hdr3.WakeupCount = 5,
     .rts.cmd3.CommandHeader =
         CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_START_RTS_CC, SC_START_RTS2_CKSUM),
     .rts.cmd3.Payload.RtsNum = SC_RTS_NUM_INITIALIZER(2)};

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -30,8 +30,8 @@
  * the following commands that are scheduled as follows:
  *
  * SC NOOP command, execution wakeup count relative to start of RTS = 0
- * SC NOOP command, execution wakeup count relative to prev cmd = 1
- * SC NOOP command, execution wakeup count relative to prev cmd = 1
+ * SC NOOP command, execution wakeup count relative to prev cmd = 5
+ * SC NOOP command, execution wakeup count relative to prev cmd = 5
  */
 
 #include "cfe.h"

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -81,8 +81,7 @@ SC_RtsTable002_t SC_Rts002 = {
 
     /* 3 */
     .rts.hdr3.WakeupCount       = 5,
-    .rts.cmd3.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_NOOP_CC, SC_NOOP_CKSUM)
-    };
+    .rts.cmd3.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_NOOP_CC, SC_NOOP_CKSUM)};
 
 /* Macro for table structure */
 CFE_TBL_FILEDEF(SC_Rts002, SC.RTS_TBL002, SC Example RTS_TBL002, sc_rts002.tbl)

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -29,9 +29,9 @@
  * This source file creates a sample RTS table that contains only
  * the following commands that are scheduled as follows:
  *
- * SC NOOP command, execution time relative to start of RTS = 0
- * SC NOOP command, execution time relative to prev cmd = 5
- * SC NOOP command, execution time relative to prev cmd = 5
+ * SC NOOP command, execution wakeup count relative to start of RTS = 0
+ * SC NOOP command, execution wakeup count relative to prev cmd = 1
+ * SC NOOP command, execution wakeup count relative to prev cmd = 1
  */
 
 #include "cfe.h"
@@ -72,16 +72,17 @@ typedef union
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable002_t SC_Rts002 = {
     /* 1 */
-    .rts.hdr1.TimeTag       = 0,
+    .rts.hdr1.WakeupCount       = 0,
     .rts.cmd1.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 2 */
-    .rts.hdr2.TimeTag       = 5,
-    .rts.cmd2.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM),
+    .rts.hdr2.WakeupCount       = 5,
+    .rts.cmd2.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd2), SC_NOOP_CC, SC_NOOP_CKSUM),
 
     /* 3 */
-    .rts.hdr3.TimeTag       = 5,
-    .rts.cmd3.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd1), SC_NOOP_CC, SC_NOOP_CKSUM)};
+    .rts.hdr3.WakeupCount       = 5,
+    .rts.cmd3.CommandHeader = CFE_MSG_CMD_HDR_INIT(SC_CMD_MID, SC_MEMBER_SIZE(cmd3), SC_NOOP_CC, SC_NOOP_CKSUM)
+    };
 
 /* Macro for table structure */
 CFE_TBL_FILEDEF(SC_Rts002, SC.RTS_TBL002, SC Example RTS_TBL002, sc_rts002.tbl)

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -148,7 +148,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
 
     Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
     Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
-    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
+    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_WAKEUP_CNT;
     Expected_SC_AppData.AutoStartRTS                = SC_RTS_NUM_C(RTS_ID_AUTO_POWER_ON);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -212,7 +212,7 @@ void SC_AppInit_Test_Nominal(void)
 
     Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
     Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
-    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_TIME;
+    Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_WAKEUP_CNT;
     Expected_SC_AppData.AutoStartRTS                = SC_RTS_NUM_C(RTS_ID_AUTO_PROCESSOR);
 
     Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_AtsCont_TRUE;

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -296,17 +296,17 @@ void SC_AppInit_Test_SBSubscribeHKError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_AppInit_Test_SubscribeTo1HzError(void)
+void SC_AppInit_Test_SubscribeToWakeupError(void)
 {
     /* Set CFE_SB_Subscribe to return -1 on the 2nd call in order to generate error message
-     * SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID */
+     * SC_INIT_SB_SUBSCRIBE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -1);
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(SC_AppInit(), -1);
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_SB_SUBSCRIBE_ONEHZ_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_INIT_SB_SUBSCRIBE_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -703,8 +703,8 @@ void UtTest_Setup(void)
                "SC_AppInit_Test_SBSubscribeHKError");
     UtTest_Add(SC_AppInit_Test_SBSubscribeToCmdError, SC_Test_Setup, SC_Test_TearDown,
                "SC_AppInit_Test_SBSubscribeToCmdError");
-    UtTest_Add(SC_AppInit_Test_SubscribeTo1HzError, SC_Test_Setup, SC_Test_TearDown,
-               "SC_AppInit_Test_SubscribeTo1HzError");
+    UtTest_Add(SC_AppInit_Test_SubscribeToWakeupError, SC_Test_Setup, SC_Test_TearDown,
+               "SC_AppInit_Test_SubscribeToWakeupError");
     UtTest_Add(SC_AppInit_Test_InitTablesError, SC_Test_Setup, SC_Test_TearDown, "SC_AppInit_Test_InitTablesError");
     UtTest_Add(SC_InitTables_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_InitTables_Test_Nominal");
     UtTest_Add(SC_InitTables_Test_ErrorRegisterAllTables, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -146,7 +146,6 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
     memset(&Expected_SC_OperData, 0, sizeof(Expected_SC_OperData));
     memset(&Expected_SC_AppData, 0, sizeof(Expected_SC_AppData));
 
-    Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
     Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
     Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_WAKEUP_CNT;
     Expected_SC_AppData.AutoStartRTS                = SC_RTS_NUM_C(RTS_ID_AUTO_POWER_ON);
@@ -183,7 +182,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
                     sizeof(Expected_SC_OperData.AtsCmdStatusHandle), "AtsCmdStatusHandle");
     UtAssert_MemCmp(&SC_OperData.AtsDupTestArray, &Expected_SC_OperData.AtsDupTestArray,
                     sizeof(Expected_SC_OperData.AtsDupTestArray), "21");
-    UtAssert_MemCmp(&SC_OperData.NumCmdsSec, &Expected_SC_OperData.NumCmdsSec, sizeof(Expected_SC_OperData.NumCmdsSec),
+    UtAssert_MemCmp(&SC_OperData.NumCmdsWakeup, &Expected_SC_OperData.NumCmdsWakeup, sizeof(Expected_SC_OperData.NumCmdsWakeup),
                     "22");
     UtAssert_MemCmp(&SC_OperData.HkPacket, &Expected_SC_OperData.HkPacket, sizeof(Expected_SC_OperData.HkPacket), "23");
 
@@ -210,7 +209,6 @@ void SC_AppInit_Test_Nominal(void)
     memset(&Expected_SC_OperData, 0, sizeof(Expected_SC_OperData));
     memset(&Expected_SC_AppData, 0, sizeof(Expected_SC_AppData));
 
-    Expected_SC_AppData.NextProcNumber              = SC_Process_NONE;
     Expected_SC_AppData.NextCmdTime[SC_Process_ATP] = SC_MAX_TIME;
     Expected_SC_AppData.NextCmdTime[SC_Process_RTP] = SC_MAX_WAKEUP_CNT;
     Expected_SC_AppData.AutoStartRTS                = SC_RTS_NUM_C(RTS_ID_AUTO_PROCESSOR);
@@ -247,7 +245,7 @@ void SC_AppInit_Test_Nominal(void)
                     sizeof(Expected_SC_OperData.AtsCmdStatusHandle), "AtsCmdStatusHandle");
     UtAssert_MemCmp(&SC_OperData.AtsDupTestArray, &Expected_SC_OperData.AtsDupTestArray,
                     sizeof(Expected_SC_OperData.AtsDupTestArray), "21");
-    UtAssert_MemCmp(&SC_OperData.NumCmdsSec, &Expected_SC_OperData.NumCmdsSec, sizeof(Expected_SC_OperData.NumCmdsSec),
+    UtAssert_MemCmp(&SC_OperData.NumCmdsWakeup, &Expected_SC_OperData.NumCmdsWakeup, sizeof(Expected_SC_OperData.NumCmdsWakeup),
                     "22");
     UtAssert_MemCmp(&SC_OperData.HkPacket, &Expected_SC_OperData.HkPacket, sizeof(Expected_SC_OperData.HkPacket), "23");
 

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -422,7 +422,7 @@ void SC_KillAts_Test(void)
 void SC_SwitchAtsCmd_Test_Nominal(void)
 {
     SC_AtsIndex_t      AtsIndex  = SC_ATS_IDX_C(1);
-    CFE_SB_MsgId_t     TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
+    CFE_SB_MsgId_t     TestMsgId = CFE_SB_ValueToMsgId(SC_WAKEUP_MID);
     SC_AtsInfoTable_t *AtsInfoPtr;
 
     AtsInfoPtr = SC_GetAtsInfoObject(AtsIndex);
@@ -464,7 +464,7 @@ void SC_SwitchAtsCmd_Test_BadId(void)
 void SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded(void)
 {
     SC_AtsIndex_t      AtsIndex  = SC_ATS_IDX_C(1);
-    CFE_SB_MsgId_t     TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
+    CFE_SB_MsgId_t     TestMsgId = CFE_SB_ValueToMsgId(SC_WAKEUP_MID);
     SC_AtsInfoTable_t *AtsInfoPtr;
 
     AtsInfoPtr = SC_GetAtsInfoObject(AtsIndex);
@@ -489,7 +489,7 @@ void SC_SwitchAtsCmd_Test_DestinationAtsNotLoaded(void)
 
 void SC_SwitchAtsCmd_Test_AtpIdle(void)
 {
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_WAKEUP_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -824,7 +824,7 @@ void SC_JumpAtsCmd_Test_SkipOneCmd(void)
     SC_Assert_ID_EQ(SC_OperData.AtsCtrlBlckAddr->CmdNumber,
                     SC_GetAtsCommandNumAtSeq(AtsIndex, SC_SEQUENCE_IDX_C(1))->CmdNum);
     SC_Assert_IDX_VALUE(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr, 1);
-    UtAssert_True(SC_AppData.NextCmdTime[0] == 0, "SC_AppData.NextCmdTime[0] == 0");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_ATP] == 0, "SC_AppData.NextCmdTime[SC_Process_ATP] == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);
@@ -928,7 +928,7 @@ void SC_JumpAtsCmd_Test_AtsNotLoaded(void)
     SC_Assert_ID_EQ(SC_OperData.AtsCtrlBlckAddr->CmdNumber,
                     SC_GetAtsCommandNumAtSeq(AtsIndex, SC_SEQUENCE_IDX_C(1))->CmdNum);
     SC_Assert_IDX_VALUE(SC_OperData.AtsCtrlBlckAddr->TimeIndexPtr, 1);
-    UtAssert_True(SC_AppData.NextCmdTime[0] == 0, "SC_AppData.NextCmdTime[0] == 0");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_ATP] == 0, "SC_AppData.NextCmdTime[SC_Process_ATP] == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, SC_JUMP_ATS_INF_EID);

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -50,15 +50,6 @@ int32 Ut_CFE_TIME_CompareHookAlessthanB(void *UserObj, int32 StubRetcode, uint32
     return CFE_TIME_A_LT_B;
 }
 
-uint8 SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount;
-int32 Ut_SC_UpdateNextTimeHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
-{
-    if (SC_CMDS_TEST_SC_UpdateNextTimeHook_RunCount++)
-        SC_AppData.NextProcNumber = SC_Process_NONE;
-
-    return 0;
-}
-
 void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 {
     SC_AtsEntryHeader_t *         Entry;
@@ -74,7 +65,6 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
     Entry->CmdNumber = SC_COMMAND_NUM_C(1);
 
-    SC_AppData.NextProcNumber             = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_AtsIndexToNum(AtsIndex);
@@ -102,7 +92,7 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_EXECUTED);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -122,7 +112,6 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
     Entry->CmdNumber = SC_COMMAND_NUM_C(1);
 
-    SC_AppData.NextProcNumber             = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_AtsIndexToNum(AtsIndex);
@@ -150,7 +139,7 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 0");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_EXECUTED);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -170,7 +159,6 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
     Entry->CmdNumber = SC_COMMAND_NUM_C(1);
 
-    SC_AppData.NextProcNumber             = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_AtsIndexToNum(AtsIndex);
@@ -199,7 +187,7 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_FAILED_DISTRIB);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrSeq, 1);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrCmd, 1);
@@ -224,7 +212,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -249,7 +236,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_FAILED_DISTRIB);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrSeq, SC_AtsId_ATSA);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrCmd, 1);
@@ -276,7 +263,6 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSB);
@@ -301,7 +287,7 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_FAILED_DISTRIB);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrSeq, SC_AtsId_ATSB);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastAtsErrCmd, 1);
@@ -329,7 +315,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -385,7 +370,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSB);
@@ -441,7 +425,6 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -494,7 +477,6 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState   = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
     SC_OperData.AtsCtrlBlckAddr->CmdNumber  = SC_COMMAND_NUM_C(1);
@@ -531,7 +513,6 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSB);
@@ -566,7 +547,6 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -599,7 +579,6 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -608,34 +587,6 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
     CmdOffsetRec->Offset = SC_ENTRY_OFFSET_FIRST;
 
     UT_SetDeferredRetcode(UT_KEY(SC_CompareAbsTime), 1, true);
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessAtpCmd());
-
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 0");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessAtpCmd_Test_NextProcNumber(void)
-{
-    SC_AtsEntryHeader_t *         Entry;
-    SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
-    SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
-
-    CmdOffsetRec     = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
-    Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->CmdNumber = SC_COMMAND_NUM_C(1);
-
-    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
-    SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_NONE;
-    SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
-
-    SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
-    SC_OperData.AtsCtrlBlckAddr->CmdNumber  = SC_COMMAND_NUM_C(1);
-    CmdOffsetRec->Offset                    = SC_ENTRY_OFFSET_FIRST;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessAtpCmd());
@@ -658,7 +609,6 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EMPTY;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(SC_AtsId_ATSA);
@@ -690,7 +640,6 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
     Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
     Entry->CmdNumber = SC_COMMAND_NUM_C(1);
 
-    SC_AppData.NextProcNumber             = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_AtsIndexToNum(AtsIndex);
@@ -717,7 +666,7 @@ void SC_ProcessAtpCmd_Test_CmdMid(void)
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.AtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.AtsCmdCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     SC_Assert_CmdStatus(StatusEntryPtr->Status, SC_Status_EXECUTED);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -731,7 +680,6 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -743,7 +691,7 @@ void SC_ProcessRtpCommand_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 1");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 0");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdCtr, 1);
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdErrCtr, 0);
 
@@ -759,7 +707,6 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -774,7 +721,7 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdCtr, 0);
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdErrCtr, 1);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrSeq, 1);
@@ -794,7 +741,6 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -810,7 +756,7 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsSec == 1, "SC_OperData.NumCmdsSec == 1");
+    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdCtr, 0);
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdErrCtr, 1);
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrSeq, 1);
@@ -829,27 +775,6 @@ void SC_ProcessRtpCommand_Test_NextCmdTime(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 1;
     SC_AppData.CurrentTime                  = 0;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
-    SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
-    RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
-
-    /* Verify results */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_ProcessRtpCommand_Test_ProcNumber(void)
-{
-    SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(0);
-    SC_RtsInfoEntry_t *RtsInfoPtr;
-
-    RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
-
-    SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
-    SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_NONE;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -864,7 +789,6 @@ void SC_ProcessRtpCommand_Test_RtsNumZero(void)
 {
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(0);
 
     /* CurrRtsNum > 0 will be false so nothing should happen, branch coverage */
@@ -878,7 +802,6 @@ void SC_ProcessRtpCommand_Test_RtsNumHigh(void)
 {
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(SC_NUMBER_OF_RTS + 1);
 
     /* Execute the function being tested */
@@ -897,7 +820,6 @@ void SC_ProcessRtpCommand_Test_RtsStatus(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EMPTY;
 
@@ -1075,7 +997,6 @@ void SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded(void)
 void SC_ProcessRequest_Test_WakeupNONE(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
-    SC_AppData.NextProcNumber                   = SC_Process_NONE;
     SC_AppData.NextCmdTime[SC_Process_ATP]      = 0;
     SC_AppData.CurrentTime                      = 0;
 
@@ -1083,7 +1004,7 @@ void SC_ProcessRequest_Test_WakeupNONE(void)
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1091,7 +1012,6 @@ void SC_ProcessRequest_Test_WakeupNONE(void)
 void SC_ProcessRequest_Test_WakeupRtpNotExecutionTime(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
-    SC_AppData.NextProcNumber                   = SC_Process_RTP;
     SC_AppData.NextCmdTime[SC_Process_RTP]      = 2;
     SC_AppData.CurrentWakeupCount               = 0;
 
@@ -1099,7 +1019,7 @@ void SC_ProcessRequest_Test_WakeupRtpNotExecutionTime(void)
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1107,7 +1027,6 @@ void SC_ProcessRequest_Test_WakeupRtpNotExecutionTime(void)
 void SC_ProcessRequest_Test_WakeupNoSwitchPending(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = false;
-    SC_AppData.NextProcNumber                   = SC_Process_NONE;
     SC_AppData.NextCmdTime[SC_Process_ATP]      = 0;
     SC_AppData.CurrentTime                      = 0;
 
@@ -1115,7 +1034,7 @@ void SC_ProcessRequest_Test_WakeupNoSwitchPending(void)
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1123,14 +1042,13 @@ void SC_ProcessRequest_Test_WakeupNoSwitchPending(void)
 void SC_ProcessRequest_Test_WakeupAtpNotExecutionTime(void)
 {
     SC_OperData.AtsCtrlBlckAddr->SwitchPendFlag = true;
-    SC_AppData.NextProcNumber                   = SC_Process_ATP;
     SC_AppData.NextCmdTime[SC_Process_ATP]      = 1000;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1144,7 +1062,6 @@ void SC_ProcessRequest_Test_WakeupRtpExecutionTime(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentWakeupCount           = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -1157,38 +1074,75 @@ void SC_ProcessRequest_Test_WakeupRtpExecutionTime(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
+void SC_ProcessRequest_Test_WakeupAtpExecutionTime(void)
+{
+    SC_AtsEntryHeader_t *         Entry;
+    CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t             FcnCode   = SC_NOOP_CC;
+    SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
+    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
+
+    SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
+    SC_AppData.CurrentTime                 = 0;
+    SC_OperData.NumCmdsWakeup              = 0;
+
+    CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
+    StatusEntryPtr = SC_GetAtsStatusEntryForCommand(AtsIndex, SC_COMMAND_IDX_C(0));
+
+    Entry            = (SC_AtsEntryHeader_t *)SC_GetAtsEntryAtOffset(AtsIndex, SC_ENTRY_OFFSET_FIRST);
+    Entry->CmdNumber = SC_COMMAND_NUM_C(1);
+
+    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
+
+    SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_AtsIndexToNum(AtsIndex);
+    SC_OperData.AtsCtrlBlckAddr->CmdNumber  = SC_COMMAND_NUM_C(1);
+
+    StatusEntryPtr->Status = SC_Status_LOADED;
+    CmdOffsetRec->Offset   = SC_ENTRY_OFFSET_FIRST;
+
+    SC_AppData.EnableHeaderUpdate = true;
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
+}
+
 void SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds(void)
 {
     SC_AppData.EnableHeaderUpdate = true;
 
-    SC_AppData.NextProcNumber              = SC_Process_RTP;
     SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
-    SC_OperData.NumCmdsSec                 = 1000;
+    SC_OperData.NumCmdsWakeup                 = 1000;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void SC_ProcessRequest_Test_WakeupAtpExecutionTimeTooManyCmds(void)
 {
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_AppData.NextCmdTime[SC_Process_ATP] = 10;
     SC_AppData.CurrentTime                 = 100;
-    SC_OperData.NumCmdsSec                 = 1000;
+    SC_OperData.NumCmdsWakeup                 = 1000;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_IDLE;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_WakeupCmd(&UT_CmdBuf.WakeupCmd));
 
     /* Verify results */
-    UtAssert_UINT32_EQ(SC_OperData.NumCmdsSec, 0);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -1705,8 +1659,6 @@ void UtTest_Setup(void)
                "SC_ProcessAtpCmd_Test_CmdNotLoaded");
     UtTest_Add(SC_ProcessAtpCmd_Test_CompareAbsTime, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessAtpCmd_Test_CompareAbsTime");
-    UtTest_Add(SC_ProcessAtpCmd_Test_NextProcNumber, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessAtpCmd_Test_NextProcNumber");
     UtTest_Add(SC_ProcessAtpCmd_Test_AtpState, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessAtpCmd_Test_AtpState");
     UtTest_Add(SC_ProcessAtpCmd_Test_CmdMid, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessAtpCmd_Test_CmdMid");
     UtTest_Add(SC_ProcessRtpCommand_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRtpCommand_Test_Nominal");
@@ -1716,8 +1668,6 @@ void UtTest_Setup(void)
                "SC_ProcessRtpCommand_Test_BadChecksum");
     UtTest_Add(SC_ProcessRtpCommand_Test_NextCmdTime, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRtpCommand_Test_NextCmdTime");
-    UtTest_Add(SC_ProcessRtpCommand_Test_ProcNumber, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRtpCommand_Test_ProcNumber");
     UtTest_Add(SC_ProcessRtpCommand_Test_RtsNumZero, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRtpCommand_Test_RtsNumZero");
     UtTest_Add(SC_ProcessRtpCommand_Test_RtsNumHigh, SC_Test_Setup, SC_Test_TearDown,
@@ -1740,6 +1690,8 @@ void UtTest_Setup(void)
                "SC_ProcessRequest_Test_WakeupAtpNotExecutionTime");
     UtTest_Add(SC_ProcessRequest_Test_WakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_WakeupRtpExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupAtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupAtpExecutionTime");
     UtTest_Add(SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds");
     UtTest_Add(SC_ProcessRequest_Test_WakeupAtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -214,33 +214,33 @@ void SC_ProcessRequest_Test_SendHkCmdInvalidLength(void)
     UtAssert_STUB_COUNT(SC_SendHkCmd, 0);
 }
 
-void SC_ProcessRequest_Test_OneHzWakeupNominal(void)
+void SC_ProcessRequest_Test_WakeupNominal(void)
 {
     /**
-     **  Test case: SC_ONEHZ_WAKEUP_MID
+     **  Test case: SC_WAKEUP_MID
      **/
 
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_WAKEUP_MID);
 
     UT_SC_Dispatch_SetMsgId(TestMsgId);
     UT_SC_Dispatch_SetFcnCode(0);
-    UT_SC_Dispatch_SetMsgSize(sizeof(SC_OneHzWakeupCmd_t));
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_WakeupCmd_t));
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRequest(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_STUB_COUNT(SC_OneHzWakeupCmd, 1);
+    UtAssert_STUB_COUNT(SC_WakeupCmd, 1);
 }
 
-void SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength(void)
+void SC_ProcessRequest_Test_WakeupCmdInvalidLength(void)
 {
     /**
-     **  Test case: SC_ONEHZ_WAKEUP_MID
+     **  Test case: SC_WAKEUP_MID
      **/
 
-    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_ONEHZ_WAKEUP_MID);
+    CFE_SB_MsgId_t TestMsgId = CFE_SB_ValueToMsgId(SC_WAKEUP_MID);
 
     UT_SC_Dispatch_SetMsgId(TestMsgId);
     UT_SC_Dispatch_SetFcnCode(0);
@@ -252,7 +252,7 @@ void SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
-    UtAssert_STUB_COUNT(SC_OneHzWakeupCmd, 0);
+    UtAssert_STUB_COUNT(SC_WakeupCmd, 0);
 }
 
 void SC_ProcessRequest_Test_MIDError(void)
@@ -932,26 +932,26 @@ void UtTest_Setup(void)
                "SC_ProcessRequest_Test_SendHkNominal");
     UtTest_Add(SC_ProcessRequest_Test_SendHkCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_SendHkCmdInvalidLength");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupCmdInvalidLength");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNominal, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupNominal");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupCmdInvalidLength");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupNominal");
     UtTest_Add(SC_ProcessRequest_Test_MIDError, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_MIDError");
 #ifdef jphfix
     UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRts, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_HkMIDAutoStartRts");
     UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNONE, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupNONE");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupNoSwitchPending");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupAtpNotExecutionTime");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTime");
-    UtTest_Add(SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_OneHzWakeupRtpExecutionTimeTooManyCmds");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupNONE, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupNONE");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupNoSwitchPending");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupAtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupAtpNotExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupRtpExecutionTime, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupRtpExecutionTime");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds");
 #endif
 
     UtTest_Add(SC_ProcessCommand_Test_NoopCmdNominal, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -130,13 +130,13 @@ SC_AtsEntryHeader_t *UT_SC_AppendSingleAtsEntry(void **TailPtr, uint16 CmdNumber
     return Entry;
 }
 
-SC_RtsEntryHeader_t *UT_SC_AppendSingleRtsEntry(void **TailPtr, SC_RelTimeTag_t TimeTag, size_t MsgSize)
+SC_RtsEntryHeader_t *UT_SC_AppendSingleRtsEntry(void **TailPtr, SC_RelWakeupCount_t WakeupCount, size_t MsgSize)
 {
     SC_RtsEntryHeader_t *Entry = (SC_RtsEntryHeader_t *)(*TailPtr);
 
     UT_SC_AdvanceTailPtr(TailPtr, SC_RTS_HEADER_SIZE, MsgSize);
 
-    Entry->TimeTag = TimeTag;
+    Entry->WakeupCount = WakeupCount;
 
     return Entry;
 }
@@ -150,7 +150,7 @@ SC_AtsEntryHeader_t *UT_SC_SetupSingleAtsEntry(SC_AtsIndex_t AtsIndex, uint16 Cm
     return UT_SC_AppendSingleAtsEntry(&TailPtr, CmdNumber, MsgSize);
 }
 
-SC_RtsEntryHeader_t *UT_SC_SetupSingleRtsEntry(SC_RtsIndex_t RtsIndex, CFE_SB_MsgId_t MsgId, SC_RelTimeTag_t TimeTag,
+SC_RtsEntryHeader_t *UT_SC_SetupSingleRtsEntry(SC_RtsIndex_t RtsIndex, CFE_SB_MsgId_t MsgId, SC_RelWakeupCount_t WakeupCount,
                                                size_t MsgSize)
 {
     void *TailPtr;
@@ -158,7 +158,7 @@ SC_RtsEntryHeader_t *UT_SC_SetupSingleRtsEntry(SC_RtsIndex_t RtsIndex, CFE_SB_Ms
     UT_SC_SetMsgId(MsgId);
     TailPtr = UT_SC_GetRtsTable(RtsIndex);
 
-    return UT_SC_AppendSingleRtsEntry(&TailPtr, TimeTag, MsgSize);
+    return UT_SC_AppendSingleRtsEntry(&TailPtr, WakeupCount, MsgSize);
 }
 
 uint32 UT_SC_GetEntryWordCount(size_t HdrSize, size_t MsgSize)
@@ -259,7 +259,7 @@ void UT_SC_RtsEntryInit(void *EntryPtr, size_t Idx, size_t MsgSize)
 {
     SC_RtsEntryHeader_t *Entry = EntryPtr;
 
-    Entry->TimeTag = 1;
+    Entry->WakeupCount = 1;
 }
 
 SC_RtsEntryHeader_t *UT_SC_SetupRtsTable(SC_RtsIndex_t RtsIndex, CFE_SB_MsgId_t MsgId, size_t MsgSize,

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -53,7 +53,7 @@ void SC_StartRtsCmd_Test_Nominal(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     UT_CmdBuf.StartRtsCmd.Payload.RtsNum = SC_RtsIndexToNum(RtsIndex);
 
@@ -97,7 +97,7 @@ void SC_StartRtsCmd_Test_StartRtsNoEvents(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     RtsInfoPtr->DisabledFlag = false;
     RtsInfoPtr->RtsStatus    = SC_Status_LOADED;
@@ -146,7 +146,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength1(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     UT_CmdBuf.StartRtsCmd.Payload.RtsNum = SC_RtsIndexToNum(RtsIndex);
 
@@ -177,7 +177,7 @@ void SC_StartRtsCmd_Test_InvalidCommandLength2(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     UT_CmdBuf.StartRtsCmd.Payload.RtsNum = SC_RtsIndexToNum(RtsIndex);
 
@@ -207,7 +207,7 @@ void SC_StartRtsCmd_Test_RtsNotLoadedOrInUse(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     UT_CmdBuf.StartRtsCmd.Payload.RtsNum = SC_RtsIndexToNum(RtsIndex);
 
@@ -231,7 +231,7 @@ void SC_StartRtsCmd_Test_RtsDisabled(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     Entry          = (SC_RtsEntryHeader_t *)SC_GetRtsEntryAtOffset(RtsIndex, SC_ENTRY_OFFSET_FIRST);
-    Entry->TimeTag = 0;
+    Entry->WakeupCount = 0;
 
     UT_CmdBuf.StartRtsCmd.Payload.RtsNum = SC_RtsIndexToNum(RtsIndex);
 
@@ -988,7 +988,7 @@ void SC_KillRts_Test(void)
 
     /* Verify results */
     UtAssert_True(RtsInfoPtr->RtsStatus == SC_Status_LOADED, "RtsInfoPtr->RtsStatus == SC_Status_LOADED");
-    UtAssert_True(RtsInfoPtr->NextCommandTime == SC_MAX_TIME, "RtsInfoPtr->NextCommandTime == SC_MAX_TIME");
+    UtAssert_True(RtsInfoPtr->NextCommandTgtWakeup == SC_MAX_WAKEUP_CNT, "RtsInfoPtr->NextCommandTgtWakeup == SC_MAX_WAKEUP_CNT");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1009,7 +1009,7 @@ void SC_KillRts_Test_NoActiveRts(void)
 
     /* Verify results */
     UtAssert_True(RtsInfoPtr->RtsStatus == SC_Status_LOADED, "RtsInfoPtr->RtsStatus == SC_Status_LOADED");
-    UtAssert_True(RtsInfoPtr->NextCommandTime == SC_MAX_TIME, "RtsInfoPtr->NextCommandTime == SC_MAX_TIME");
+    UtAssert_True(RtsInfoPtr->NextCommandTgtWakeup == SC_MAX_WAKEUP_CNT, "RtsInfoPtr->NextCommandTgtWakeup == SC_MAX_WAKEUP_CNT");
     UtAssert_True(SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0, "SC_OperData.RtsCtrlBlckAddr->NumRtsActive == 0");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -62,14 +62,14 @@ void SC_GetNextRtsTime_Test_Nominal(void)
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     RtsInfoPtr->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr->NextCommandTime = SC_MAX_TIME;
+    RtsInfoPtr->NextCommandTgtWakeup = SC_MAX_WAKEUP_CNT;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_GetNextRtsTime());
 
     /* Verify results */
     SC_Assert_ID_VALUE(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum, 1);
-    UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT, "SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -91,8 +91,8 @@ void SC_GetNextRtsTime_Test_InvalidRtsNum(void)
 
     /* Verify results */
     SC_Assert_ID_EQ(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum, SC_RTS_NUM_NULL);
-    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_TIME,
-                  "SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_TIME");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT,
+                  "SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -106,17 +106,17 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
     RtsInfoPtr1 = SC_GetRtsInfoObject(SC_RTS_IDX_C(1));
 
     RtsInfoPtr0->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr0->NextCommandTime = SC_MAX_TIME;
+    RtsInfoPtr0->NextCommandTgtWakeup = SC_MAX_WAKEUP_CNT;
 
     RtsInfoPtr1->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr1->NextCommandTime = SC_MAX_TIME - 1;
+    RtsInfoPtr1->NextCommandTgtWakeup = SC_MAX_WAKEUP_CNT - 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_GetNextRtsTime());
 
     /* Verify results */
     SC_Assert_ID_VALUE(SC_OperData.RtsCtrlBlckAddr->CurrRtsNum, 2);
-    UtAssert_True(SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1, "SC_AppData.NextCmdTime[1] == SC_MAX_TIME - 1");
+    UtAssert_True(SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT - 1, "SC_AppData.NextCmdTime[SC_Process_RTP] == SC_MAX_WAKEUP_CNT - 1");
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -162,7 +162,7 @@ void SC_UpdateNextTime_Test_Rtp(void)
     SC_AppData.NextCmdTime[SC_Process_ATP]  = 10;
 
     RtsInfoPtr->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr->NextCommandTime = 1;
+    RtsInfoPtr->NextCommandTgtWakeup = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_UpdateNextTime());
@@ -178,6 +178,7 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
     SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(SC_NUMBER_OF_RTS - 1);
     SC_RtsInfoEntry_t *RtsInfoPtr;
 
+    SC_OperData.AtsCtrlBlckAddr->AtpState   = SC_Status_EXECUTING;
     RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
 
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
@@ -185,7 +186,7 @@ void SC_UpdateNextTime_Test_RtpAtpPriority(void)
     SC_AppData.NextCmdTime[SC_Process_ATP]  = 0;
 
     RtsInfoPtr->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr->NextCommandTime = 1;
+    RtsInfoPtr->NextCommandTgtWakeup = 1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_UpdateNextTime());

--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -121,80 +121,6 @@ void SC_GetNextRtsTime_Test_RtsPriority(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void SC_UpdateNextTime_Test_Atp(void)
-{
-    SC_OperData.AtsCtrlBlckAddr->AtpState = SC_Status_EXECUTING;
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_UpdateNextTime());
-
-    /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_ATP, "SC_AppData.NextProcNumber == SC_Process_ATP");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_UpdateNextTime_Test_Atp2(void)
-{
-    SC_OperData.AtsCtrlBlckAddr->AtpState   = SC_Status_EXECUTING;
-    SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(SC_NUMBER_OF_RTS + 1);
-    SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
-    SC_AppData.NextCmdTime[SC_Process_ATP]  = 10;
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_UpdateNextTime());
-
-    /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_ATP, "SC_AppData.NextProcNumber == SC_Process_ATP");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_UpdateNextTime_Test_Rtp(void)
-{
-    SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(0);
-    SC_RtsInfoEntry_t *RtsInfoPtr;
-
-    RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
-
-    SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(10);
-    SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
-    SC_AppData.NextCmdTime[SC_Process_ATP]  = 10;
-
-    RtsInfoPtr->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr->NextCommandTgtWakeup = 1;
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_UpdateNextTime());
-
-    /* Verify results */
-    UtAssert_True(SC_AppData.NextProcNumber == SC_Process_RTP, "SC_AppData.NextProcNumber == SC_Process_RTP");
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void SC_UpdateNextTime_Test_RtpAtpPriority(void)
-{
-    SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(SC_NUMBER_OF_RTS - 1);
-    SC_RtsInfoEntry_t *RtsInfoPtr;
-
-    SC_OperData.AtsCtrlBlckAddr->AtpState   = SC_Status_EXECUTING;
-    RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
-
-    SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
-    SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
-    SC_AppData.NextCmdTime[SC_Process_ATP]  = 0;
-
-    RtsInfoPtr->RtsStatus       = SC_Status_EXECUTING;
-    RtsInfoPtr->NextCommandTgtWakeup = 1;
-
-    /* Execute the function being tested */
-    UtAssert_VOIDCALL(SC_UpdateNextTime());
-
-    /* Verify results */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
 void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 {
     size_t             MsgSize;
@@ -208,7 +134,6 @@ void SC_GetNextRtsCommand_Test_GetNextCommand(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(1);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
     AtsInfoPtr->NumberOfCommands            = 1;
@@ -253,7 +178,6 @@ void SC_GetNextRtsCommand_Test_RtsNumMax(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
     AtsInfoPtr->NumberOfCommands            = 1;
@@ -284,7 +208,6 @@ void SC_GetNextRtsCommand_Test_RtsNumOverMax(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RTS_NUM_C(SC_NUMBER_OF_RTS + 1);
     AtsInfoPtr->NumberOfCommands            = 1;
 
@@ -317,7 +240,6 @@ void SC_GetNextRtsCommand_Test_RtsNotExecuting(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_IDLE;
     AtsInfoPtr->NumberOfCommands            = 1;
@@ -354,7 +276,6 @@ void SC_GetNextRtsCommand_Test_RtsLengthError(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -407,7 +328,6 @@ void SC_GetNextRtsCommand_Test_CommandLengthError(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -460,7 +380,6 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLength(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -509,7 +428,6 @@ void SC_GetNextRtsCommand_Test_ZeroCommandLengthLastRts(void)
 
         SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
         SC_AppData.CurrentTime                  = 1;
-        SC_AppData.NextProcNumber               = SC_Process_RTP;
         SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
         RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -554,7 +472,6 @@ void SC_GetNextRtsCommand_Test_EndOfBuffer(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
     SC_AppData.CurrentTime                  = 1;
-    SC_AppData.NextProcNumber               = SC_Process_RTP;
     SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
     RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -600,7 +517,6 @@ void SC_GetNextRtsCommand_Test_EndOfBufferLastRts(void)
 
         SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
         SC_AppData.CurrentTime                  = 1;
-        SC_AppData.NextProcNumber               = SC_Process_RTP;
         SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
         RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
 
@@ -677,7 +593,6 @@ void SC_GetNextAtsCommand_Test_GetNextCommand(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP]                           = 0;
     SC_AppData.CurrentTime                                           = 1;
-    SC_AppData.NextProcNumber                                        = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState                            = SC_Status_EXECUTING;
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum                          = SC_AtsIndexToNum(AtsIndex);
     SC_GetAtsCommandNumAtSeq(AtsIndex, SC_SEQUENCE_IDX_C(0))->CmdNum = SC_COMMAND_NUM_C(1);
@@ -715,7 +630,6 @@ void SC_GetNextAtsCommand_Test_ExecutionACompleted(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(2);
@@ -747,7 +661,6 @@ void SC_GetNextAtsCommand_Test_ExecutionBCompleted(void)
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
     SC_AppData.CurrentTime                 = 1;
-    SC_AppData.NextProcNumber              = SC_Process_ATP;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     SC_OperData.AtsCtrlBlckAddr->CurrAtsNum = SC_ATS_NUM_C(1);
@@ -771,11 +684,6 @@ void UtTest_Setup(void)
                "SC_GetNextRtsTime_Test_InvalidRtsNum");
     UtTest_Add(SC_GetNextRtsTime_Test_RtsPriority, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextRtsTime_Test_RtsPriority");
-    UtTest_Add(SC_UpdateNextTime_Test_Atp, SC_Test_Setup, SC_Test_TearDown, "SC_UpdateNextTime_Test_Atp");
-    UtTest_Add(SC_UpdateNextTime_Test_Atp2, SC_Test_Setup, SC_Test_TearDown, "SC_UpdateNextTime_Test_Atp2");
-    UtTest_Add(SC_UpdateNextTime_Test_Rtp, SC_Test_Setup, SC_Test_TearDown, "SC_UpdateNextTime_Test_Rtp");
-    UtTest_Add(SC_UpdateNextTime_Test_RtpAtpPriority, SC_Test_Setup, SC_Test_TearDown,
-               "SC_UpdateNextTime_Test_RtpAtpPriority");
     UtTest_Add(SC_GetNextRtsCommand_Test_GetNextCommand, SC_Test_Setup, SC_Test_TearDown,
                "SC_GetNextRtsCommand_Test_GetNextCommand");
     UtTest_Add(SC_GetNextRtsCommand_Test_RtsNumZero, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_utils_tests.c
+++ b/unit-test/sc_utils_tests.c
@@ -83,6 +83,14 @@ void SC_ComputeAbsTime_Test(void)
     UtAssert_UINT32_EQ(SC_ComputeAbsTime(0), 1);
 }
 
+void SC_ComputeAbsWakeup_Test(void)
+{
+    SC_AppData.CurrentWakeupCount = 0;
+
+    /* Execute the function being tested */
+    UtAssert_UINT32_EQ(SC_ComputeAbsWakeup(1), 1);
+}
+
 void SC_CompareAbsTime_Test_True(void)
 {
     SC_AbsTimeTag_t AbsTimeTag1 = {0};
@@ -122,6 +130,7 @@ void UtTest_Setup(void)
     UtTest_Add(SC_GetCurrentTime_Test, SC_Test_Setup, SC_Test_TearDown, "SC_GetCurrentTime_Test");
     UtTest_Add(SC_GetAtsEntryTime_Test, SC_Test_Setup, SC_Test_TearDown, "SC_GetAtsEntryTime_Test");
     UtTest_Add(SC_ComputeAbsTime_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ComputeAbsTime_Test");
+    UtTest_Add(SC_ComputeAbsWakeup_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ComputeAbsWakeup_Test");
     UtTest_Add(SC_CompareAbsTime_Test_True, SC_Test_Setup, SC_Test_TearDown, "SC_CompareAbsTime_Test_True");
     UtTest_Add(SC_CompareAbsTime_Test_False, SC_Test_Setup, SC_Test_TearDown, "SC_CompareAbsTime_Test_False");
     UtTest_Add(SC_ToggleAtsIndex_Test, SC_Test_Setup, SC_Test_TearDown, "SC_ToggleAtsIndex_Test");

--- a/unit-test/stubs/sc_app_stubs.c
+++ b/unit-test/stubs/sc_app_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_AppInit()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_AppInit(void) {
+CFE_Status_t SC_AppInit(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
 
   UT_GenStub_Execute(SC_AppInit, Basic, NULL);
@@ -44,14 +45,18 @@ CFE_Status_t SC_AppInit(void) {
  * Generated stub function for SC_AppMain()
  * ----------------------------------------------------
  */
-void SC_AppMain(void) { UT_GenStub_Execute(SC_AppMain, Basic, NULL); }
+void SC_AppMain(void)
+{
+  UT_GenStub_Execute(SC_AppMain, Basic, NULL); 
+}
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_GetDumpTablePointers()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_GetDumpTablePointers(void) {
+CFE_Status_t SC_GetDumpTablePointers(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
 
   UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
@@ -64,7 +69,8 @@ CFE_Status_t SC_GetDumpTablePointers(void) {
  * Generated stub function for SC_GetLoadTablePointers()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_GetLoadTablePointers(void) {
+CFE_Status_t SC_GetLoadTablePointers(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
 
   UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
@@ -77,7 +83,8 @@ CFE_Status_t SC_GetLoadTablePointers(void) {
  * Generated stub function for SC_InitTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_InitTables(void) {
+CFE_Status_t SC_InitTables(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
 
   UT_GenStub_Execute(SC_InitTables, Basic, NULL);
@@ -90,8 +97,8 @@ CFE_Status_t SC_InitTables(void) {
  * Generated stub function for SC_LoadDefaultTables()
  * ----------------------------------------------------
  */
-void SC_LoadDefaultTables(void) {
-
+void SC_LoadDefaultTables(void)
+{
   UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
 }
 
@@ -100,7 +107,8 @@ void SC_LoadDefaultTables(void) {
  * Generated stub function for SC_RegisterAllTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterAllTables(void) {
+CFE_Status_t SC_RegisterAllTables(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
 
   UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
@@ -113,7 +121,8 @@ CFE_Status_t SC_RegisterAllTables(void) {
  * Generated stub function for SC_RegisterDumpOnlyTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterDumpOnlyTables(void) {
+CFE_Status_t SC_RegisterDumpOnlyTables(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
 
   UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
@@ -126,7 +135,8 @@ CFE_Status_t SC_RegisterDumpOnlyTables(void) {
  * Generated stub function for SC_RegisterLoadableTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterLoadableTables(void) {
+CFE_Status_t SC_RegisterLoadableTables(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
 
   UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
@@ -139,7 +149,7 @@ CFE_Status_t SC_RegisterLoadableTables(void) {
  * Generated stub function for SC_RegisterManageCmds()
  * ----------------------------------------------------
  */
-void SC_RegisterManageCmds(void) {
-
+void SC_RegisterManageCmds(void)
+{
   UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
 }

--- a/unit-test/stubs/sc_app_stubs.c
+++ b/unit-test/stubs/sc_app_stubs.c
@@ -31,13 +31,12 @@
  * Generated stub function for SC_AppInit()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_AppInit(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
+CFE_Status_t SC_AppInit(void) {
+  UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_AppInit, Basic, NULL);
+  UT_GenStub_Execute(SC_AppInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_AppInit, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_AppInit, CFE_Status_t);
 }
 
 /*
@@ -45,24 +44,19 @@ CFE_Status_t SC_AppInit(void)
  * Generated stub function for SC_AppMain()
  * ----------------------------------------------------
  */
-void SC_AppMain(void)
-{
-
-    UT_GenStub_Execute(SC_AppMain, Basic, NULL);
-}
+void SC_AppMain(void) { UT_GenStub_Execute(SC_AppMain, Basic, NULL); }
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_GetDumpTablePointers()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_GetDumpTablePointers(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
+CFE_Status_t SC_GetDumpTablePointers(void) {
+  UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
+  UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_GetDumpTablePointers, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_GetDumpTablePointers, CFE_Status_t);
 }
 
 /*
@@ -70,13 +64,12 @@ CFE_Status_t SC_GetDumpTablePointers(void)
  * Generated stub function for SC_GetLoadTablePointers()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_GetLoadTablePointers(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
+CFE_Status_t SC_GetLoadTablePointers(void) {
+  UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
+  UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_GetLoadTablePointers, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_GetLoadTablePointers, CFE_Status_t);
 }
 
 /*
@@ -84,13 +77,12 @@ CFE_Status_t SC_GetLoadTablePointers(void)
  * Generated stub function for SC_InitTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_InitTables(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
+CFE_Status_t SC_InitTables(void) {
+  UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_InitTables, Basic, NULL);
+  UT_GenStub_Execute(SC_InitTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_InitTables, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_InitTables, CFE_Status_t);
 }
 
 /*
@@ -98,10 +90,9 @@ CFE_Status_t SC_InitTables(void)
  * Generated stub function for SC_LoadDefaultTables()
  * ----------------------------------------------------
  */
-void SC_LoadDefaultTables(void)
-{
+void SC_LoadDefaultTables(void) {
 
-    UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
+  UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
 }
 
 /*
@@ -109,13 +100,12 @@ void SC_LoadDefaultTables(void)
  * Generated stub function for SC_RegisterAllTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterAllTables(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
+CFE_Status_t SC_RegisterAllTables(void) {
+  UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
+  UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_RegisterAllTables, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_RegisterAllTables, CFE_Status_t);
 }
 
 /*
@@ -123,13 +113,12 @@ CFE_Status_t SC_RegisterAllTables(void)
  * Generated stub function for SC_RegisterDumpOnlyTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterDumpOnlyTables(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
+CFE_Status_t SC_RegisterDumpOnlyTables(void) {
+  UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
+  UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_RegisterDumpOnlyTables, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_RegisterDumpOnlyTables, CFE_Status_t);
 }
 
 /*
@@ -137,13 +126,12 @@ CFE_Status_t SC_RegisterDumpOnlyTables(void)
  * Generated stub function for SC_RegisterLoadableTables()
  * ----------------------------------------------------
  */
-CFE_Status_t SC_RegisterLoadableTables(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
+CFE_Status_t SC_RegisterLoadableTables(void) {
+  UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
 
-    UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
+  UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_RegisterLoadableTables, CFE_Status_t);
+  return UT_GenStub_GetReturnValue(SC_RegisterLoadableTables, CFE_Status_t);
 }
 
 /*
@@ -151,8 +139,7 @@ CFE_Status_t SC_RegisterLoadableTables(void)
  * Generated stub function for SC_RegisterManageCmds()
  * ----------------------------------------------------
  */
-void SC_RegisterManageCmds(void)
-{
+void SC_RegisterManageCmds(void) {
 
-    UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
+  UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
 }

--- a/unit-test/stubs/sc_app_stubs.c
+++ b/unit-test/stubs/sc_app_stubs.c
@@ -33,11 +33,11 @@
  */
 CFE_Status_t SC_AppInit(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_AppInit, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_AppInit, Basic, NULL);
+    UT_GenStub_Execute(SC_AppInit, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_AppInit, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_AppInit, CFE_Status_t);
 }
 
 /*
@@ -47,7 +47,7 @@ CFE_Status_t SC_AppInit(void)
  */
 void SC_AppMain(void)
 {
-  UT_GenStub_Execute(SC_AppMain, Basic, NULL); 
+    UT_GenStub_Execute(SC_AppMain, Basic, NULL);
 }
 
 /*
@@ -57,11 +57,11 @@ void SC_AppMain(void)
  */
 CFE_Status_t SC_GetDumpTablePointers(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_GetDumpTablePointers, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
+    UT_GenStub_Execute(SC_GetDumpTablePointers, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_GetDumpTablePointers, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_GetDumpTablePointers, CFE_Status_t);
 }
 
 /*
@@ -71,11 +71,11 @@ CFE_Status_t SC_GetDumpTablePointers(void)
  */
 CFE_Status_t SC_GetLoadTablePointers(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_GetLoadTablePointers, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
+    UT_GenStub_Execute(SC_GetLoadTablePointers, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_GetLoadTablePointers, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_GetLoadTablePointers, CFE_Status_t);
 }
 
 /*
@@ -85,11 +85,11 @@ CFE_Status_t SC_GetLoadTablePointers(void)
  */
 CFE_Status_t SC_InitTables(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_InitTables, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_InitTables, Basic, NULL);
+    UT_GenStub_Execute(SC_InitTables, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_InitTables, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_InitTables, CFE_Status_t);
 }
 
 /*
@@ -99,7 +99,7 @@ CFE_Status_t SC_InitTables(void)
  */
 void SC_LoadDefaultTables(void)
 {
-  UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
+    UT_GenStub_Execute(SC_LoadDefaultTables, Basic, NULL);
 }
 
 /*
@@ -109,11 +109,11 @@ void SC_LoadDefaultTables(void)
  */
 CFE_Status_t SC_RegisterAllTables(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_RegisterAllTables, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
+    UT_GenStub_Execute(SC_RegisterAllTables, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_RegisterAllTables, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_RegisterAllTables, CFE_Status_t);
 }
 
 /*
@@ -123,11 +123,11 @@ CFE_Status_t SC_RegisterAllTables(void)
  */
 CFE_Status_t SC_RegisterDumpOnlyTables(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_RegisterDumpOnlyTables, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
+    UT_GenStub_Execute(SC_RegisterDumpOnlyTables, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_RegisterDumpOnlyTables, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_RegisterDumpOnlyTables, CFE_Status_t);
 }
 
 /*
@@ -137,11 +137,11 @@ CFE_Status_t SC_RegisterDumpOnlyTables(void)
  */
 CFE_Status_t SC_RegisterLoadableTables(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(SC_RegisterLoadableTables, CFE_Status_t);
 
-  UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
+    UT_GenStub_Execute(SC_RegisterLoadableTables, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_RegisterLoadableTables, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(SC_RegisterLoadableTables, CFE_Status_t);
 }
 
 /*
@@ -151,5 +151,5 @@ CFE_Status_t SC_RegisterLoadableTables(void)
  */
 void SC_RegisterManageCmds(void)
 {
-  UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
+    UT_GenStub_Execute(SC_RegisterManageCmds, Basic, NULL);
 }

--- a/unit-test/stubs/sc_atsrq_stubs.c
+++ b/unit-test/stubs/sc_atsrq_stubs.c
@@ -31,11 +31,10 @@
  * Generated stub function for SC_AppendAtsCmd()
  * ----------------------------------------------------
  */
-void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
+void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
 }
 
 /*
@@ -43,16 +42,15 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
  * Generated stub function for SC_BeginAts()
  * ----------------------------------------------------
  */
-bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
-{
-    UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
+bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset) {
+  UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
 
-    UT_GenStub_AddParam(SC_BeginAts, SC_AtsIndex_t, AtsIndex);
-    UT_GenStub_AddParam(SC_BeginAts, uint16, TimeOffset);
+  UT_GenStub_AddParam(SC_BeginAts, SC_AtsIndex_t, AtsIndex);
+  UT_GenStub_AddParam(SC_BeginAts, uint16, TimeOffset);
 
-    UT_GenStub_Execute(SC_BeginAts, Basic, NULL);
+  UT_GenStub_Execute(SC_BeginAts, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_BeginAts, bool);
+  return UT_GenStub_GetReturnValue(SC_BeginAts, bool);
 }
 
 /*
@@ -60,11 +58,11 @@ bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
  * Generated stub function for SC_ContinueAtsOnFailureCmd()
  * ----------------------------------------------------
  */
-void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd, const SC_ContinueAtsOnFailureCmd_t *, Cmd);
+void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd,
+                      const SC_ContinueAtsOnFailureCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
 }
 
 /*
@@ -72,13 +70,12 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
  * Generated stub function for SC_InlineSwitch()
  * ----------------------------------------------------
  */
-bool SC_InlineSwitch(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
+bool SC_InlineSwitch(void) {
+  UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
 
-    UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
+  UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_InlineSwitch, bool);
+  return UT_GenStub_GetReturnValue(SC_InlineSwitch, bool);
 }
 
 /*
@@ -86,11 +83,10 @@ bool SC_InlineSwitch(void)
  * Generated stub function for SC_JumpAtsCmd()
  * ----------------------------------------------------
  */
-void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
+void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
 }
 
 /*
@@ -98,21 +94,16 @@ void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
  * Generated stub function for SC_KillAts()
  * ----------------------------------------------------
  */
-void SC_KillAts(void)
-{
-
-    UT_GenStub_Execute(SC_KillAts, Basic, NULL);
-}
+void SC_KillAts(void) { UT_GenStub_Execute(SC_KillAts, Basic, NULL); }
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_ServiceSwitchPend()
  * ----------------------------------------------------
  */
-void SC_ServiceSwitchPend(void)
-{
+void SC_ServiceSwitchPend(void) {
 
-    UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
+  UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
 }
 
 /*
@@ -120,11 +111,10 @@ void SC_ServiceSwitchPend(void)
  * Generated stub function for SC_StartAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
+void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
 }
 
 /*
@@ -132,11 +122,10 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
  * Generated stub function for SC_StopAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
+void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
 }
 
 /*
@@ -144,9 +133,8 @@ void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
  * Generated stub function for SC_SwitchAtsCmd()
  * ----------------------------------------------------
  */
-void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
+void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_atsrq_stubs.c
+++ b/unit-test/stubs/sc_atsrq_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_AppendAtsCmd()
  * ----------------------------------------------------
  */
-void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd) {
+void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
@@ -42,7 +43,8 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd) {
  * Generated stub function for SC_BeginAts()
  * ----------------------------------------------------
  */
-bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset) {
+bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
+{
   UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
 
   UT_GenStub_AddParam(SC_BeginAts, SC_AtsIndex_t, AtsIndex);
@@ -58,7 +60,8 @@ bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset) {
  * Generated stub function for SC_ContinueAtsOnFailureCmd()
  * ----------------------------------------------------
  */
-void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd) {
+void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd,
                       const SC_ContinueAtsOnFailureCmd_t *, Cmd);
 
@@ -70,7 +73,8 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd) {
  * Generated stub function for SC_InlineSwitch()
  * ----------------------------------------------------
  */
-bool SC_InlineSwitch(void) {
+bool SC_InlineSwitch(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
 
   UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
@@ -83,7 +87,8 @@ bool SC_InlineSwitch(void) {
  * Generated stub function for SC_JumpAtsCmd()
  * ----------------------------------------------------
  */
-void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd) {
+void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
@@ -94,15 +99,18 @@ void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd) {
  * Generated stub function for SC_KillAts()
  * ----------------------------------------------------
  */
-void SC_KillAts(void) { UT_GenStub_Execute(SC_KillAts, Basic, NULL); }
+void SC_KillAts(void)
+{
+  UT_GenStub_Execute(SC_KillAts, Basic, NULL);
+}
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_ServiceSwitchPend()
  * ----------------------------------------------------
  */
-void SC_ServiceSwitchPend(void) {
-
+void SC_ServiceSwitchPend(void)
+{
   UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
 }
 
@@ -111,7 +119,8 @@ void SC_ServiceSwitchPend(void) {
  * Generated stub function for SC_StartAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd) {
+void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
@@ -122,7 +131,8 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd) {
  * Generated stub function for SC_StopAtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd) {
+void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
@@ -133,7 +143,8 @@ void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd) {
  * Generated stub function for SC_SwitchAtsCmd()
  * ----------------------------------------------------
  */
-void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd) {
+void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);

--- a/unit-test/stubs/sc_atsrq_stubs.c
+++ b/unit-test/stubs/sc_atsrq_stubs.c
@@ -33,9 +33,9 @@
  */
 void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_AppendAtsCmd, const SC_AppendAtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_AppendAtsCmd, Basic, NULL);
 }
 
 /*
@@ -45,14 +45,14 @@ void SC_AppendAtsCmd(const SC_AppendAtsCmd_t *Cmd)
  */
 bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
 {
-  UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
+    UT_GenStub_SetupReturnBuffer(SC_BeginAts, bool);
 
-  UT_GenStub_AddParam(SC_BeginAts, SC_AtsIndex_t, AtsIndex);
-  UT_GenStub_AddParam(SC_BeginAts, uint16, TimeOffset);
+    UT_GenStub_AddParam(SC_BeginAts, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_BeginAts, uint16, TimeOffset);
 
-  UT_GenStub_Execute(SC_BeginAts, Basic, NULL);
+    UT_GenStub_Execute(SC_BeginAts, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_BeginAts, bool);
+    return UT_GenStub_GetReturnValue(SC_BeginAts, bool);
 }
 
 /*
@@ -62,10 +62,9 @@ bool SC_BeginAts(SC_AtsIndex_t AtsIndex, uint16 TimeOffset)
  */
 void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd,
-                      const SC_ContinueAtsOnFailureCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_ContinueAtsOnFailureCmd, const SC_ContinueAtsOnFailureCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_ContinueAtsOnFailureCmd, Basic, NULL);
 }
 
 /*
@@ -75,11 +74,11 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
  */
 bool SC_InlineSwitch(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
+    UT_GenStub_SetupReturnBuffer(SC_InlineSwitch, bool);
 
-  UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
+    UT_GenStub_Execute(SC_InlineSwitch, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_InlineSwitch, bool);
+    return UT_GenStub_GetReturnValue(SC_InlineSwitch, bool);
 }
 
 /*
@@ -89,9 +88,9 @@ bool SC_InlineSwitch(void)
  */
 void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_JumpAtsCmd, const SC_JumpAtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_JumpAtsCmd, Basic, NULL);
 }
 
 /*
@@ -101,7 +100,7 @@ void SC_JumpAtsCmd(const SC_JumpAtsCmd_t *Cmd)
  */
 void SC_KillAts(void)
 {
-  UT_GenStub_Execute(SC_KillAts, Basic, NULL);
+    UT_GenStub_Execute(SC_KillAts, Basic, NULL);
 }
 
 /*
@@ -111,7 +110,7 @@ void SC_KillAts(void)
  */
 void SC_ServiceSwitchPend(void)
 {
-  UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
+    UT_GenStub_Execute(SC_ServiceSwitchPend, Basic, NULL);
 }
 
 /*
@@ -121,9 +120,9 @@ void SC_ServiceSwitchPend(void)
  */
 void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StartAtsCmd, const SC_StartAtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StartAtsCmd, Basic, NULL);
 }
 
 /*
@@ -133,9 +132,9 @@ void SC_StartAtsCmd(const SC_StartAtsCmd_t *Cmd)
  */
 void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StopAtsCmd, const SC_StopAtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StopAtsCmd, Basic, NULL);
 }
 
 /*
@@ -145,7 +144,7 @@ void SC_StopAtsCmd(const SC_StopAtsCmd_t *Cmd)
  */
 void SC_SwitchAtsCmd(const SC_SwitchAtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_SwitchAtsCmd, const SC_SwitchAtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_SwitchAtsCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_cmds_stubs.c
+++ b/unit-test/stubs/sc_cmds_stubs.c
@@ -31,11 +31,10 @@
  * Generated stub function for SC_ManageAtsTable()
  * ----------------------------------------------------
  */
-void SC_ManageAtsTable(int32 ArrayIndex)
-{
-    UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
+void SC_ManageAtsTable(int32 ArrayIndex) {
+  UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
 
-    UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
+  UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
 }
 
 /*
@@ -43,11 +42,10 @@ void SC_ManageAtsTable(int32 ArrayIndex)
  * Generated stub function for SC_ManageRtsTable()
  * ----------------------------------------------------
  */
-void SC_ManageRtsTable(int32 ArrayIndex)
-{
-    UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
+void SC_ManageRtsTable(int32 ArrayIndex) {
+  UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
 
-    UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
+  UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
 }
 
 /*
@@ -55,12 +53,11 @@ void SC_ManageRtsTable(int32 ArrayIndex)
  * Generated stub function for SC_ManageTable()
  * ----------------------------------------------------
  */
-void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
-{
-    UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
-    UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
+void SC_ManageTable(SC_TableType type, int32 ArrayIndex) {
+  UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
+  UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
 
-    UT_GenStub_Execute(SC_ManageTable, Basic, NULL);
+  UT_GenStub_Execute(SC_ManageTable, Basic, NULL);
 }
 
 /*
@@ -68,11 +65,10 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
  * Generated stub function for SC_ManageTableCmd()
  * ----------------------------------------------------
  */
-void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
+void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
 }
 
 /*
@@ -80,11 +76,10 @@ void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
  * Generated stub function for SC_NoopCmd()
  * ----------------------------------------------------
  */
-void SC_NoopCmd(const SC_NoopCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
+void SC_NoopCmd(const SC_NoopCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
 }
 
 /*
@@ -92,11 +87,10 @@ void SC_NoopCmd(const SC_NoopCmd_t *Cmd)
  * Generated stub function for SC_OneHzWakeupCmd()
  * ----------------------------------------------------
  */
-void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_OneHzWakeupCmd, const SC_OneHzWakeupCmd_t *, Cmd);
+void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_OneHzWakeupCmd, const SC_OneHzWakeupCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_OneHzWakeupCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_OneHzWakeupCmd, Basic, NULL);
 }
 
 /*
@@ -104,10 +98,9 @@ void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
  * Generated stub function for SC_ProcessAtpCmd()
  * ----------------------------------------------------
  */
-void SC_ProcessAtpCmd(void)
-{
+void SC_ProcessAtpCmd(void) {
 
-    UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
 }
 
 /*
@@ -115,10 +108,9 @@ void SC_ProcessAtpCmd(void)
  * Generated stub function for SC_ProcessRtpCommand()
  * ----------------------------------------------------
  */
-void SC_ProcessRtpCommand(void)
-{
+void SC_ProcessRtpCommand(void) {
 
-    UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
+  UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
 }
 
 /*
@@ -126,11 +118,10 @@ void SC_ProcessRtpCommand(void)
  * Generated stub function for SC_ResetCountersCmd()
  * ----------------------------------------------------
  */
-void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
+void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
 }
 
 /*
@@ -138,11 +129,10 @@ void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
  * Generated stub function for SC_SendHkCmd()
  * ----------------------------------------------------
  */
-void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
+void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
 }
 
 /*
@@ -150,8 +140,4 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
  * Generated stub function for SC_SendHkPacket()
  * ----------------------------------------------------
  */
-void SC_SendHkPacket(void)
-{
-
-    UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
-}
+void SC_SendHkPacket(void) { UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL); }

--- a/unit-test/stubs/sc_cmds_stubs.c
+++ b/unit-test/stubs/sc_cmds_stubs.c
@@ -33,9 +33,9 @@
  */
 void SC_ManageAtsTable(int32 ArrayIndex)
 {
-  UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
+    UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
 
-  UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
+    UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
 }
 
 /*
@@ -45,9 +45,9 @@ void SC_ManageAtsTable(int32 ArrayIndex)
  */
 void SC_ManageRtsTable(int32 ArrayIndex)
 {
-  UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
+    UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
 
-  UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
+    UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
 }
 
 /*
@@ -57,10 +57,10 @@ void SC_ManageRtsTable(int32 ArrayIndex)
  */
 void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
 {
-  UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
-  UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
+    UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
+    UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
 
-  UT_GenStub_Execute(SC_ManageTable, Basic, NULL);
+    UT_GenStub_Execute(SC_ManageTable, Basic, NULL);
 }
 
 /*
@@ -70,9 +70,9 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
  */
 void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
 }
 
 /*
@@ -82,21 +82,21 @@ void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
  */
 void SC_NoopCmd(const SC_NoopCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for SC_OneHzWakeupCmd()
+ * Generated stub function for SC_WakeupCmd()
  * ----------------------------------------------------
  */
-void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
+void SC_WakeupCmd(const SC_WakeupCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_OneHzWakeupCmd, const SC_OneHzWakeupCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_WakeupCmd, const SC_WakeupCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_OneHzWakeupCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_WakeupCmd, Basic, NULL);
 }
 
 /*
@@ -106,7 +106,7 @@ void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
  */
 void SC_ProcessAtpCmd(void)
 {
-  UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
 }
 
 /*
@@ -116,7 +116,7 @@ void SC_ProcessAtpCmd(void)
  */
 void SC_ProcessRtpCommand(void)
 {
-  UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
+    UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
 }
 
 /*
@@ -126,9 +126,9 @@ void SC_ProcessRtpCommand(void)
  */
 void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
 }
 
 /*
@@ -138,9 +138,9 @@ void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
  */
 void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
 }
 
 /*
@@ -150,5 +150,5 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
  */
 void SC_SendHkPacket(void)
 {
-  UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
+    UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
 }

--- a/unit-test/stubs/sc_cmds_stubs.c
+++ b/unit-test/stubs/sc_cmds_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_ManageAtsTable()
  * ----------------------------------------------------
  */
-void SC_ManageAtsTable(int32 ArrayIndex) {
+void SC_ManageAtsTable(int32 ArrayIndex)
+{
   UT_GenStub_AddParam(SC_ManageAtsTable, int32, ArrayIndex);
 
   UT_GenStub_Execute(SC_ManageAtsTable, Basic, NULL);
@@ -42,7 +43,8 @@ void SC_ManageAtsTable(int32 ArrayIndex) {
  * Generated stub function for SC_ManageRtsTable()
  * ----------------------------------------------------
  */
-void SC_ManageRtsTable(int32 ArrayIndex) {
+void SC_ManageRtsTable(int32 ArrayIndex)
+{
   UT_GenStub_AddParam(SC_ManageRtsTable, int32, ArrayIndex);
 
   UT_GenStub_Execute(SC_ManageRtsTable, Basic, NULL);
@@ -53,7 +55,8 @@ void SC_ManageRtsTable(int32 ArrayIndex) {
  * Generated stub function for SC_ManageTable()
  * ----------------------------------------------------
  */
-void SC_ManageTable(SC_TableType type, int32 ArrayIndex) {
+void SC_ManageTable(SC_TableType type, int32 ArrayIndex)
+{
   UT_GenStub_AddParam(SC_ManageTable, SC_TableType, type);
   UT_GenStub_AddParam(SC_ManageTable, int32, ArrayIndex);
 
@@ -65,7 +68,8 @@ void SC_ManageTable(SC_TableType type, int32 ArrayIndex) {
  * Generated stub function for SC_ManageTableCmd()
  * ----------------------------------------------------
  */
-void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd) {
+void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_ManageTableCmd, const SC_ManageTableCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_ManageTableCmd, Basic, NULL);
@@ -76,7 +80,8 @@ void SC_ManageTableCmd(const SC_ManageTableCmd_t *Cmd) {
  * Generated stub function for SC_NoopCmd()
  * ----------------------------------------------------
  */
-void SC_NoopCmd(const SC_NoopCmd_t *Cmd) {
+void SC_NoopCmd(const SC_NoopCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_NoopCmd, const SC_NoopCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_NoopCmd, Basic, NULL);
@@ -87,7 +92,8 @@ void SC_NoopCmd(const SC_NoopCmd_t *Cmd) {
  * Generated stub function for SC_OneHzWakeupCmd()
  * ----------------------------------------------------
  */
-void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd) {
+void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_OneHzWakeupCmd, const SC_OneHzWakeupCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_OneHzWakeupCmd, Basic, NULL);
@@ -98,8 +104,8 @@ void SC_OneHzWakeupCmd(const SC_OneHzWakeupCmd_t *Cmd) {
  * Generated stub function for SC_ProcessAtpCmd()
  * ----------------------------------------------------
  */
-void SC_ProcessAtpCmd(void) {
-
+void SC_ProcessAtpCmd(void)
+{
   UT_GenStub_Execute(SC_ProcessAtpCmd, Basic, NULL);
 }
 
@@ -108,8 +114,8 @@ void SC_ProcessAtpCmd(void) {
  * Generated stub function for SC_ProcessRtpCommand()
  * ----------------------------------------------------
  */
-void SC_ProcessRtpCommand(void) {
-
+void SC_ProcessRtpCommand(void)
+{
   UT_GenStub_Execute(SC_ProcessRtpCommand, Basic, NULL);
 }
 
@@ -118,7 +124,8 @@ void SC_ProcessRtpCommand(void) {
  * Generated stub function for SC_ResetCountersCmd()
  * ----------------------------------------------------
  */
-void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd) {
+void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_ResetCountersCmd, const SC_ResetCountersCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_ResetCountersCmd, Basic, NULL);
@@ -129,7 +136,8 @@ void SC_ResetCountersCmd(const SC_ResetCountersCmd_t *Cmd) {
  * Generated stub function for SC_SendHkCmd()
  * ----------------------------------------------------
  */
-void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd) {
+void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_SendHkCmd, const SC_SendHkCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_SendHkCmd, Basic, NULL);
@@ -140,4 +148,7 @@ void SC_SendHkCmd(const SC_SendHkCmd_t *Cmd) {
  * Generated stub function for SC_SendHkPacket()
  * ----------------------------------------------------
  */
-void SC_SendHkPacket(void) { UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL); }
+void SC_SendHkPacket(void)
+{
+  UT_GenStub_Execute(SC_SendHkPacket, Basic, NULL);
+}

--- a/unit-test/stubs/sc_dispatch_stubs.c
+++ b/unit-test/stubs/sc_dispatch_stubs.c
@@ -20,7 +20,8 @@
 /**
  * @file
  *
- * Auto-Generated stub implementations for functions defined in sc_dispatch header
+ * Auto-Generated stub implementations for functions defined in sc_dispatch
+ * header
  */
 
 #include "sc_dispatch.h"
@@ -31,11 +32,10 @@
  * Generated stub function for SC_ProcessCommand()
  * ----------------------------------------------------
  */
-void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr) {
+  UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
+  UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
 }
 
 /*
@@ -43,11 +43,10 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for SC_ProcessRequest()
  * ----------------------------------------------------
  */
-void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr) {
+  UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
+  UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
 }
 
 /*
@@ -55,14 +54,13 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for SC_VerifyCmdLength()
  * ----------------------------------------------------
  */
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
-{
-    UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength) {
+  UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
 
-    UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
-    UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
+  UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
+  UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
 
-    UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
+  UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
+  return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
 }

--- a/unit-test/stubs/sc_dispatch_stubs.c
+++ b/unit-test/stubs/sc_dispatch_stubs.c
@@ -32,7 +32,8 @@
  * Generated stub function for SC_ProcessCommand()
  * ----------------------------------------------------
  */
-void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr) {
+void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
+{
   UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
 
   UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
@@ -43,7 +44,8 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr) {
  * Generated stub function for SC_ProcessRequest()
  * ----------------------------------------------------
  */
-void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr) {
+void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
+{
   UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
 
   UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
@@ -54,7 +56,8 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr) {
  * Generated stub function for SC_VerifyCmdLength()
  * ----------------------------------------------------
  */
-bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength) {
+bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
+{
   UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
 
   UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);

--- a/unit-test/stubs/sc_dispatch_stubs.c
+++ b/unit-test/stubs/sc_dispatch_stubs.c
@@ -34,9 +34,9 @@
  */
 void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
 {
-  UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_ProcessCommand, const CFE_SB_Buffer_t *, BufPtr);
 
-  UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
+    UT_GenStub_Execute(SC_ProcessCommand, Basic, NULL);
 }
 
 /*
@@ -46,9 +46,9 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
  */
 void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
 {
-  UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(SC_ProcessRequest, const CFE_SB_Buffer_t *, BufPtr);
 
-  UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
+    UT_GenStub_Execute(SC_ProcessRequest, Basic, NULL);
 }
 
 /*
@@ -58,12 +58,12 @@ void SC_ProcessRequest(const CFE_SB_Buffer_t *BufPtr)
  */
 bool SC_VerifyCmdLength(const CFE_MSG_Message_t *Msg, size_t ExpectedLength)
 {
-  UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
+    UT_GenStub_SetupReturnBuffer(SC_VerifyCmdLength, bool);
 
-  UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
-  UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
+    UT_GenStub_AddParam(SC_VerifyCmdLength, const CFE_MSG_Message_t *, Msg);
+    UT_GenStub_AddParam(SC_VerifyCmdLength, size_t, ExpectedLength);
 
-  UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
+    UT_GenStub_Execute(SC_VerifyCmdLength, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
+    return UT_GenStub_GetReturnValue(SC_VerifyCmdLength, bool);
 }

--- a/unit-test/stubs/sc_loads_stubs.c
+++ b/unit-test/stubs/sc_loads_stubs.c
@@ -31,11 +31,10 @@
  * Generated stub function for SC_BuildTimeIndexTable()
  * ----------------------------------------------------
  */
-void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
-{
-    UT_GenStub_AddParam(SC_BuildTimeIndexTable, SC_AtsIndex_t, AtsIndex);
+void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex) {
+  UT_GenStub_AddParam(SC_BuildTimeIndexTable, SC_AtsIndex_t, AtsIndex);
 
-    UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
+  UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
 }
 
 /*
@@ -43,11 +42,10 @@ void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
  * Generated stub function for SC_InitAtsTables()
  * ----------------------------------------------------
  */
-void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
-{
-    UT_GenStub_AddParam(SC_InitAtsTables, SC_AtsIndex_t, AtsIndex);
+void SC_InitAtsTables(SC_AtsIndex_t AtsIndex) {
+  UT_GenStub_AddParam(SC_InitAtsTables, SC_AtsIndex_t, AtsIndex);
 
-    UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
+  UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
 }
 
 /*
@@ -55,13 +53,13 @@ void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
  * Generated stub function for SC_Insert()
  * ----------------------------------------------------
  */
-void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex, uint32 ListLength)
-{
-    UT_GenStub_AddParam(SC_Insert, SC_AtsIndex_t, AtsIndex);
-    UT_GenStub_AddParam(SC_Insert, SC_CommandIndex_t, NewCmdIndex);
-    UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
+void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex,
+               uint32 ListLength) {
+  UT_GenStub_AddParam(SC_Insert, SC_AtsIndex_t, AtsIndex);
+  UT_GenStub_AddParam(SC_Insert, SC_CommandIndex_t, NewCmdIndex);
+  UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
 
-    UT_GenStub_Execute(SC_Insert, Basic, NULL);
+  UT_GenStub_Execute(SC_Insert, Basic, NULL);
 }
 
 /*
@@ -69,11 +67,10 @@ void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex, uint32 Lis
  * Generated stub function for SC_LoadAts()
  * ----------------------------------------------------
  */
-void SC_LoadAts(SC_AtsIndex_t AtsIndex)
-{
-    UT_GenStub_AddParam(SC_LoadAts, SC_AtsIndex_t, AtsIndex);
+void SC_LoadAts(SC_AtsIndex_t AtsIndex) {
+  UT_GenStub_AddParam(SC_LoadAts, SC_AtsIndex_t, AtsIndex);
 
-    UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
+  UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
 }
 
 /*
@@ -81,11 +78,10 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex)
  * Generated stub function for SC_LoadRts()
  * ----------------------------------------------------
  */
-void SC_LoadRts(SC_RtsIndex_t RtsIndex)
-{
-    UT_GenStub_AddParam(SC_LoadRts, SC_RtsIndex_t, RtsIndex);
+void SC_LoadRts(SC_RtsIndex_t RtsIndex) {
+  UT_GenStub_AddParam(SC_LoadRts, SC_RtsIndex_t, RtsIndex);
 
-    UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
+  UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
 }
 
 /*
@@ -93,13 +89,12 @@ void SC_LoadRts(SC_RtsIndex_t RtsIndex)
  * Generated stub function for SC_ParseRts()
  * ----------------------------------------------------
  */
-bool SC_ParseRts(uint32 Buffer32[])
-{
-    UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
+bool SC_ParseRts(uint32 Buffer32[]) {
+  UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
 
-    UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
+  UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ParseRts, bool);
+  return UT_GenStub_GetReturnValue(SC_ParseRts, bool);
 }
 
 /*
@@ -107,11 +102,10 @@ bool SC_ParseRts(uint32 Buffer32[])
  * Generated stub function for SC_ProcessAppend()
  * ----------------------------------------------------
  */
-void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
-{
-    UT_GenStub_AddParam(SC_ProcessAppend, SC_AtsIndex_t, AtsIndex);
+void SC_ProcessAppend(SC_AtsIndex_t AtsIndex) {
+  UT_GenStub_AddParam(SC_ProcessAppend, SC_AtsIndex_t, AtsIndex);
 
-    UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
+  UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
 }
 
 /*
@@ -119,26 +113,21 @@ void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
  * Generated stub function for SC_UpdateAppend()
  * ----------------------------------------------------
  */
-void SC_UpdateAppend(void)
-{
-
-    UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL);
-}
+void SC_UpdateAppend(void) { UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL); }
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_ValidateAppend()
  * ----------------------------------------------------
  */
-int32 SC_ValidateAppend(void *TableData)
-{
-    UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
+int32 SC_ValidateAppend(void *TableData) {
+  UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
 
-    UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
+  UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
 
-    UT_GenStub_Execute(SC_ValidateAppend, Basic, NULL);
+  UT_GenStub_Execute(SC_ValidateAppend, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ValidateAppend, int32);
+  return UT_GenStub_GetReturnValue(SC_ValidateAppend, int32);
 }
 
 /*
@@ -146,15 +135,14 @@ int32 SC_ValidateAppend(void *TableData)
  * Generated stub function for SC_ValidateAts()
  * ----------------------------------------------------
  */
-int32 SC_ValidateAts(void *TableData)
-{
-    UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
+int32 SC_ValidateAts(void *TableData) {
+  UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
 
-    UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
+  UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
 
-    UT_GenStub_Execute(SC_ValidateAts, Basic, NULL);
+  UT_GenStub_Execute(SC_ValidateAts, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ValidateAts, int32);
+  return UT_GenStub_GetReturnValue(SC_ValidateAts, int32);
 }
 
 /*
@@ -162,15 +150,14 @@ int32 SC_ValidateAts(void *TableData)
  * Generated stub function for SC_ValidateRts()
  * ----------------------------------------------------
  */
-int32 SC_ValidateRts(void *TableData)
-{
-    UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
+int32 SC_ValidateRts(void *TableData) {
+  UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
 
-    UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
+  UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
 
-    UT_GenStub_Execute(SC_ValidateRts, Basic, NULL);
+  UT_GenStub_Execute(SC_ValidateRts, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ValidateRts, int32);
+  return UT_GenStub_GetReturnValue(SC_ValidateRts, int32);
 }
 
 /*
@@ -178,17 +165,16 @@ int32 SC_ValidateRts(void *TableData)
  * Generated stub function for SC_VerifyAtsEntry()
  * ----------------------------------------------------
  */
-int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
-{
-    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
+int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords) {
+  UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
 
-    UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
-    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, EntryIndex);
-    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, BufferWords);
+  UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
+  UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, EntryIndex);
+  UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, BufferWords);
 
-    UT_GenStub_Execute(SC_VerifyAtsEntry, Basic, NULL);
+  UT_GenStub_Execute(SC_VerifyAtsEntry, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_VerifyAtsEntry, int32);
+  return UT_GenStub_GetReturnValue(SC_VerifyAtsEntry, int32);
 }
 
 /*
@@ -196,14 +182,13 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
  * Generated stub function for SC_VerifyAtsTable()
  * ----------------------------------------------------
  */
-int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords)
-{
-    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
+int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords) {
+  UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
 
-    UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);
-    UT_GenStub_AddParam(SC_VerifyAtsTable, int32, BufferWords);
+  UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);
+  UT_GenStub_AddParam(SC_VerifyAtsTable, int32, BufferWords);
 
-    UT_GenStub_Execute(SC_VerifyAtsTable, Basic, NULL);
+  UT_GenStub_Execute(SC_VerifyAtsTable, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_VerifyAtsTable, int32);
+  return UT_GenStub_GetReturnValue(SC_VerifyAtsTable, int32);
 }

--- a/unit-test/stubs/sc_loads_stubs.c
+++ b/unit-test/stubs/sc_loads_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_BuildTimeIndexTable()
  * ----------------------------------------------------
  */
-void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex) {
+void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
+{
   UT_GenStub_AddParam(SC_BuildTimeIndexTable, SC_AtsIndex_t, AtsIndex);
 
   UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
@@ -42,7 +43,8 @@ void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex) {
  * Generated stub function for SC_InitAtsTables()
  * ----------------------------------------------------
  */
-void SC_InitAtsTables(SC_AtsIndex_t AtsIndex) {
+void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
+{
   UT_GenStub_AddParam(SC_InitAtsTables, SC_AtsIndex_t, AtsIndex);
 
   UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
@@ -54,7 +56,8 @@ void SC_InitAtsTables(SC_AtsIndex_t AtsIndex) {
  * ----------------------------------------------------
  */
 void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex,
-               uint32 ListLength) {
+               uint32 ListLength)
+               {
   UT_GenStub_AddParam(SC_Insert, SC_AtsIndex_t, AtsIndex);
   UT_GenStub_AddParam(SC_Insert, SC_CommandIndex_t, NewCmdIndex);
   UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
@@ -67,7 +70,8 @@ void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex,
  * Generated stub function for SC_LoadAts()
  * ----------------------------------------------------
  */
-void SC_LoadAts(SC_AtsIndex_t AtsIndex) {
+void SC_LoadAts(SC_AtsIndex_t AtsIndex)
+{
   UT_GenStub_AddParam(SC_LoadAts, SC_AtsIndex_t, AtsIndex);
 
   UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
@@ -78,7 +82,8 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex) {
  * Generated stub function for SC_LoadRts()
  * ----------------------------------------------------
  */
-void SC_LoadRts(SC_RtsIndex_t RtsIndex) {
+void SC_LoadRts(SC_RtsIndex_t RtsIndex)
+{
   UT_GenStub_AddParam(SC_LoadRts, SC_RtsIndex_t, RtsIndex);
 
   UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
@@ -89,7 +94,8 @@ void SC_LoadRts(SC_RtsIndex_t RtsIndex) {
  * Generated stub function for SC_ParseRts()
  * ----------------------------------------------------
  */
-bool SC_ParseRts(uint32 Buffer32[]) {
+bool SC_ParseRts(uint32 Buffer32[])
+{
   UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
 
   UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
@@ -102,7 +108,8 @@ bool SC_ParseRts(uint32 Buffer32[]) {
  * Generated stub function for SC_ProcessAppend()
  * ----------------------------------------------------
  */
-void SC_ProcessAppend(SC_AtsIndex_t AtsIndex) {
+void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
+{
   UT_GenStub_AddParam(SC_ProcessAppend, SC_AtsIndex_t, AtsIndex);
 
   UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
@@ -113,14 +120,18 @@ void SC_ProcessAppend(SC_AtsIndex_t AtsIndex) {
  * Generated stub function for SC_UpdateAppend()
  * ----------------------------------------------------
  */
-void SC_UpdateAppend(void) { UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL); }
+void SC_UpdateAppend(void)
+{
+  UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL);
+}
 
 /*
  * ----------------------------------------------------
  * Generated stub function for SC_ValidateAppend()
  * ----------------------------------------------------
  */
-int32 SC_ValidateAppend(void *TableData) {
+int32 SC_ValidateAppend(void *TableData)
+{
   UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
 
   UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
@@ -135,7 +146,8 @@ int32 SC_ValidateAppend(void *TableData) {
  * Generated stub function for SC_ValidateAts()
  * ----------------------------------------------------
  */
-int32 SC_ValidateAts(void *TableData) {
+int32 SC_ValidateAts(void *TableData)
+{
   UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
 
   UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
@@ -150,7 +162,8 @@ int32 SC_ValidateAts(void *TableData) {
  * Generated stub function for SC_ValidateRts()
  * ----------------------------------------------------
  */
-int32 SC_ValidateRts(void *TableData) {
+int32 SC_ValidateRts(void *TableData)
+{
   UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
 
   UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
@@ -165,7 +178,8 @@ int32 SC_ValidateRts(void *TableData) {
  * Generated stub function for SC_VerifyAtsEntry()
  * ----------------------------------------------------
  */
-int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords) {
+int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
+{
   UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
 
   UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
@@ -182,7 +196,8 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords) {
  * Generated stub function for SC_VerifyAtsTable()
  * ----------------------------------------------------
  */
-int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords) {
+int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords)
+{
   UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
 
   UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);

--- a/unit-test/stubs/sc_loads_stubs.c
+++ b/unit-test/stubs/sc_loads_stubs.c
@@ -33,9 +33,9 @@
  */
 void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
 {
-  UT_GenStub_AddParam(SC_BuildTimeIndexTable, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_BuildTimeIndexTable, SC_AtsIndex_t, AtsIndex);
 
-  UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
+    UT_GenStub_Execute(SC_BuildTimeIndexTable, Basic, NULL);
 }
 
 /*
@@ -45,9 +45,9 @@ void SC_BuildTimeIndexTable(SC_AtsIndex_t AtsIndex)
  */
 void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
 {
-  UT_GenStub_AddParam(SC_InitAtsTables, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_InitAtsTables, SC_AtsIndex_t, AtsIndex);
 
-  UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
+    UT_GenStub_Execute(SC_InitAtsTables, Basic, NULL);
 }
 
 /*
@@ -55,14 +55,13 @@ void SC_InitAtsTables(SC_AtsIndex_t AtsIndex)
  * Generated stub function for SC_Insert()
  * ----------------------------------------------------
  */
-void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex,
-               uint32 ListLength)
-               {
-  UT_GenStub_AddParam(SC_Insert, SC_AtsIndex_t, AtsIndex);
-  UT_GenStub_AddParam(SC_Insert, SC_CommandIndex_t, NewCmdIndex);
-  UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
+void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex, uint32 ListLength)
+{
+    UT_GenStub_AddParam(SC_Insert, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_Insert, SC_CommandIndex_t, NewCmdIndex);
+    UT_GenStub_AddParam(SC_Insert, uint32, ListLength);
 
-  UT_GenStub_Execute(SC_Insert, Basic, NULL);
+    UT_GenStub_Execute(SC_Insert, Basic, NULL);
 }
 
 /*
@@ -72,9 +71,9 @@ void SC_Insert(SC_AtsIndex_t AtsIndex, SC_CommandIndex_t NewCmdIndex,
  */
 void SC_LoadAts(SC_AtsIndex_t AtsIndex)
 {
-  UT_GenStub_AddParam(SC_LoadAts, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_LoadAts, SC_AtsIndex_t, AtsIndex);
 
-  UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
+    UT_GenStub_Execute(SC_LoadAts, Basic, NULL);
 }
 
 /*
@@ -84,9 +83,9 @@ void SC_LoadAts(SC_AtsIndex_t AtsIndex)
  */
 void SC_LoadRts(SC_RtsIndex_t RtsIndex)
 {
-  UT_GenStub_AddParam(SC_LoadRts, SC_RtsIndex_t, RtsIndex);
+    UT_GenStub_AddParam(SC_LoadRts, SC_RtsIndex_t, RtsIndex);
 
-  UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
+    UT_GenStub_Execute(SC_LoadRts, Basic, NULL);
 }
 
 /*
@@ -96,11 +95,11 @@ void SC_LoadRts(SC_RtsIndex_t RtsIndex)
  */
 bool SC_ParseRts(uint32 Buffer32[])
 {
-  UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
+    UT_GenStub_SetupReturnBuffer(SC_ParseRts, bool);
 
-  UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
+    UT_GenStub_Execute(SC_ParseRts, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ParseRts, bool);
+    return UT_GenStub_GetReturnValue(SC_ParseRts, bool);
 }
 
 /*
@@ -110,9 +109,9 @@ bool SC_ParseRts(uint32 Buffer32[])
  */
 void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
 {
-  UT_GenStub_AddParam(SC_ProcessAppend, SC_AtsIndex_t, AtsIndex);
+    UT_GenStub_AddParam(SC_ProcessAppend, SC_AtsIndex_t, AtsIndex);
 
-  UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
+    UT_GenStub_Execute(SC_ProcessAppend, Basic, NULL);
 }
 
 /*
@@ -122,7 +121,7 @@ void SC_ProcessAppend(SC_AtsIndex_t AtsIndex)
  */
 void SC_UpdateAppend(void)
 {
-  UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL);
+    UT_GenStub_Execute(SC_UpdateAppend, Basic, NULL);
 }
 
 /*
@@ -132,13 +131,13 @@ void SC_UpdateAppend(void)
  */
 int32 SC_ValidateAppend(void *TableData)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
+    UT_GenStub_SetupReturnBuffer(SC_ValidateAppend, int32);
 
-  UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
+    UT_GenStub_AddParam(SC_ValidateAppend, void *, TableData);
 
-  UT_GenStub_Execute(SC_ValidateAppend, Basic, NULL);
+    UT_GenStub_Execute(SC_ValidateAppend, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ValidateAppend, int32);
+    return UT_GenStub_GetReturnValue(SC_ValidateAppend, int32);
 }
 
 /*
@@ -148,13 +147,13 @@ int32 SC_ValidateAppend(void *TableData)
  */
 int32 SC_ValidateAts(void *TableData)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
+    UT_GenStub_SetupReturnBuffer(SC_ValidateAts, int32);
 
-  UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
+    UT_GenStub_AddParam(SC_ValidateAts, void *, TableData);
 
-  UT_GenStub_Execute(SC_ValidateAts, Basic, NULL);
+    UT_GenStub_Execute(SC_ValidateAts, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ValidateAts, int32);
+    return UT_GenStub_GetReturnValue(SC_ValidateAts, int32);
 }
 
 /*
@@ -164,13 +163,13 @@ int32 SC_ValidateAts(void *TableData)
  */
 int32 SC_ValidateRts(void *TableData)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
+    UT_GenStub_SetupReturnBuffer(SC_ValidateRts, int32);
 
-  UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
+    UT_GenStub_AddParam(SC_ValidateRts, void *, TableData);
 
-  UT_GenStub_Execute(SC_ValidateRts, Basic, NULL);
+    UT_GenStub_Execute(SC_ValidateRts, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ValidateRts, int32);
+    return UT_GenStub_GetReturnValue(SC_ValidateRts, int32);
 }
 
 /*
@@ -180,15 +179,15 @@ int32 SC_ValidateRts(void *TableData)
  */
 int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
 {
-  UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
+    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsEntry, int32);
 
-  UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
-  UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, EntryIndex);
-  UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, BufferWords);
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, uint32 *, Buffer32);
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, EntryIndex);
+    UT_GenStub_AddParam(SC_VerifyAtsEntry, int32, BufferWords);
 
-  UT_GenStub_Execute(SC_VerifyAtsEntry, Basic, NULL);
+    UT_GenStub_Execute(SC_VerifyAtsEntry, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_VerifyAtsEntry, int32);
+    return UT_GenStub_GetReturnValue(SC_VerifyAtsEntry, int32);
 }
 
 /*
@@ -198,12 +197,12 @@ int32 SC_VerifyAtsEntry(uint32 *Buffer32, int32 EntryIndex, int32 BufferWords)
  */
 int32 SC_VerifyAtsTable(uint32 *Buffer32, int32 BufferWords)
 {
-  UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
+    UT_GenStub_SetupReturnBuffer(SC_VerifyAtsTable, int32);
 
-  UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);
-  UT_GenStub_AddParam(SC_VerifyAtsTable, int32, BufferWords);
+    UT_GenStub_AddParam(SC_VerifyAtsTable, uint32 *, Buffer32);
+    UT_GenStub_AddParam(SC_VerifyAtsTable, int32, BufferWords);
 
-  UT_GenStub_Execute(SC_VerifyAtsTable, Basic, NULL);
+    UT_GenStub_Execute(SC_VerifyAtsTable, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_VerifyAtsTable, int32);
+    return UT_GenStub_GetReturnValue(SC_VerifyAtsTable, int32);
 }

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -33,9 +33,9 @@
  */
 void SC_AutoStartRts(SC_RtsNum_t RtsNum)
 {
-  UT_GenStub_AddParam(SC_AutoStartRts, SC_RtsNum_t, RtsNum);
+    UT_GenStub_AddParam(SC_AutoStartRts, SC_RtsNum_t, RtsNum);
 
-  UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
+    UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
 }
 
 /*
@@ -45,9 +45,9 @@ void SC_AutoStartRts(SC_RtsNum_t RtsNum)
  */
 void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
 }
 
 /*
@@ -57,9 +57,9 @@ void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
  */
 void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -69,9 +69,9 @@ void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
  */
 void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
 }
 
 /*
@@ -81,9 +81,9 @@ void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
  */
 void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -93,9 +93,9 @@ void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
  */
 void SC_KillRts(SC_RtsIndex_t RtsIndex)
 {
-  UT_GenStub_AddParam(SC_KillRts, SC_RtsIndex_t, RtsIndex);
+    UT_GenStub_AddParam(SC_KillRts, SC_RtsIndex_t, RtsIndex);
 
-  UT_GenStub_Execute(SC_KillRts, Basic, NULL);
+    UT_GenStub_Execute(SC_KillRts, Basic, NULL);
 }
 
 /*
@@ -105,9 +105,9 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex)
  */
 void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
 }
 
 /*
@@ -117,9 +117,9 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
  */
 void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -129,9 +129,9 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
  */
 void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
 }
 
 /*
@@ -141,7 +141,7 @@ void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
  */
 void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
 {
-  UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
+    UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
 
-  UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
+    UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_AutoStartRts()
  * ----------------------------------------------------
  */
-void SC_AutoStartRts(SC_RtsNum_t RtsNum) {
+void SC_AutoStartRts(SC_RtsNum_t RtsNum)
+{
   UT_GenStub_AddParam(SC_AutoStartRts, SC_RtsNum_t, RtsNum);
 
   UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
@@ -42,7 +43,8 @@ void SC_AutoStartRts(SC_RtsNum_t RtsNum) {
  * Generated stub function for SC_DisableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd) {
+void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
@@ -53,7 +55,8 @@ void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd) {
  * Generated stub function for SC_DisableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd) {
+void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
@@ -64,7 +67,8 @@ void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd) {
  * Generated stub function for SC_EnableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd) {
+void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
@@ -75,7 +79,8 @@ void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd) {
  * Generated stub function for SC_EnableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd) {
+void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
@@ -86,7 +91,8 @@ void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd) {
  * Generated stub function for SC_KillRts()
  * ----------------------------------------------------
  */
-void SC_KillRts(SC_RtsIndex_t RtsIndex) {
+void SC_KillRts(SC_RtsIndex_t RtsIndex)
+{
   UT_GenStub_AddParam(SC_KillRts, SC_RtsIndex_t, RtsIndex);
 
   UT_GenStub_Execute(SC_KillRts, Basic, NULL);
@@ -97,7 +103,8 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex) {
  * Generated stub function for SC_StartRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd) {
+void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
@@ -108,7 +115,8 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd) {
  * Generated stub function for SC_StartRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd) {
+void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
@@ -119,7 +127,8 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd) {
  * Generated stub function for SC_StopRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd) {
+void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
@@ -130,7 +139,8 @@ void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd) {
  * Generated stub function for SC_StopRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd) {
+void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
+{
   UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
 
   UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -31,11 +31,10 @@
  * Generated stub function for SC_AutoStartRts()
  * ----------------------------------------------------
  */
-void SC_AutoStartRts(SC_RtsNum_t RtsNum)
-{
-    UT_GenStub_AddParam(SC_AutoStartRts, SC_RtsNum_t, RtsNum);
+void SC_AutoStartRts(SC_RtsNum_t RtsNum) {
+  UT_GenStub_AddParam(SC_AutoStartRts, SC_RtsNum_t, RtsNum);
 
-    UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
+  UT_GenStub_Execute(SC_AutoStartRts, Basic, NULL);
 }
 
 /*
@@ -43,11 +42,10 @@ void SC_AutoStartRts(SC_RtsNum_t RtsNum)
  * Generated stub function for SC_DisableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
+void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_DisableRtsCmd, const SC_DisableRtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_DisableRtsCmd, Basic, NULL);
 }
 
 /*
@@ -55,11 +53,10 @@ void SC_DisableRtsCmd(const SC_DisableRtsCmd_t *Cmd)
  * Generated stub function for SC_DisableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
+void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_DisableRtsGrpCmd, const SC_DisableRtsGrpCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_DisableRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -67,11 +64,10 @@ void SC_DisableRtsGrpCmd(const SC_DisableRtsGrpCmd_t *Cmd)
  * Generated stub function for SC_EnableRtsCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
+void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_EnableRtsCmd, const SC_EnableRtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_EnableRtsCmd, Basic, NULL);
 }
 
 /*
@@ -79,11 +75,10 @@ void SC_EnableRtsCmd(const SC_EnableRtsCmd_t *Cmd)
  * Generated stub function for SC_EnableRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
+void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_EnableRtsGrpCmd, const SC_EnableRtsGrpCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_EnableRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -91,11 +86,10 @@ void SC_EnableRtsGrpCmd(const SC_EnableRtsGrpCmd_t *Cmd)
  * Generated stub function for SC_KillRts()
  * ----------------------------------------------------
  */
-void SC_KillRts(SC_RtsIndex_t RtsIndex)
-{
-    UT_GenStub_AddParam(SC_KillRts, SC_RtsIndex_t, RtsIndex);
+void SC_KillRts(SC_RtsIndex_t RtsIndex) {
+  UT_GenStub_AddParam(SC_KillRts, SC_RtsIndex_t, RtsIndex);
 
-    UT_GenStub_Execute(SC_KillRts, Basic, NULL);
+  UT_GenStub_Execute(SC_KillRts, Basic, NULL);
 }
 
 /*
@@ -103,11 +97,10 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex)
  * Generated stub function for SC_StartRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
+void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StartRtsCmd, const SC_StartRtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StartRtsCmd, Basic, NULL);
 }
 
 /*
@@ -115,11 +108,10 @@ void SC_StartRtsCmd(const SC_StartRtsCmd_t *Cmd)
  * Generated stub function for SC_StartRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
+void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StartRtsGrpCmd, const SC_StartRtsGrpCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StartRtsGrpCmd, Basic, NULL);
 }
 
 /*
@@ -127,11 +119,10 @@ void SC_StartRtsGrpCmd(const SC_StartRtsGrpCmd_t *Cmd)
  * Generated stub function for SC_StopRtsCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
+void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StopRtsCmd, const SC_StopRtsCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StopRtsCmd, Basic, NULL);
 }
 
 /*
@@ -139,9 +130,8 @@ void SC_StopRtsCmd(const SC_StopRtsCmd_t *Cmd)
  * Generated stub function for SC_StopRtsGrpCmd()
  * ----------------------------------------------------
  */
-void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
-{
-    UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
+void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd) {
+  UT_GenStub_AddParam(SC_StopRtsGrpCmd, const SC_StopRtsGrpCmd_t *, Cmd);
 
-    UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
+  UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
 }

--- a/unit-test/stubs/sc_state_stubs.c
+++ b/unit-test/stubs/sc_state_stubs.c
@@ -31,10 +31,9 @@
  * Generated stub function for SC_GetNextAtsCommand()
  * ----------------------------------------------------
  */
-void SC_GetNextAtsCommand(void)
-{
+void SC_GetNextAtsCommand(void) {
 
-    UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
+  UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
 }
 
 /*
@@ -42,10 +41,9 @@ void SC_GetNextAtsCommand(void)
  * Generated stub function for SC_GetNextRtsCommand()
  * ----------------------------------------------------
  */
-void SC_GetNextRtsCommand(void)
-{
+void SC_GetNextRtsCommand(void) {
 
-    UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
+  UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
 }
 
 /*
@@ -53,10 +51,9 @@ void SC_GetNextRtsCommand(void)
  * Generated stub function for SC_GetNextRtsTime()
  * ----------------------------------------------------
  */
-void SC_GetNextRtsTime(void)
-{
+void SC_GetNextRtsTime(void) {
 
-    UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
+  UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
 }
 
 /*
@@ -64,8 +61,7 @@ void SC_GetNextRtsTime(void)
  * Generated stub function for SC_UpdateNextTime()
  * ----------------------------------------------------
  */
-void SC_UpdateNextTime(void)
-{
+void SC_UpdateNextTime(void) {
 
-    UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
+  UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
 }

--- a/unit-test/stubs/sc_state_stubs.c
+++ b/unit-test/stubs/sc_state_stubs.c
@@ -31,8 +31,8 @@
  * Generated stub function for SC_GetNextAtsCommand()
  * ----------------------------------------------------
  */
-void SC_GetNextAtsCommand(void) {
-
+void SC_GetNextAtsCommand(void)
+{
   UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
 }
 
@@ -41,8 +41,8 @@ void SC_GetNextAtsCommand(void) {
  * Generated stub function for SC_GetNextRtsCommand()
  * ----------------------------------------------------
  */
-void SC_GetNextRtsCommand(void) {
-
+void SC_GetNextRtsCommand(void)
+{
   UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
 }
 
@@ -51,8 +51,8 @@ void SC_GetNextRtsCommand(void) {
  * Generated stub function for SC_GetNextRtsTime()
  * ----------------------------------------------------
  */
-void SC_GetNextRtsTime(void) {
-
+void SC_GetNextRtsTime(void)
+{
   UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
 }
 
@@ -61,7 +61,7 @@ void SC_GetNextRtsTime(void) {
  * Generated stub function for SC_UpdateNextTime()
  * ----------------------------------------------------
  */
-void SC_UpdateNextTime(void) {
-
+void SC_UpdateNextTime(void)
+{
   UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
 }

--- a/unit-test/stubs/sc_state_stubs.c
+++ b/unit-test/stubs/sc_state_stubs.c
@@ -33,7 +33,7 @@
  */
 void SC_GetNextAtsCommand(void)
 {
-  UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
+    UT_GenStub_Execute(SC_GetNextAtsCommand, Basic, NULL);
 }
 
 /*
@@ -43,7 +43,7 @@ void SC_GetNextAtsCommand(void)
  */
 void SC_GetNextRtsCommand(void)
 {
-  UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
+    UT_GenStub_Execute(SC_GetNextRtsCommand, Basic, NULL);
 }
 
 /*
@@ -53,7 +53,7 @@ void SC_GetNextRtsCommand(void)
  */
 void SC_GetNextRtsTime(void)
 {
-  UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
+    UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
 }
 
 /*
@@ -63,5 +63,5 @@ void SC_GetNextRtsTime(void)
  */
 void SC_UpdateNextTime(void)
 {
-  UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
+    UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
 }

--- a/unit-test/stubs/sc_state_stubs.c
+++ b/unit-test/stubs/sc_state_stubs.c
@@ -55,13 +55,3 @@ void SC_GetNextRtsTime(void)
 {
     UT_GenStub_Execute(SC_GetNextRtsTime, Basic, NULL);
 }
-
-/*
- * ----------------------------------------------------
- * Generated stub function for SC_UpdateNextTime()
- * ----------------------------------------------------
- */
-void SC_UpdateNextTime(void)
-{
-    UT_GenStub_Execute(SC_UpdateNextTime, Basic, NULL);
-}

--- a/unit-test/stubs/sc_utils_stubs.c
+++ b/unit-test/stubs/sc_utils_stubs.c
@@ -31,16 +31,15 @@
  * Generated stub function for SC_CompareAbsTime()
  * ----------------------------------------------------
  */
-bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
-{
-    UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
+bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2) {
+  UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
 
-    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
-    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime2);
+  UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
+  UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime2);
 
-    UT_GenStub_Execute(SC_CompareAbsTime, Basic, NULL);
+  UT_GenStub_Execute(SC_CompareAbsTime, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_CompareAbsTime, bool);
+  return UT_GenStub_GetReturnValue(SC_CompareAbsTime, bool);
 }
 
 /*
@@ -48,15 +47,29 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
  * Generated stub function for SC_ComputeAbsTime()
  * ----------------------------------------------------
  */
-SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
-{
-    UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime) {
+  UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
 
-    UT_GenStub_AddParam(SC_ComputeAbsTime, SC_RelTimeTag_t, RelTime);
+  UT_GenStub_AddParam(SC_ComputeAbsTime, SC_RelTimeTag_t, RelTime);
 
-    UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
+  UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+  return UT_GenStub_GetReturnValue(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ComputeAbsWakeup()
+ * ----------------------------------------------------
+ */
+uint32 SC_ComputeAbsWakeup(uint32 RelWakeup) {
+  UT_GenStub_SetupReturnBuffer(SC_ComputeAbsWakeup, uint32);
+
+  UT_GenStub_AddParam(SC_ComputeAbsWakeup, uint32, RelWakeup);
+
+  UT_GenStub_Execute(SC_ComputeAbsWakeup, Basic, NULL);
+
+  return UT_GenStub_GetReturnValue(SC_ComputeAbsWakeup, uint32);
 }
 
 /*
@@ -64,15 +77,14 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime)
  * Generated stub function for SC_GetAtsEntryTime()
  * ----------------------------------------------------
  */
-SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
-{
-    UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry) {
+  UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
 
-    UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
+  UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
 
-    UT_GenStub_Execute(SC_GetAtsEntryTime, Basic, NULL);
+  UT_GenStub_Execute(SC_GetAtsEntryTime, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+  return UT_GenStub_GetReturnValue(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
 }
 
 /*
@@ -80,10 +92,9 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
  * Generated stub function for SC_GetCurrentTime()
  * ----------------------------------------------------
  */
-void SC_GetCurrentTime(void)
-{
+void SC_GetCurrentTime(void) {
 
-    UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
+  UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
 }
 
 /*
@@ -91,15 +102,14 @@ void SC_GetCurrentTime(void)
  * Generated stub function for SC_LookupTimeAccessor()
  * ----------------------------------------------------
  */
-SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef)
-{
-    UT_GenStub_SetupReturnBuffer(SC_LookupTimeAccessor, SC_TimeAccessor_t);
+SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef) {
+  UT_GenStub_SetupReturnBuffer(SC_LookupTimeAccessor, SC_TimeAccessor_t);
 
-    UT_GenStub_AddParam(SC_LookupTimeAccessor, SC_TimeRef_Enum_t, TimeRef);
+  UT_GenStub_AddParam(SC_LookupTimeAccessor, SC_TimeRef_Enum_t, TimeRef);
 
-    UT_GenStub_Execute(SC_LookupTimeAccessor, Basic, NULL);
+  UT_GenStub_Execute(SC_LookupTimeAccessor, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_LookupTimeAccessor, SC_TimeAccessor_t);
+  return UT_GenStub_GetReturnValue(SC_LookupTimeAccessor, SC_TimeAccessor_t);
 }
 
 /*
@@ -107,11 +117,10 @@ SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef)
  * Generated stub function for SC_ToggleAtsIndex()
  * ----------------------------------------------------
  */
-SC_AtsIndex_t SC_ToggleAtsIndex(void)
-{
-    UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, SC_AtsIndex_t);
+SC_AtsIndex_t SC_ToggleAtsIndex(void) {
+  UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, SC_AtsIndex_t);
 
-    UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);
+  UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, SC_AtsIndex_t);
+  return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, SC_AtsIndex_t);
 }

--- a/unit-test/stubs/sc_utils_stubs.c
+++ b/unit-test/stubs/sc_utils_stubs.c
@@ -31,7 +31,8 @@
  * Generated stub function for SC_CompareAbsTime()
  * ----------------------------------------------------
  */
-bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2) {
+bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
+{
   UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
 
   UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
@@ -47,10 +48,11 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2) {
  * Generated stub function for SC_ComputeAbsTime()
  * ----------------------------------------------------
  */
-SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime) {
+SC_AbsTimeTag_t SC_ComputeAbsTime(uint32 RelTime)
+{
   UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
 
-  UT_GenStub_AddParam(SC_ComputeAbsTime, SC_RelTimeTag_t, RelTime);
+  UT_GenStub_AddParam(SC_ComputeAbsTime, uint32, RelTime);
 
   UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
 
@@ -62,7 +64,8 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(SC_RelTimeTag_t RelTime) {
  * Generated stub function for SC_ComputeAbsWakeup()
  * ----------------------------------------------------
  */
-uint32 SC_ComputeAbsWakeup(uint32 RelWakeup) {
+uint32 SC_ComputeAbsWakeup(uint32 RelWakeup)
+{
   UT_GenStub_SetupReturnBuffer(SC_ComputeAbsWakeup, uint32);
 
   UT_GenStub_AddParam(SC_ComputeAbsWakeup, uint32, RelWakeup);
@@ -77,7 +80,8 @@ uint32 SC_ComputeAbsWakeup(uint32 RelWakeup) {
  * Generated stub function for SC_GetAtsEntryTime()
  * ----------------------------------------------------
  */
-SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry) {
+SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
+{
   UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
 
   UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
@@ -92,8 +96,8 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry) {
  * Generated stub function for SC_GetCurrentTime()
  * ----------------------------------------------------
  */
-void SC_GetCurrentTime(void) {
-
+void SC_GetCurrentTime(void)
+{
   UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
 }
 
@@ -102,7 +106,8 @@ void SC_GetCurrentTime(void) {
  * Generated stub function for SC_LookupTimeAccessor()
  * ----------------------------------------------------
  */
-SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef) {
+SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef)
+{
   UT_GenStub_SetupReturnBuffer(SC_LookupTimeAccessor, SC_TimeAccessor_t);
 
   UT_GenStub_AddParam(SC_LookupTimeAccessor, SC_TimeRef_Enum_t, TimeRef);
@@ -117,7 +122,8 @@ SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef) {
  * Generated stub function for SC_ToggleAtsIndex()
  * ----------------------------------------------------
  */
-SC_AtsIndex_t SC_ToggleAtsIndex(void) {
+SC_AtsIndex_t SC_ToggleAtsIndex(void)
+{
   UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, SC_AtsIndex_t);
 
   UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);

--- a/unit-test/stubs/sc_utils_stubs.c
+++ b/unit-test/stubs/sc_utils_stubs.c
@@ -33,14 +33,14 @@
  */
 bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
 {
-  UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
+    UT_GenStub_SetupReturnBuffer(SC_CompareAbsTime, bool);
 
-  UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
-  UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime2);
+    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime1);
+    UT_GenStub_AddParam(SC_CompareAbsTime, SC_AbsTimeTag_t, AbsTime2);
 
-  UT_GenStub_Execute(SC_CompareAbsTime, Basic, NULL);
+    UT_GenStub_Execute(SC_CompareAbsTime, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_CompareAbsTime, bool);
+    return UT_GenStub_GetReturnValue(SC_CompareAbsTime, bool);
 }
 
 /*
@@ -50,13 +50,13 @@ bool SC_CompareAbsTime(SC_AbsTimeTag_t AbsTime1, SC_AbsTimeTag_t AbsTime2)
  */
 SC_AbsTimeTag_t SC_ComputeAbsTime(uint32 RelTime)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+    UT_GenStub_SetupReturnBuffer(SC_ComputeAbsTime, SC_AbsTimeTag_t);
 
-  UT_GenStub_AddParam(SC_ComputeAbsTime, uint32, RelTime);
+    UT_GenStub_AddParam(SC_ComputeAbsTime, uint32, RelTime);
 
-  UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
+    UT_GenStub_Execute(SC_ComputeAbsTime, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ComputeAbsTime, SC_AbsTimeTag_t);
+    return UT_GenStub_GetReturnValue(SC_ComputeAbsTime, SC_AbsTimeTag_t);
 }
 
 /*
@@ -66,13 +66,13 @@ SC_AbsTimeTag_t SC_ComputeAbsTime(uint32 RelTime)
  */
 uint32 SC_ComputeAbsWakeup(uint32 RelWakeup)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ComputeAbsWakeup, uint32);
+    UT_GenStub_SetupReturnBuffer(SC_ComputeAbsWakeup, uint32);
 
-  UT_GenStub_AddParam(SC_ComputeAbsWakeup, uint32, RelWakeup);
+    UT_GenStub_AddParam(SC_ComputeAbsWakeup, uint32, RelWakeup);
 
-  UT_GenStub_Execute(SC_ComputeAbsWakeup, Basic, NULL);
+    UT_GenStub_Execute(SC_ComputeAbsWakeup, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ComputeAbsWakeup, uint32);
+    return UT_GenStub_GetReturnValue(SC_ComputeAbsWakeup, uint32);
 }
 
 /*
@@ -82,13 +82,13 @@ uint32 SC_ComputeAbsWakeup(uint32 RelWakeup)
  */
 SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
 {
-  UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+    UT_GenStub_SetupReturnBuffer(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
 
-  UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
+    UT_GenStub_AddParam(SC_GetAtsEntryTime, SC_AtsEntryHeader_t *, Entry);
 
-  UT_GenStub_Execute(SC_GetAtsEntryTime, Basic, NULL);
+    UT_GenStub_Execute(SC_GetAtsEntryTime, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
+    return UT_GenStub_GetReturnValue(SC_GetAtsEntryTime, SC_AbsTimeTag_t);
 }
 
 /*
@@ -98,7 +98,7 @@ SC_AbsTimeTag_t SC_GetAtsEntryTime(SC_AtsEntryHeader_t *Entry)
  */
 void SC_GetCurrentTime(void)
 {
-  UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
+    UT_GenStub_Execute(SC_GetCurrentTime, Basic, NULL);
 }
 
 /*
@@ -108,13 +108,13 @@ void SC_GetCurrentTime(void)
  */
 SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef)
 {
-  UT_GenStub_SetupReturnBuffer(SC_LookupTimeAccessor, SC_TimeAccessor_t);
+    UT_GenStub_SetupReturnBuffer(SC_LookupTimeAccessor, SC_TimeAccessor_t);
 
-  UT_GenStub_AddParam(SC_LookupTimeAccessor, SC_TimeRef_Enum_t, TimeRef);
+    UT_GenStub_AddParam(SC_LookupTimeAccessor, SC_TimeRef_Enum_t, TimeRef);
 
-  UT_GenStub_Execute(SC_LookupTimeAccessor, Basic, NULL);
+    UT_GenStub_Execute(SC_LookupTimeAccessor, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_LookupTimeAccessor, SC_TimeAccessor_t);
+    return UT_GenStub_GetReturnValue(SC_LookupTimeAccessor, SC_TimeAccessor_t);
 }
 
 /*
@@ -124,9 +124,9 @@ SC_TimeAccessor_t SC_LookupTimeAccessor(SC_TimeRef_Enum_t TimeRef)
  */
 SC_AtsIndex_t SC_ToggleAtsIndex(void)
 {
-  UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, SC_AtsIndex_t);
+    UT_GenStub_SetupReturnBuffer(SC_ToggleAtsIndex, SC_AtsIndex_t);
 
-  UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);
+    UT_GenStub_Execute(SC_ToggleAtsIndex, Basic, NULL);
 
-  return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, SC_AtsIndex_t);
+    return UT_GenStub_GetReturnValue(SC_ToggleAtsIndex, SC_AtsIndex_t);
 }

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -60,7 +60,7 @@ typedef union
 {
     CFE_SB_Buffer_t              Buf;
     SC_SendHkCmd_t               SendHkCmd;
-    SC_OneHzWakeupCmd_t          OneHzWakeupCmd;
+    SC_WakeupCmd_t               WakeupCmd;
     SC_NoopCmd_t                 NoopCmd;
     SC_ResetCountersCmd_t        ResetCountersCmd;
     SC_StopAtsCmd_t              StopAtsCmd;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #84 - Updating the way the RTS commands are scheduled. Instead of using seconds to determine when a command should be executed, SC's wakeup counts are being used. Each command in an RTS is linked to a wakeup count and the command will execute only after SC has woken up a certain number of times since the previous command’s execution

**Testing performed**
Built and ran all tests

**Expected behavior changes**
RTS commands will be executed based on the number of wakeups instead of a specific time in seconds

**System(s) tested on**
OS: RHEL 8.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Tvisha Andharia - GSFC 582 intern
