### PR TITLE
Fixed unit-test/sc_loads_tests.c for the address-sanitizer

### DIFF
--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -413,7 +413,7 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
 {
     SC_AtsEntryHeader_t *Entry;
     SC_AtsInfoTable_t    AtsInfoTbl;
-    uint32               AtsTable[SC_ATS_BUFF_SIZE32];
+    uint32               Big_AtsTable[SC_ATS_BUFF_SIZE32 * 2];
     uint8                AtsIndex = 0;
     size_t               MsgSize1;
     size_t               MsgSize2;
@@ -423,12 +423,12 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     int                  j;
 
     memset(&AtsInfoTbl, 0, sizeof(AtsInfoTbl));
-    memset(&AtsTable, 0, sizeof(AtsTable));
+    memset(&Big_AtsTable, 0, sizeof(Big_AtsTable));
 
     SC_InitTables();
 
     SC_OperData.AtsCmdStatusTblAddr[AtsIndex] = &SC_APP_TEST_GlobalAtsCmdStatusTbl[0];
-    SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
+    SC_OperData.AtsTblAddr[AtsIndex]          = &Big_AtsTable[0];
     SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
     MsgSize1      = SC_PACKET_MAX_SIZE;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #148 
  - In SC_LoadAts_Test_AtsEntryOverflow(), increased the size of AtsTable array

**Testing performed**
Steps taken to test the contribution:
1. Unit tests passed with address sanitizer enabled

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - Unit tests will now pass when address-sanitizer is enabled

**System(s) tested on**
 - OS: Ubuntu 20.04.6
