### PR TITLE
Fix #11, add continue RTS on checksum failure capability

### DIFF
--- a/config/default_sc_fcncodes.h
+++ b/config/default_sc_fcncodes.h
@@ -362,7 +362,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #SC_HkTlm_Payload_t.CmdCtr will increment
- *       - The #SC_CONT_CMD_INF_EID will be sent
+ *       - The #SC_CONT_ATS_CMD_INF_EID will be sent
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -377,6 +377,37 @@
  *       None
  */
 #define SC_CONTINUE_ATS_ON_FAILURE_CC 10
+
+/**
+ * \brief Set the Continue-On-Checksum-Failure flag
+ *
+ *  \par Description
+ *       Sets the flag which specifies whether or not to continue
+ *        processing an RTS if one of the commands in the RTS fails
+ *        checksum validation before being sent out.
+ *
+ *  \par Command Structure
+ *       #SC_ContinueRtsOnFailureCmd_t
+ *
+ *  \par Command Verification
+ *       Successful execution of this command may be verified with
+ *       the following telemetry:
+ *       - #SC_HkTlm_Payload_t.CmdCtr will increment
+ *       - The #SC_CONT_RTS_CMD_INF_EID will be sent
+ *
+ *  \par Error Conditions
+ *       This command may fail for the following reason(s):
+ *       - Command packet length not as expected
+ *       - Invalid State specified
+ *
+ *  \par Evidence of failure may be found in the following telemetry:
+ *       - #SC_HkTlm_Payload_t.CmdErrCtr will increment
+ *       - Error specific event message
+ *
+ *  \par Criticality
+ *       None
+ */
+#define SC_CONTINUE_RTS_ON_FAILURE_CC 12
 
 /**
  * \brief Append to an ATS table
@@ -443,7 +474,7 @@
  *  \par Criticality
  *       None
  */
-#define SC_MANAGE_TABLE_CC 12
+#define SC_MANAGE_TABLE_CC 13
 
 /**
  * \brief START a group of RTS
@@ -484,7 +515,7 @@
  *
  *  \sa #SC_STOP_RTS_GRP_CC
  */
-#define SC_START_RTS_GRP_CC 13
+#define SC_START_RTS_GRP_CC 14
 
 /**
  * \brief STOP a group of RTS
@@ -524,7 +555,7 @@
  *
  *  \sa #SC_START_RTS_GRP_CC
  */
-#define SC_STOP_RTS_GRP_CC 14
+#define SC_STOP_RTS_GRP_CC 15
 
 /**
  * \brief DISABLE a group of RTS
@@ -562,7 +593,7 @@
  *
  *  \sa #SC_ENABLE_RTS_GRP_CC
  */
-#define SC_DISABLE_RTS_GRP_CC 15
+#define SC_DISABLE_RTS_GRP_CC 16
 
 /**
  * \brief ENABLE a group of RTS
@@ -600,7 +631,7 @@
  *
  *  \sa #SC_DISABLE_RTS_GRP_CC
  */
-#define SC_ENABLE_RTS_GRP_CC 16
+#define SC_ENABLE_RTS_GRP_CC 17
 
 /**\}*/
 

--- a/config/default_sc_internal_cfg.h
+++ b/config/default_sc_internal_cfg.h
@@ -336,7 +336,19 @@
  *  \par Limits:
  *       Must be SC_AtsCont_TRUE or SC_AtsCont_FALSE
  */
-#define SC_CONT_ON_FAILURE_START SC_AtsCont_TRUE
+#define SC_CONT_ON_ATS_FAILURE_START SC_AtsCont_TRUE
+
+/**
+ * \brief Defines default state of Continue-Rts-On-Checksum-Failure Flag
+ *
+ *  \par Description:
+ *       This parameter specifies the default state to continue an RTS
+ *       when a command in the RTS fails checksum validation
+ *
+ *  \par Limits:
+ *       Must be SC_RtsCont_TRUE or SC_RtsCont_FALSE
+ */
+#define SC_CONT_ON_RTS_FAILURE_START SC_RtsCont_TRUE
 
 /**
  * \brief Defines the TIME SC should use for its commands

--- a/config/default_sc_msgdefs.h
+++ b/config/default_sc_msgdefs.h
@@ -155,7 +155,7 @@ typedef uint8 SC_TimeRef_Enum_t;
 #define SC_INVALID_RTS_NUMBER 0 /**< \brief Invalid RTS number */
 
 /**
- * SC Continue After Failure Enumeration
+ * SC Continue ATS After Failure Enumeration
  */
 enum SC_AtsCont
 {
@@ -164,6 +164,17 @@ enum SC_AtsCont
 };
 
 typedef uint8 SC_AtsCont_Enum_t;
+
+/**
+ * SC Continue RTS After Failure Enumeration
+ */
+enum SC_RtsCont
+{
+    SC_RtsCont_FALSE = false, /**< \brief Do not continue RTS on failure */
+    SC_RtsCont_TRUE  = true   /**< \brief Continue RTS on failure */
+};
+
+typedef uint8 SC_RtsCont_Enum_t;
 
 #ifndef SC_OMIT_DEPRECATED
 /**
@@ -192,10 +203,10 @@ typedef struct
     SC_AtsId_Enum_t   CurrAtsId;                /**< \brief Current ATS number: 1 = ATS A, 2 = ATS B */
     SC_Status_Enum_t  AtpState;                 /**< \brief Current ATP state: 2 = IDLE, 5 = EXECUTING */
     SC_AtsCont_Enum_t ContinueAtsOnFailureFlag; /**< \brief Continue ATS execution on failure flag */
+    SC_RtsCont_Enum_t ContinueRtsOnFailureFlag; /**< \brief Continue RTS execution on checksum failure flag */
 
     uint8 CmdErrCtr; /**< \brief Counts Request Errors */
     uint8 CmdCtr;    /**< \brief Counts Ground Requests */
-    uint8 Padding8;  /**< \brief Structure padding */
 
     uint16           SwitchPendFlag;  /**< \brief Switch pending flag: 0 = NO, 1 = YES */
     uint16           NumRtsActive;    /**< \brief Number of RTSs currently active */
@@ -276,6 +287,15 @@ typedef struct
     SC_AtsCont_Enum_t ContinueState; /**< \brief true or false, to continue ATS after a failure  */
     uint16            Padding;       /**< \brief Structure Padding */
 } SC_SetContinueAtsOnFailureCmd_Payload_t;
+
+/**
+ *  \brief Continue RTS on failure command Payload
+ */
+typedef struct
+{
+    SC_RtsCont_Enum_t ContinueState; /**< \brief true or false, to continue RTS after a failure  */
+    uint16            Padding;       /**< \brief Structure Padding */
+} SC_SetContinueRtsOnFailureCmd_Payload_t;
 
 /**
  *  \brief Append to ATS Command Payload

--- a/config/default_sc_msgstruct.h
+++ b/config/default_sc_msgstruct.h
@@ -227,6 +227,17 @@ typedef struct
 } SC_ContinueAtsOnFailureCmd_t;
 
 /**
+ *  \brief Continue RTS on failure command
+ *
+ *  For command details see #SC_CONTINUE_RTS_ON_FAILURE_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command Header */
+    SC_SetContinueRtsOnFailureCmd_Payload_t Payload;
+} SC_ContinueRtsOnFailureCmd_t;
+
+/**
  *  \brief Manage Table Command
  *
  *  For command details see #SC_MANAGE_TABLE_CC

--- a/fsw/inc/sc_events.h
+++ b/fsw/inc/sc_events.h
@@ -409,7 +409,7 @@
  *  This event message is issued when a #SC_CONTINUE_ATS_ON_FAILURE_CC command was received, but the state
  *  in the command was invalid
  */
-#define SC_CONT_CMD_ERR_EID 42
+#define SC_CONT_ATS_CMD_ERR_EID 42
 
 /**
  * \brief SC Continue ATS On Failure Command Event ID
@@ -420,7 +420,29 @@
  *  This event message is issued when the #SC_CONTINUE_ATS_ON_FAILURE_CC command was received and
  *  the state was changed successfully
  */
-#define SC_CONT_CMD_INF_EID 43
+#define SC_CONT_ATS_CMD_INF_EID 43
+
+/**
+ * \brief SC Continue RTS On Failure Commanded State Invalid Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *  This event message is issued when a #SC_CONTINUE_RTS_ON_FAILURE_CC command was received, but the state
+ *  in the command was invalid
+ */
+#define SC_CONT_RTS_CMD_ERR_EID 44
+
+/**
+ * \brief SC Continue RTS On Failure Command Event ID
+ *
+ *  \par Type: INFORMATIONAL
+ *
+ *  \par Cause:
+ *  This event message is issued when the #SC_CONTINUE_RTS_ON_FAILURE_CC command was received and
+ *  the state was changed successfully
+ */
+#define SC_CONT_RTS_CMD_INF_EID 45
 
 /**
  * \brief SC ATS Command Skipped Checksum Failed Event ID
@@ -431,7 +453,30 @@
  *  This event message is issued when a command from an ATS is about to be sent out
  *  but it fails checksum validation
  */
-#define SC_ATS_CHKSUM_ERR_EID 44
+#define SC_ATS_CHKSUM_ERR_EID 46
+
+/**
+ * \brief SC RTS Aborted Command Checksum Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *  This event message is issued when a command from an RTS fails checksum validation
+ *  and the ContinueRtsOnFailureFlag is FALSE, causing the RTS to be aborted
+ */
+#define SC_RTS_CHKSUM_ERR_EID 47
+
+/**
+ * \brief SC RTS Command Skipped Checksum Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *  This event message is issued when a command from an RTS is about to be sent out
+ *  but it fails checksum validation and the Continue-RTS-on-Failure flag was
+ *  set to 'TRUE'
+ */
+#define SC_RTS_CHKSUM_CONT_EID 48
 
 /**
  * \brief SC ATS Aborted Command Checksum Failed Event ID
@@ -443,7 +488,7 @@
  *  failed checksum validation, and the Continue-ATS-on_checksum-Failure flag was
  *  set to 'FALSE'
  */
-#define SC_ATS_ABT_ERR_EID 45
+#define SC_ATS_ABT_ERR_EID 49
 
 /**
  * \brief SC ATS Transmit Message Failed Event ID
@@ -454,7 +499,7 @@
  *  This event message is issued when an ATS command is about to be sent out,
  *  and the #CFE_SB_TransmitMsg call failed to send it
  */
-#define SC_ATS_DIST_ERR_EID 46
+#define SC_ATS_DIST_ERR_EID 50
 
 /**
  * \brief SC ATS Command Skipped Due To Number Mismatch Event ID
@@ -465,7 +510,7 @@
  *  This event message is issued when an ATS command is about to be sent out,
  *  but it's command number is not what was expected
  */
-#define SC_ATS_MSMTCH_ERR_EID 47
+#define SC_ATS_MSMTCH_ERR_EID 51
 
 /**
  * \brief SC ATS Command Skipped Due To Command Status Invalid Event ID
@@ -476,7 +521,7 @@
  *  This event message is issued when an ATS command is about to be send out,
  *  but the command isn't marked as '#SC_Status_LOADED'
  */
-#define SC_ATS_SKP_ERR_EID 48
+#define SC_ATS_SKP_ERR_EID 52
 
 /**
  * \brief SC RTS Transmit Message Failed Event ID
@@ -487,18 +532,7 @@
  *  This event message is issued when an RTS command was about to be sent out,
  *  and #CFE_SB_TransmitMsg couldn't send the message
  */
-#define SC_RTS_DIST_ERR_EID 49
-
-/**
- * \brief SC RTS Stopped Due To Command Checksum Failure Event ID
- *
- *  \par Type: ERROR
- *
- *  \par Cause:
- *  This event message is issued when an RTS command was about to be sent out,
- *  but the command failed checksum validation
- */
-#define SC_RTS_CHKSUM_ERR_EID 50
+#define SC_RTS_DIST_ERR_EID 53
 
 /**
  * \brief SC Reset Counters Command Event ID
@@ -509,7 +543,7 @@
  *  This event message is issued when the #SC_RESET_COUNTERS_CC command was
  * received
  */
-#define SC_RESET_INF_EID 51
+#define SC_RESET_INF_EID 54
 
 /**
  * \brief SC No-op Command Event ID
@@ -520,7 +554,7 @@
  *
  *  This event message is issued when a #SC_NOOP_CC command has been received
  */
-#define SC_NOOP_INF_EID 52
+#define SC_NOOP_INF_EID 55
 
 /**
  * \brief SC RTS Table Command Message ID Invalid Event ID
@@ -531,7 +565,7 @@
  *  This event message is issued when and RTS table is loaded, but there is an invalid
  *  message Id in the command
  */
-#define SC_RTS_INVLD_MID_ERR_EID 59
+#define SC_RTS_INVLD_MID_ERR_EID 56
 
 /**
  * \brief SC RTS Table Command Message Length Invalid Event ID
@@ -542,7 +576,7 @@
  *  This event message is issued when and RTS table is loaded, but there is an invalid
  *  length in the command
  */
-#define SC_RTS_LEN_ERR_EID 60
+#define SC_RTS_LEN_ERR_EID 57
 
 /**
  * \brief SC RTS Table Command Runs Off Buffer Event ID
@@ -553,7 +587,7 @@
  *  This event message is issued when and RTS table is loaded, but the command
  *  runs off the end of the buffer
  */
-#define SC_RTS_LEN_BUFFER_ERR_EID 61
+#define SC_RTS_LEN_BUFFER_ERR_EID 58
 
 /**
  * \brief SC RTS Table Data Detected That Would Exceed Buffer Event ID
@@ -564,7 +598,7 @@
  *  This event message is issued when and RTS table is loaded, but there
  *  is non-zero data at the end when the size left is less than #SC_RTS_HDR_WORDS
  */
-#define SC_RTS_LEN_TOO_LONG_ERR_EID 62
+#define SC_RTS_LEN_TOO_LONG_ERR_EID 59
 
 /**
  * \brief SC Command Pipe Message ID Invalid Event ID
@@ -575,7 +609,7 @@
  *  This event message is issued when an invalid message Id is received in the
  *  command pipe
  */
-#define SC_MID_ERR_EID 63
+#define SC_MID_ERR_EID 60
 
 /**
  * \brief SC Command Code Invalid Event ID
@@ -586,7 +620,7 @@
  *  This event message is issued when an invalid command code was received in
  *  the command pipe
  */
-#define SC_CC_ERR_EID 64
+#define SC_CC_ERR_EID 61
 
 /**
  * \brief SC RTS Info Table Get Address Failed Event ID
@@ -597,7 +631,7 @@
  *  This event message is issued when getting the address of the Rts Info table
  *  failed
  */
-#define SC_GET_ADDRESS_RTS_INFO_ERR_EID 65
+#define SC_GET_ADDRESS_RTS_INFO_ERR_EID 62
 
 /**
  * \brief SC RTS Control Block Table Get Address Failed Event ID
@@ -608,7 +642,7 @@
  *  This event message is issued when getting the address of the Rts Control Block table
  *  failed
  */
-#define SC_GET_ADDRESS_RTS_CTRL_BLCK_ERR_EID 66
+#define SC_GET_ADDRESS_RTS_CTRL_BLCK_ERR_EID 63
 
 /**
  * \brief SC ATS Info Table Get Address Failed Event ID
@@ -619,7 +653,7 @@
  *  This event message is issued when getting the address of the Ats Info table
  *  failed
  */
-#define SC_GET_ADDRESS_ATS_INFO_ERR_EID 67
+#define SC_GET_ADDRESS_ATS_INFO_ERR_EID 64
 
 /**
  * \brief SC ATS Control Block Table Get Address Failed Event ID
@@ -630,7 +664,7 @@
  *  This event message is issued when getting the address of the Ats Control Block table
  *  failed
  */
-#define SC_GET_ADDRESS_ATS_CTRL_BLCK_ERR_EID 68
+#define SC_GET_ADDRESS_ATS_CTRL_BLCK_ERR_EID 65
 
 /**
  * \brief SC ATS Command Status Table Get Address Failed Event ID
@@ -641,7 +675,7 @@
  *  This event message is issued when getting the address of an Ats Command Status table
  *  failed
  */
-#define SC_GET_ADDRESS_ATS_CMD_STAT_ERR_EID 69
+#define SC_GET_ADDRESS_ATS_CMD_STAT_ERR_EID 66
 
 /**
  * \brief SC RTS Table Get Address Failed Event ID
@@ -652,7 +686,7 @@
  *  This event message is issued when getting the address of an RTS table
  *  failed
  */
-#define SC_GET_ADDRESS_RTS_ERR_EID 70
+#define SC_GET_ADDRESS_RTS_ERR_EID 67
 
 /**
  * \brief SC ATS Table Get Address Failed Event ID
@@ -663,7 +697,7 @@
  *  This event message is issued when getting the address of an ATS table
  *  failed
  */
-#define SC_GET_ADDRESS_ATS_ERR_EID 71
+#define SC_GET_ADDRESS_ATS_ERR_EID 68
 
 /**
  * \brief SC RTS Start Command Event ID
@@ -673,7 +707,7 @@
  *  \par Cause:
  *  This event message is issued when a #SC_START_RTS_CC cmd is received and is successful
  */
-#define SC_STARTRTS_CMD_DBG_EID 72
+#define SC_STARTRTS_CMD_DBG_EID 69
 
 /**
  * \brief SC RTS Started Event ID
@@ -683,7 +717,7 @@
  *  \par Cause:
  *  This event message is issued when an RTS is started successfully
  */
-#define SC_RTS_START_INF_EID 73
+#define SC_RTS_START_INF_EID 70
 
 /**
  * \brief SC Start RTS Rejected Due To First Command Length Invalid Event ID
@@ -693,7 +727,7 @@
  *  \par Cause:
  *  This event message is issued when an RTS is started but the first command has an invalid length
  */
-#define SC_STARTRTS_CMD_INVLD_LEN_ERR_EID 74
+#define SC_STARTRTS_CMD_INVLD_LEN_ERR_EID 71
 
 /**
  * \brief SC Start RTS Rejected Due To RTS Not Loaded Or In Use Event ID
@@ -704,7 +738,7 @@
  *  This event message is issued when an RTS is tried to be started, but the RTS is not
  *  marked as #SC_Status_LOADED
  */
-#define SC_STARTRTS_CMD_NOT_LDED_ERR_EID 75
+#define SC_STARTRTS_CMD_NOT_LDED_ERR_EID 72
 
 /**
  * \brief SC Start RTS Rejected RTS Disabled Event ID
@@ -715,7 +749,7 @@
  *  This event message is issued when a #SC_START_RTS_CC command was received, but the
  *  RTS is disabled
  */
-#define SC_STARTRTS_CMD_DISABLED_ERR_EID 76
+#define SC_STARTRTS_CMD_DISABLED_ERR_EID 73
 
 /**
  * \brief SC Start RTS Rejected RTS ID Invalid Event ID
@@ -726,7 +760,7 @@
  *  This event message is issued when a #SC_START_RTS_CC command was received, but the
  *  RTS Id was invalid
  */
-#define SC_STARTRTS_CMD_INVALID_ERR_EID 77
+#define SC_STARTRTS_CMD_INVALID_ERR_EID 74
 
 /**
  * \brief SC Stop RTS Command Event ID
@@ -736,7 +770,7 @@
  *  \par Cause:
  *  This event message is issued when an #SC_STOP_RTS_CC command is received and exexuted successfully
  */
-#define SC_STOPRTS_CMD_INF_EID 78
+#define SC_STOPRTS_CMD_INF_EID 75
 
 /**
  * \brief SC Stop RTS Rejected RTS ID Invalid Event ID
@@ -747,7 +781,7 @@
  *  This event message is issued when a #SC_STOP_RTS_CC command was rejected because the
  *  RTS Id given was invalid
  */
-#define SC_STOPRTS_CMD_ERR_EID 79
+#define SC_STOPRTS_CMD_ERR_EID 76
 
 /**
  * \brief SC Disable RTS Command Event ID
@@ -758,7 +792,7 @@
  *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
  * and executed successfully
  */
-#define SC_DISABLE_RTS_INF_EID 80
+#define SC_DISABLE_RTS_INF_EID 77
 
 /**
  * \brief SC Disable RTS Rejected RTS ID Invalid Event ID
@@ -769,7 +803,7 @@
  *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
  *  but the RTS Id given was invalid
  */
-#define SC_DISRTS_CMD_ERR_EID 81
+#define SC_DISRTS_CMD_ERR_EID 78
 
 /**
  * \brief SC Enable RTS Command ID Event ID
@@ -780,7 +814,7 @@
  *  This event message is issued when a #SC_ENABLE_RTS_CC command was received,
  * and executed successfully
  */
-#define SC_ENABLE_RTS_INF_EID 82
+#define SC_ENABLE_RTS_INF_EID 79
 
 /**
  * \brief SC Enable RTS Rejected RTS ID Invalid Event ID
@@ -791,7 +825,7 @@
  *  This event message is issued when a #SC_DISABLE_RTS_CC command was received,
  *  but the RTS Id given was invalid
  */
-#define SC_ENARTS_CMD_ERR_EID 83
+#define SC_ENARTS_CMD_ERR_EID 80
 
 /**
  * \brief SC RTS Aborted Due To Command Exceeding Buffer Event ID
@@ -802,7 +836,7 @@
  *  This event message is issued when trying to get the next RTS command to execute,
  *  and that command runs passed the end of the RTS table buffer
  */
-#define SC_RTS_LNGTH_ERR_EID 84
+#define SC_RTS_LNGTH_ERR_EID 81
 
 /**
  * \brief SC RTS Aborted Due To Command Length Field Invalid Event ID
@@ -813,7 +847,7 @@
  *  This event message is issued when trying to get the next RTS command to execute,
  *  and that command has an illegal length value in the command
  */
-#define SC_RTS_CMD_LNGTH_ERR_EID 85
+#define SC_RTS_CMD_LNGTH_ERR_EID 82
 
 /**
  * \brief SC RTS Execution Completed Event ID
@@ -823,7 +857,7 @@
  *  \par Cause:
  *  This event message is issued when an RTS completes execution
  */
-#define SC_RTS_COMPL_INF_EID 86
+#define SC_RTS_COMPL_INF_EID 83
 
 /**
  * \brief SC ATS Execution Completed Event ID
@@ -833,7 +867,7 @@
  *  \par Cause:
  *  This event message is issued when an ATS completes execution
  */
-#define SC_ATS_COMPL_INF_EID 87
+#define SC_ATS_COMPL_INF_EID 84
 
 /**
  * \brief SC Jump Command Skipped ATS Commands Event ID
@@ -844,7 +878,7 @@
  *  This event message is issued a Jump Command is issued and
  *  Some of the ATS commands were marked as skipped
  */
-#define SC_JUMP_ATS_SKIPPED_DBG_EID 88
+#define SC_JUMP_ATS_SKIPPED_DBG_EID 85
 
 /**
  * \brief SC Append ATS Table Get Address Failed Event ID
@@ -855,7 +889,7 @@
  *  This event message indicates a failure to get the table data address from
  *  cFE Table Services
  */
-#define SC_GET_ADDRESS_APPEND_ERR_EID 92
+#define SC_GET_ADDRESS_APPEND_ERR_EID 86
 
 /**
  * \brief SC Append ATS Table Registration Failed Event ID
@@ -865,7 +899,7 @@
  *  \par Cause:
  *  This event message indicates a failure to register the table with cFE Table Services
  */
-#define SC_REGISTER_APPEND_TBL_ERR_EID 93
+#define SC_REGISTER_APPEND_TBL_ERR_EID 87
 
 /**
  * \brief SC Append ATS Table Updated Event ID
@@ -875,7 +909,7 @@
  *  \par Cause:
  *  This event message signals that the Append ATS table has been updated.
  */
-#define SC_UPDATE_APPEND_EID 97
+#define SC_UPDATE_APPEND_EID 88
 
 /**
  * \brief SC Append ATS Table Appended Event ID
@@ -885,7 +919,7 @@
  *  \par Cause:
  *  This event signals the successful completion of an Append ATS command.
  */
-#define SC_APPEND_CMD_INF_EID 98
+#define SC_APPEND_CMD_INF_EID 100
 
 /**
  * \brief SC Append ATS Rejected ATS ID Invalid Event ID
@@ -896,7 +930,7 @@
  *  This event message is issued when a #SC_APPEND_ATS_CC command has failed
  *  because the specified ATS command argument was not a valid ATS ID.
  */
-#define SC_APPEND_CMD_ARG_ERR_EID 99
+#define SC_APPEND_CMD_ARG_ERR_EID 101
 
 /**
  * \brief SC Append ATS Rejected Target ATS Table Empty Event ID
@@ -909,7 +943,7 @@
  *  requires that both the source Append table and the target ATS table have
  *  valid contents.
  */
-#define SC_APPEND_CMD_TGT_ERR_EID 100
+#define SC_APPEND_CMD_TGT_ERR_EID 102
 
 /**
  * \brief SC Append ATS Rejected Append Table Empty Event ID
@@ -922,7 +956,7 @@
  *  that both the source Append table and the target ATS table have valid
  *  contents.
  */
-#define SC_APPEND_CMD_SRC_ERR_EID 101
+#define SC_APPEND_CMD_SRC_ERR_EID 103
 
 /**
  * \brief SC Append ATS Rejected Insufficent Space Left In ATS Event ID
@@ -934,7 +968,7 @@
  *  because there is not room in the specified target ATS table to add the
  *  contents of the Append table.
  */
-#define SC_APPEND_CMD_FIT_ERR_EID 102
+#define SC_APPEND_CMD_FIT_ERR_EID 104
 
 /**
  * \brief SC ATS Or Append Table Verification Event ID
@@ -945,7 +979,7 @@
  *  This event message signals the successful verification of an ATS or an
  *     Append ATS table.
  */
-#define SC_VERIFY_ATS_EID 103
+#define SC_VERIFY_ATS_EID 105
 
 /**
  * \brief SC ATS Or Append Table Verification Table Entry Command Number Invalid Event ID
@@ -957,7 +991,7 @@
  *  or an Append ATS table due to an invalid table entry. The cause is
  *  a table entry with an invalid command number.
  */
-#define SC_VERIFY_ATS_NUM_ERR_EID 104
+#define SC_VERIFY_ATS_NUM_ERR_EID 106
 
 /**
  * \brief SC ATS Or Append Table Data Detected That Would Exceed Buffer Event ID
@@ -975,7 +1009,7 @@
  *  follows the last valid table entry to zero. Note that the first
  *  word in an ATS table entry is the entry command number.
  */
-#define SC_VERIFY_ATS_END_ERR_EID 105
+#define SC_VERIFY_ATS_END_ERR_EID 107
 
 /**
  * \brief SC ATS Or Append Table Verification Command Length Invalid Event ID
@@ -987,7 +1021,7 @@
  *  or an Append ATS table due to an invalid table entry. The cause is
  *  a table entry with an invalid command packet length.
  */
-#define SC_VERIFY_ATS_PKT_ERR_EID 106
+#define SC_VERIFY_ATS_PKT_ERR_EID 108
 
 /**
  * \brief SC ATS Or Append Table Verification Command Length Exceeds Buffer Event ID
@@ -1000,7 +1034,7 @@
  *  a table entry with an otherwise valid command packet length that
  *  would extend past the end of the table buffer.
  */
-#define SC_VERIFY_ATS_BUF_ERR_EID 107
+#define SC_VERIFY_ATS_BUF_ERR_EID 109
 
 /**
  * \brief SC ATS Or Append Table Verification Duplicate Command Number Event ID
@@ -1013,7 +1047,7 @@
  *  a table entry with an otherwise valid command number that is already
  *  in use by an earlier table entry.
  */
-#define SC_VERIFY_ATS_DUP_ERR_EID 109
+#define SC_VERIFY_ATS_DUP_ERR_EID 111
 
 /**
  * \brief SC ATS Or Append Table Verification Table Empty Event ID
@@ -1026,7 +1060,7 @@
  *  error can only occur if the first entry in the table has a command
  *  number equal to zero - the end of data marker.
  */
-#define SC_VERIFY_ATS_MPT_ERR_EID 110
+#define SC_VERIFY_ATS_MPT_ERR_EID 112
 
 /**
  * \brief SC Table Manage Request Table ID Invalid Event ID
@@ -1037,7 +1071,7 @@
  *  This event message is issued upon receipt of a table manage
  *  request command that has an invalid table ID argument.
  */
-#define SC_TABLE_MANAGE_ID_ERR_EID 111
+#define SC_TABLE_MANAGE_ID_ERR_EID 113
 
 /**
  * \brief SC RTS Table Manage Processing Failed Event ID
@@ -1053,7 +1087,7 @@
  *  data has been updated.  This event message is issued upon
  *  receipt of any other function result.
  */
-#define SC_TABLE_MANAGE_RTS_ERR_EID 112
+#define SC_TABLE_MANAGE_RTS_ERR_EID 114
 
 /**
  * \brief SC ATS Table Manage Processing Failed Event ID
@@ -1069,7 +1103,7 @@
  *  data has been updated.  This event message is issued upon
  *  receipt of any other function result.
  */
-#define SC_TABLE_MANAGE_ATS_ERR_EID 113
+#define SC_TABLE_MANAGE_ATS_ERR_EID 115
 
 /**
  * \brief SC ATS Append Table Manage Processing Failed Event ID
@@ -1085,7 +1119,7 @@
  *  data has been updated.  This event message is issued upon
  *  receipt of any other function result.
  */
-#define SC_TABLE_MANAGE_APPEND_ERR_EID 114
+#define SC_TABLE_MANAGE_APPEND_ERR_EID 116
 
 /**
  * \brief SC Start RTS Group Command Event ID
@@ -1096,7 +1130,7 @@
  *  This event message is issued following the successful execution of
  *  a #SC_START_RTS_GRP_CC command.
  */
-#define SC_STARTRTSGRP_CMD_INF_EID 115
+#define SC_STARTRTSGRP_CMD_INF_EID 117
 
 /**
  * \brief SC Start RTS Group RTS ID Invalid Event ID
@@ -1110,7 +1144,7 @@
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be greater than or equal to First RTS ID
  */
-#define SC_STARTRTSGRP_CMD_ERR_EID 116
+#define SC_STARTRTSGRP_CMD_ERR_EID 118
 
 /**
  * \brief SC Stop RTS Group Command Event ID
@@ -1121,7 +1155,7 @@
  *  This event message is issued following the successful execution of
  *  a #SC_STOP_RTS_GRP_CC command.
  */
-#define SC_STOPRTSGRP_CMD_INF_EID 117
+#define SC_STOPRTSGRP_CMD_INF_EID 119
 
 /**
  * \brief SC Stop RTS Group RTS ID Invalid Event ID
@@ -1135,7 +1169,7 @@
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be greater than or equal to First RTS ID
  */
-#define SC_STOPRTSGRP_CMD_ERR_EID 118
+#define SC_STOPRTSGRP_CMD_ERR_EID 120
 
 /**
  * \brief SC Disable RTS Group Command Event ID
@@ -1146,7 +1180,7 @@
  *  This event message is issued following the successful execution of
  *  a #SC_DISABLE_RTS_GRP_CC command.
  */
-#define SC_DISRTSGRP_CMD_INF_EID 119
+#define SC_DISRTSGRP_CMD_INF_EID 121
 
 /**
  * \brief SC Disable RTS Group RTS ID Invalid Event ID
@@ -1160,7 +1194,7 @@
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be greater than or equal to First RTS ID
  */
-#define SC_DISRTSGRP_CMD_ERR_EID 120
+#define SC_DISRTSGRP_CMD_ERR_EID 122
 
 /**
  * \brief SC Enable RTS Group Command Event ID
@@ -1171,7 +1205,7 @@
  *  This event message is issued following the successful execution of
  *  a #SC_ENABLE_RTS_GRP_CC command.
  */
-#define SC_ENARTSGRP_CMD_INF_EID 121
+#define SC_ENARTSGRP_CMD_INF_EID 123
 
 /**
  * \brief SC Enable RTS Group RTS ID Invalid Event ID
@@ -1185,7 +1219,7 @@
  *  - Last RTS ID must be 1 through #SC_NUMBER_OF_RTS
  *  - Last RTS ID must be greater than or equal to First RTS ID
  */
-#define SC_ENARTSGRP_CMD_ERR_EID 122
+#define SC_ENARTSGRP_CMD_ERR_EID 124
 
 /**
  * \brief SC Jump Command Entry Event ID
@@ -1196,7 +1230,7 @@
  *  This event message is issued when a #SC_JUMP_ATS_CC command was issued, and the time to
  *  jump to was less than or equal to a list entry.
  */
-#define SC_JUMPATS_CMD_LIST_INF_EID 123
+#define SC_JUMPATS_CMD_LIST_INF_EID 125
 
 /**
  * \brief SC RTS Table Load Failed Event ID
@@ -1209,7 +1243,7 @@
  *  The event text includes the RTS index and the result of the
  *  #CFE_TBL_Load call.
  */
-#define SC_RTS_LOAD_FAIL_DBG_EID 124
+#define SC_RTS_LOAD_FAIL_DBG_EID 126
 
 /**
  * \brief SC Start RTS Group RTS Not Loaded Or In Use Event ID
@@ -1220,7 +1254,7 @@
  *  This event message is issued when a #SC_START_RTS_GRP_CC command was received, but an
  *  RTS is marked as #SC_Status_LOADED
  */
-#define SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID 126
+#define SC_STARTRTSGRP_CMD_NOT_LDED_ERR_EID 128
 
 /**
  * \brief SC Start RTS Group RTS Disabled Event ID
@@ -1231,7 +1265,7 @@
  *  This event message is issued when a #SC_START_RTS_GRP_CC command was received, but an
  *  RTS is disabled
  */
-#define SC_STARTRTSGRP_CMD_DISABLED_ERR_EID 127
+#define SC_STARTRTSGRP_CMD_DISABLED_ERR_EID 129
 
 /**
  * \brief SC Begin ATS ID Invalid Event ID
@@ -1242,7 +1276,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_BeginAts function
  */
-#define SC_BEGINATS_INVLD_INDEX_ERR_EID 128
+#define SC_BEGINATS_INVLD_INDEX_ERR_EID 130
 
 /**
  * \brief SC RTS Table Manage RTS Index Invalid Event ID
@@ -1253,7 +1287,7 @@
  *  This event message is issued when an invalid RTS index is received
  *  in the SC_ManageRtsTable function
  */
-#define SC_TABLE_MANAGE_RTS_INV_INDEX_ERR_EID 129
+#define SC_TABLE_MANAGE_RTS_INV_INDEX_ERR_EID 131
 
 /**
  * \brief SC ATS Table Manage ATS Index Invalid Event ID
@@ -1264,7 +1298,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_ManageAtsTable function
  */
-#define SC_TABLE_MANAGE_ATS_INV_INDEX_ERR_EID 130
+#define SC_TABLE_MANAGE_ATS_INV_INDEX_ERR_EID 132
 
 /**
  * \brief SC ATS Table Load ATS Index Invalid Event ID
@@ -1275,7 +1309,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_LoadAts function
  */
-#define SC_LOADATS_INV_INDEX_ERR_EID 131
+#define SC_LOADATS_INV_INDEX_ERR_EID 133
 
 /**
  * \brief SC ATS Build Time Index ATS Index Invalid Event ID
@@ -1286,7 +1320,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_BuildTimeIndexTable function
  */
-#define SC_BUILD_TIME_IDXTBL_ERR_EID 132
+#define SC_BUILD_TIME_IDXTBL_ERR_EID 134
 
 /**
  * \brief SC ATS Insert ATS Index Invalid Event ID
@@ -1297,7 +1331,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_Insert function
  */
-#define SC_INSERTATS_INV_INDEX_ERR_EID 133
+#define SC_INSERTATS_INV_INDEX_ERR_EID 135
 
 /**
  * \brief SC ATS Table Initialization Error ATS Index Invalid Event ID
@@ -1308,7 +1342,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_InitAtsTables function
  */
-#define SC_INIT_ATSTBL_INV_INDEX_ERR_EID 134
+#define SC_INIT_ATSTBL_INV_INDEX_ERR_EID 136
 
 /**
  * \brief SC RTS Table Initialization Error RTS Index Invalid Event ID
@@ -1319,7 +1353,7 @@
  *  This event message is issued when an invalid RTS index is received
  *  in the SC_LoadRts function
  */
-#define SC_LOADRTS_INV_INDEX_ERR_EID 135
+#define SC_LOADRTS_INV_INDEX_ERR_EID 137
 
 /**
  * \brief SC ATS Process Append ATS Index Invalid Event ID
@@ -1330,7 +1364,7 @@
  *  This event message is issued when an invalid ATS index is received
  *  in the SC_ProcessAppend function
  */
-#define SC_PROCESS_APPEND_INV_INDEX_ERR_EID 136
+#define SC_PROCESS_APPEND_INV_INDEX_ERR_EID 138
 
 /**
  * \brief SC RTS Kill RTS Index Invalid Event ID
@@ -1341,7 +1375,7 @@
  *  This event message is issued when an invalid RTS index is received
  *  in the SC_KillRts function
  */
-#define SC_KILLRTS_INV_INDEX_ERR_EID 137
+#define SC_KILLRTS_INV_INDEX_ERR_EID 139
 
 /**
  * \brief SC RTS Autostart RTS ID Invalid Event ID
@@ -1352,7 +1386,7 @@
  *  This event message is issued when an invalid RTS ID is received
  *  in the SC_AutoStartRts function
  */
-#define SC_AUTOSTART_RTS_INV_ID_ERR_EID 138
+#define SC_AUTOSTART_RTS_INV_ID_ERR_EID 140
 
 /**\}*/
 

--- a/fsw/src/sc_app.c
+++ b/fsw/src/sc_app.c
@@ -148,7 +148,10 @@ CFE_Status_t SC_AppInit(void)
     SC_OperData.NumCmdsWakeup = 0;
 
     /* Continue ATS execution if ATS command checksum fails */
-    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_CONT_ON_FAILURE_START;
+    SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_CONT_ON_ATS_FAILURE_START;
+
+    /* Continue RTS execution if RTS command checksum fails */
+    SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = SC_CONT_ON_RTS_FAILURE_START;
 
     SC_AppData.EnableHeaderUpdate = SC_PLATFORM_ENABLE_HEADER_UPDATE;
 

--- a/fsw/src/sc_atsrq.c
+++ b/fsw/src/sc_atsrq.c
@@ -647,7 +647,7 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
     {
         SC_OperData.HkPacket.Payload.CmdErrCtr++;
 
-        CFE_EVS_SendEvent(SC_CONT_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(SC_CONT_ATS_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Continue ATS On Failure command  failed, invalid state: %lu", (unsigned long)State);
     }
     else
@@ -656,7 +656,7 @@ void SC_ContinueAtsOnFailureCmd(const SC_ContinueAtsOnFailureCmd_t *Cmd)
 
         SC_OperData.HkPacket.Payload.CmdCtr++;
 
-        CFE_EVS_SendEvent(SC_CONT_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(SC_CONT_ATS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Continue-ATS-On-Failure command, State: %lu",
                           (unsigned long)State);
     }

--- a/fsw/src/sc_dispatch.c
+++ b/fsw/src/sc_dispatch.c
@@ -221,6 +221,13 @@ void SC_ProcessCommand(const CFE_SB_Buffer_t *BufPtr)
             }
             break;
 
+        case SC_CONTINUE_RTS_ON_FAILURE_CC:
+            if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_ContinueRtsOnFailureCmd_t)))
+            {
+                SC_ContinueRtsOnFailureCmd((const SC_ContinueRtsOnFailureCmd_t *)BufPtr);
+            }
+            break;
+
         case SC_APPEND_ATS_CC:
             if (SC_VerifyCmdLength(&BufPtr->Msg, sizeof(SC_AppendAtsCmd_t)))
             {

--- a/fsw/src/sc_rtsrq.c
+++ b/fsw/src/sc_rtsrq.c
@@ -599,3 +599,33 @@ void SC_AutoStartRts(SC_RtsNum_t RtsNum)
                           "RTS autostart error: invalid RTS ID %u", SC_IDNUM_AS_UINT(RtsNum));
     }
 }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Continue RTS if a command in the RTS fails                     */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void SC_ContinueRtsOnFailureCmd(const SC_ContinueRtsOnFailureCmd_t *Cmd)
+{
+    SC_RtsCont_Enum_t State;
+
+    State = Cmd->Payload.ContinueState;
+
+    if (State != SC_RtsCont_TRUE && State != SC_RtsCont_FALSE)
+    {
+        SC_OperData.HkPacket.Payload.CmdErrCtr++;
+
+        CFE_EVS_SendEvent(SC_CONT_RTS_CMD_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Continue RTS On Failure command  failed, invalid state: %lu", (unsigned long)State);
+    }
+    else
+    {
+        SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = State;
+
+        SC_OperData.HkPacket.Payload.CmdCtr++;
+
+        CFE_EVS_SendEvent(SC_CONT_RTS_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Continue-RTS-On-Failure command, State: %lu",
+                          (unsigned long)State);
+    }
+}

--- a/fsw/src/sc_rtsrq.h
+++ b/fsw/src/sc_rtsrq.h
@@ -177,4 +177,20 @@ void SC_KillRts(SC_RtsIndex_t RtsIndex);
  */
 void SC_AutoStartRts(SC_RtsNum_t RtsNum);
 
+/**
+ * \brief Lets an RTS continue if a command failed the checksum
+ *
+ *  \par Description
+ *         This routine sets whether or not to let an RTS continue when
+ *         one of the commands in the RTS fails a checksum validation
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        None
+ *
+ *  \param[in] Cmd Pointer to Software Bus buffer
+ *
+ *  \sa #SC_CONTINUE_RTS_ON_FAILURE_CC
+ */
+void SC_ContinueRtsOnFailureCmd(const SC_ContinueRtsOnFailureCmd_t *Cmd);
+
 #endif

--- a/fsw/src/sc_verify.h
+++ b/fsw/src/sc_verify.h
@@ -187,10 +187,16 @@
 #error SC_ATS_CMD_STAT_TABLE_NAME must be defined!
 #endif
 
-#ifndef SC_CONT_ON_FAILURE_START
-#error SC_CONT_ON_FAILURE_START must be defined!
-#elif ((SC_CONT_ON_FAILURE_START != SC_AtsCont_TRUE) && (SC_CONT_ON_FAILURE_START != SC_AtsCont_FALSE))
-#error SC_CONT_ON_FAILURE_START must be either SC_AtsCont_TRUE or SC_AtsCont_FALSE!
+#ifndef SC_CONT_ON_ATS_FAILURE_START
+#error SC_CONT_ON_ATS_FAILURE_START must be defined!
+#elif ((SC_CONT_ON_ATS_FAILURE_START != SC_AtsCont_TRUE) && (SC_CONT_ON_ATS_FAILURE_START != SC_AtsCont_FALSE))
+#error SC_CONT_ON_ATS_FAILURE_START must be either SC_AtsCont_TRUE or SC_AtsCont_FALSE!
+#endif
+
+#ifndef SC_CONT_ON_RTS_FAILURE_START
+#error SC_CONT_ON_RTS_FAILURE_START must be defined!
+#elif ((SC_CONT_ON_RTS_FAILURE_START != SC_RtsCont_TRUE) && (SC_CONT_ON_RTS_FAILURE_START != SC_RtsCont_FALSE))
+#error SC_CONT_ON_RTS_FAILURE_START must be either SC_RtsCont_TRUE or SC_RtsCont_FALSE!
 #endif
 
 #ifndef SC_TIME_TO_USE

--- a/unit-test/sc_app_tests.c
+++ b/unit-test/sc_app_tests.c
@@ -168,6 +168,7 @@ void SC_AppInit_Test_NominalPowerOnReset(void)
     Expected_SC_OperData.AtsCmdStatusHandle[1] = 0;
 
     Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_AtsCont_TRUE;
+    Expected_SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = SC_RtsCont_TRUE;
 
     UtAssert_MemCmp(&SC_OperData.CmdPipe, &Expected_SC_OperData.CmdPipe, sizeof(Expected_SC_OperData.CmdPipe), "2");
     UtAssert_MemCmp(&SC_OperData.AtsInfoHandle, &Expected_SC_OperData.AtsInfoHandle,
@@ -214,6 +215,7 @@ void SC_AppInit_Test_Nominal(void)
     Expected_SC_AppData.AutoStartRTS                = SC_RTS_NUM_C(RTS_ID_AUTO_PROCESSOR);
 
     Expected_SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag = SC_AtsCont_TRUE;
+    Expected_SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = SC_RtsCont_TRUE;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);

--- a/unit-test/sc_atsrq_tests.c
+++ b/unit-test/sc_atsrq_tests.c
@@ -953,7 +953,7 @@ void ContinueAtsOnFailureCmd_Test_Nominal(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
-                      SC_CONT_CMD_INF_EID);
+                      SC_CONT_ATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -976,7 +976,7 @@ void ContinueAtsOnFailureCmd_Test_FalseState(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
-                      SC_CONT_CMD_INF_EID);
+                      SC_CONT_ATS_CMD_INF_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
@@ -996,7 +996,7 @@ void ContinueAtsOnFailureCmd_Test_InvalidState(void)
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_CMD_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_ATS_CMD_ERR_EID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 

--- a/unit-test/sc_cmds_tests.c
+++ b/unit-test/sc_cmds_tests.c
@@ -52,11 +52,11 @@ int32 Ut_CFE_TIME_CompareHookAlessthanB(void *UserObj, int32 StubRetcode, uint32
 
 void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     StatusEntryPtr = SC_GetAtsStatusEntryForCommand(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -99,11 +99,11 @@ void SC_ProcessAtpCmd_Test_SwitchCmd(void)
 
 void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_NOOP_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -146,11 +146,11 @@ void SC_ProcessAtpCmd_Test_NonSwitchCmd(void)
 
 void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -197,11 +197,11 @@ void SC_ProcessAtpCmd_Test_InlineSwitchError(void)
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_NOOP_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -248,11 +248,11 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsA(void)
 
 void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_NOOP_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(1);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -299,12 +299,12 @@ void SC_ProcessAtpCmd_Test_SBErrorAtsB(void)
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     bool                          ChecksumValid;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -354,12 +354,12 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsA(void)
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     bool                          ChecksumValid;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(1);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -409,12 +409,12 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsB(void)
 
 void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     bool                          ChecksumValid;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -463,9 +463,9 @@ void SC_ProcessAtpCmd_Test_ChecksumFailedAtsAContinue(void)
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -500,9 +500,9 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsA(void)
 
 void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(1);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -537,7 +537,7 @@ void SC_ProcessAtpCmd_Test_CmdNumberMismatchAtsB(void)
 
 void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
@@ -568,7 +568,7 @@ void SC_ProcessAtpCmd_Test_CmdNotLoaded(void)
 
 void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
@@ -599,7 +599,7 @@ void SC_ProcessAtpCmd_Test_CompareAbsTime(void)
 
 void SC_ProcessAtpCmd_Test_AtpState(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     SC_AtsIndex_t                 AtsIndex = SC_ATS_IDX_C(0);
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
@@ -627,11 +627,11 @@ void SC_ProcessAtpCmd_Test_AtpState(void)
 
 void SC_ProcessAtpCmd_Test_CmdMid(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t             FcnCode   = SC_SWITCH_ATS_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     CmdOffsetRec   = SC_GetAtsEntryOffsetForCmd(AtsIndex, SC_COMMAND_IDX_C(0));
@@ -731,7 +731,8 @@ void SC_ProcessRtpCommand_Test_BadSoftwareBusReturn(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
-void SC_ProcessRtpCommand_Test_BadChecksum(void)
+
+void SC_ProcessRtpCommand_Test_ChecksumFailedRtsContinue(void)
 {
     bool               ChecksumValid;
     SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(0);
@@ -746,6 +747,54 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
 
     SC_AppData.EnableHeaderUpdate = false;
 
+    /* Set ContinueRtsOnFailureFlag to TRUE to test continue behavior */
+    SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = SC_RtsCont_TRUE;
+
+    /* Set to return false in order to generate error message SC_RTS_CHKSUM_CONT_EID */
+    ChecksumValid = false;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ProcessRtpCommand());
+
+    /* Verify results - RTS should continue, not be killed */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.RtsCmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.RtsCmdErrCtr, 1);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 1);
+    UtAssert_UINT32_EQ(RtsInfoPtr->CmdCtr, 0);
+    UtAssert_UINT32_EQ(RtsInfoPtr->CmdErrCtr, 1);
+
+    /* Verify SC_KillRts was NOT called (RTS should continue) */
+    UtAssert_STUB_COUNT(SC_KillRts, 0);
+
+    /* Verify SC_GetNextRtsCommand was called to continue */
+    UtAssert_STUB_COUNT(SC_GetNextRtsCommand, 1);
+
+    SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrSeq, 1);
+    SC_Assert_IDX_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrCmd, 0);
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_RTS_CHKSUM_CONT_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void SC_ProcessRtpCommand_Test_ChecksumFailedRts(void)
+{
+    bool               ChecksumValid;
+    SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(0);
+    SC_RtsInfoEntry_t *RtsInfoPtr;
+
+    RtsInfoPtr = SC_GetRtsInfoObject(RtsIndex);
+
+    SC_AppData.NextCmdTime[SC_Process_RTP]  = 0;
+    SC_AppData.CurrentTime                  = 1;
+    SC_OperData.RtsCtrlBlckAddr->CurrRtsNum = SC_RtsIndexToNum(RtsIndex);
+    RtsInfoPtr->RtsStatus                   = SC_Status_EXECUTING;
+
+    SC_AppData.EnableHeaderUpdate = false;
+
+    /* Set ContinueRtsOnFailureFlag to FALSE to test abort behavior */
+    SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag = SC_RtsCont_FALSE;
+
     /* Set to return false in order to generate error message SC_RTS_CHKSUM_ERR_EID */
     ChecksumValid = false;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_ValidateChecksum), &ChecksumValid, sizeof(ChecksumValid), false);
@@ -753,12 +802,19 @@ void SC_ProcessRtpCommand_Test_BadChecksum(void)
     /* Execute the function being tested */
     UtAssert_VOIDCALL(SC_ProcessRtpCommand());
 
-    /* Verify results */
-    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdCtr == 0, "SC_OperData.HkPacket.Payload.RtsCmdCtr == 0");
-    UtAssert_True(SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1, "SC_OperData.HkPacket.Payload.RtsCmdErrCtr == 1");
-    UtAssert_True(SC_OperData.NumCmdsWakeup == 1, "SC_OperData.NumCmdsWakeup == 1");
+    /* Verify results - RTS should be killed */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.RtsCmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.RtsCmdErrCtr, 1);
+    UtAssert_UINT32_EQ(SC_OperData.NumCmdsWakeup, 1);
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdCtr, 0);
     UtAssert_UINT32_EQ(RtsInfoPtr->CmdErrCtr, 1);
+
+    /* Verify SC_KillRts was called */
+    UtAssert_STUB_COUNT(SC_KillRts, 1);
+
+    /* Verify SC_GetNextRtsCommand was NOT called (RTS was killed) */
+    UtAssert_STUB_COUNT(SC_GetNextRtsCommand, 0);
+
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrSeq, 1);
     SC_Assert_IDX_VALUE(SC_OperData.HkPacket.Payload.LastRtsErrCmd, 0);
 
@@ -923,7 +979,8 @@ void SC_SendHkPacket_Test(void)
     UtAssert_True(SC_OperData.HkPacket.Payload.NextAtsTime == 0, "SC_OperData.HkPacket.Payload.NextAtsTime == 0");
     UtAssert_True(SC_OperData.HkPacket.Payload.NumRtsActive == 20, "SC_OperData.HkPacket.Payload.NumRtsActive == 20");
     SC_Assert_ID_VALUE(SC_OperData.HkPacket.Payload.RtsNum, 21);
-    UtAssert_True(SC_OperData.HkPacket.Payload.NextRtsWakeupCnt == 0, "SC_OperData.HkPacket.Payload.NextRtsWakeupCnt == 0");
+    UtAssert_True(SC_OperData.HkPacket.Payload.NextRtsWakeupCnt == 0,
+                  "SC_OperData.HkPacket.Payload.NextRtsWakeupCnt == 0");
     UtAssert_BOOL_TRUE(SC_OperData.HkPacket.Payload.ContinueAtsOnFailureFlag);
 
     /* Check first element */
@@ -1076,11 +1133,11 @@ void SC_ProcessRequest_Test_WakeupRtpExecutionTime(void)
 
 void SC_ProcessRequest_Test_WakeupAtpExecutionTime(void)
 {
-    SC_AtsEntryHeader_t *         Entry;
+    SC_AtsEntryHeader_t          *Entry;
     CFE_SB_MsgId_t                TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
     CFE_MSG_FcnCode_t             FcnCode   = SC_NOOP_CC;
     SC_AtsIndex_t                 AtsIndex  = SC_ATS_IDX_C(0);
-    SC_AtsCmdStatusEntry_t *      StatusEntryPtr;
+    SC_AtsCmdStatusEntry_t       *StatusEntryPtr;
     SC_AtsCmdEntryOffsetRecord_t *CmdOffsetRec;
 
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
@@ -1119,7 +1176,7 @@ void SC_ProcessRequest_Test_WakeupRtpExecutionTimeTooManyCmds(void)
 
     SC_AppData.NextCmdTime[SC_Process_RTP] = 0;
     SC_AppData.NextCmdTime[SC_Process_ATP] = 0;
-    SC_OperData.NumCmdsWakeup                 = 1000;
+    SC_OperData.NumCmdsWakeup              = 1000;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_EXECUTING;
 
     /* Execute the function being tested */
@@ -1135,7 +1192,7 @@ void SC_ProcessRequest_Test_WakeupAtpExecutionTimeTooManyCmds(void)
 {
     SC_AppData.NextCmdTime[SC_Process_ATP] = 10;
     SC_AppData.CurrentTime                 = 100;
-    SC_OperData.NumCmdsWakeup                 = 1000;
+    SC_OperData.NumCmdsWakeup              = 1000;
     SC_OperData.AtsCtrlBlckAddr->AtpState  = SC_Status_IDLE;
 
     /* Execute the function being tested */
@@ -1664,8 +1721,10 @@ void UtTest_Setup(void)
     UtTest_Add(SC_ProcessRtpCommand_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRtpCommand_Test_Nominal");
     UtTest_Add(SC_ProcessRtpCommand_Test_BadSoftwareBusReturn, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRtpCommand_Test_BadSoftwareBusReturn");
-    UtTest_Add(SC_ProcessRtpCommand_Test_BadChecksum, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRtpCommand_Test_BadChecksum");
+    UtTest_Add(SC_ProcessRtpCommand_Test_ChecksumFailedRtsContinue, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRtpCommand_Test_ChecksumFailedRtsContinue");
+    UtTest_Add(SC_ProcessRtpCommand_Test_ChecksumFailedRts, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessRtpCommand_Test_ChecksumFailedRts");
     UtTest_Add(SC_ProcessRtpCommand_Test_NextCmdTime, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRtpCommand_Test_NextCmdTime");
     UtTest_Add(SC_ProcessRtpCommand_Test_RtsNumZero, SC_Test_Setup, SC_Test_TearDown,
@@ -1680,8 +1739,7 @@ void UtTest_Setup(void)
                "SC_ProcessRequest_Test_HkMIDAutoStartRts");
     UtTest_Add(SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_HkMIDAutoStartRtsLoaded");
-    UtTest_Add(SC_ProcessRequest_Test_WakeupNONE, SC_Test_Setup, SC_Test_TearDown,
-               "SC_ProcessRequest_Test_WakeupNONE");
+    UtTest_Add(SC_ProcessRequest_Test_WakeupNONE, SC_Test_Setup, SC_Test_TearDown, "SC_ProcessRequest_Test_WakeupNONE");
     UtTest_Add(SC_ProcessRequest_Test_WakeupRtpNotExecutionTime, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessRequest_Test_WakeupRtpNotExecutionTime");
     UtTest_Add(SC_ProcessRequest_Test_WakeupNoSwitchPending, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_dispatch_tests.c
+++ b/unit-test/sc_dispatch_tests.c
@@ -498,6 +498,26 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
 }
 
+void SC_ProcessCommand_Test_ContinueRtsOnFailureCmdInvalidLength(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_RTS_ON_FAILURE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(CFE_MSG_Message_t) - 1);
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdCtr, 0);
+    UtAssert_UINT32_EQ(SC_OperData.HkPacket.Payload.CmdErrCtr, 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CMD_LEN_ERR_EID);
+}
+
 void SC_ProcessCommand_Test_AppendAtsCmdInvalidLength(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
@@ -794,6 +814,22 @@ void SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal(void)
     UtAssert_STUB_COUNT(SC_ContinueAtsOnFailureCmd, 1);
 }
 
+void SC_ProcessCommand_Test_ContinueRtsOnFailureCmdNominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_RTS_ON_FAILURE_CC;
+
+    UT_SC_Dispatch_SetMsgId(TestMsgId);
+    UT_SC_Dispatch_SetFcnCode(FcnCode);
+    UT_SC_Dispatch_SetMsgSize(sizeof(SC_ContinueRtsOnFailureCmd_t));
+
+    /* Execute the function being tested */
+    SC_ProcessCommand(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(SC_ContinueRtsOnFailureCmd, 1);
+}
+
 void SC_ProcessCommand_Test_AppendAtsCmdNominal(void)
 {
     CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
@@ -976,6 +1012,8 @@ void UtTest_Setup(void)
                "SC_ProcessCommand_Test_JumpAtsCmdNominal");
     UtTest_Add(SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_ContinueAtsOnFailureCmdNominal");
+    UtTest_Add(SC_ProcessCommand_Test_ContinueRtsOnFailureCmdNominal, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ContinueRtsOnFailureCmdNominal");
     UtTest_Add(SC_ProcessCommand_Test_AppendAtsCmdNominal, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_AppendAtsCmdNominal");
     UtTest_Add(SC_ProcessCommand_Test_TableManageCmdNominal, SC_Test_Setup, SC_Test_TearDown,
@@ -1011,6 +1049,8 @@ void UtTest_Setup(void)
                "SC_ProcessCommand_Test_JumpAtsCmdInvalidLength");
     UtTest_Add(SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_ContinueAtsOnFailureCmdInvalidLength");
+    UtTest_Add(SC_ProcessCommand_Test_ContinueRtsOnFailureCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
+               "SC_ProcessCommand_Test_ContinueRtsOnFailureCmdInvalidLength");
     UtTest_Add(SC_ProcessCommand_Test_AppendAtsCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,
                "SC_ProcessCommand_Test_AppendAtsCmdInvalidLength");
     UtTest_Add(SC_ProcessCommand_Test_TableManageCmdInvalidLength, SC_Test_Setup, SC_Test_TearDown,

--- a/unit-test/sc_rtsrq_tests.c
+++ b/unit-test/sc_rtsrq_tests.c
@@ -1062,6 +1062,72 @@ void SC_AutoStartRts_Test_InvalidIdZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
+void ContinueRtsOnFailureCmd_Test_Nominal(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_RTS_ON_FAILURE_CC;
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueRtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+
+    UT_CmdBuf.ContinueRtsOnFailureCmd.Payload.ContinueState = SC_RtsCont_TRUE;
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ContinueRtsOnFailureCmd(&UT_CmdBuf.ContinueRtsOnFailureCmd));
+
+    /* Verify results */
+    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag == SC_RtsCont_TRUE,
+                  "SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag == SC_RtsCont_TRUE");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_CONT_RTS_CMD_INF_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void ContinueRtsOnFailureCmd_Test_FalseState(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_RTS_ON_FAILURE_CC;
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueRtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+
+    UT_CmdBuf.ContinueRtsOnFailureCmd.Payload.ContinueState = SC_RtsCont_FALSE;
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ContinueRtsOnFailureCmd(&UT_CmdBuf.ContinueRtsOnFailureCmd));
+
+    /* Verify results */
+    UtAssert_True(SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag == SC_RtsCont_FALSE,
+                  "SC_OperData.HkPacket.Payload.ContinueRtsOnFailureFlag == SC_RtsCont_FALSE");
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdCtr == 1, "SC_OperData.HkPacket.Payload.CmdCtr == 1");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID,
+                      SC_CONT_RTS_CMD_INF_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void ContinueRtsOnFailureCmd_Test_InvalidState(void)
+{
+    CFE_SB_MsgId_t    TestMsgId = CFE_SB_ValueToMsgId(SC_CMD_MID);
+    CFE_MSG_FcnCode_t FcnCode   = SC_CONTINUE_RTS_ON_FAILURE_CC;
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(SC_ContinueRtsOnFailureCmd_t), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+
+    UT_CmdBuf.ContinueRtsOnFailureCmd.Payload.ContinueState = (SC_RtsCont_Enum_t)99;
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(SC_ContinueRtsOnFailureCmd(&UT_CmdBuf.ContinueRtsOnFailureCmd));
+
+    /* Verify results */
+    UtAssert_True(SC_OperData.HkPacket.Payload.CmdErrCtr == 1, "SC_OperData.HkPacket.Payload.CmdErrCtr == 1");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_CONT_RTS_CMD_ERR_EID);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
 void UtTest_Setup(void)
 {
     UtTest_Add(SC_StartRtsCmd_Test_Nominal, SC_Test_Setup, SC_Test_TearDown, "SC_StartRtsCmd_Test_Nominal");
@@ -1152,4 +1218,10 @@ void UtTest_Setup(void)
     UtTest_Add(SC_AutoStartRts_Test_InvalidId, SC_Test_Setup, SC_Test_TearDown, "SC_AutoStartRts_Test_InvalidId");
     UtTest_Add(SC_AutoStartRts_Test_InvalidIdZero, SC_Test_Setup, SC_Test_TearDown,
                "SC_AutoStartRts_Test_InvalidIdZero");
+    UtTest_Add(ContinueRtsOnFailureCmd_Test_Nominal, SC_Test_Setup, SC_Test_TearDown,
+               "ContinueRtsOnFailureCmd_Test_Nominal");
+    UtTest_Add(ContinueRtsOnFailureCmd_Test_FalseState, SC_Test_Setup, SC_Test_TearDown,
+               "ContinueRtsOnFailureCmd_Test_FalseState");
+    UtTest_Add(ContinueRtsOnFailureCmd_Test_InvalidState, SC_Test_Setup, SC_Test_TearDown,
+               "ContinueRtsOnFailureCmd_Test_InvalidState");
 }

--- a/unit-test/stubs/sc_rtsrq_stubs.c
+++ b/unit-test/stubs/sc_rtsrq_stubs.c
@@ -145,3 +145,15 @@ void SC_StopRtsGrpCmd(const SC_StopRtsGrpCmd_t *Cmd)
 
     UT_GenStub_Execute(SC_StopRtsGrpCmd, Basic, NULL);
 }
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for SC_ContinueRtsOnFailureCmd()
+ * ----------------------------------------------------
+ */
+void SC_ContinueRtsOnFailureCmd(const SC_ContinueRtsOnFailureCmd_t *Cmd)
+{
+    UT_GenStub_AddParam(SC_ContinueRtsOnFailureCmd, const SC_ContinueRtsOnFailureCmd_t *, Cmd);
+
+    UT_GenStub_Execute(SC_ContinueRtsOnFailureCmd, Basic, NULL);
+}

--- a/unit-test/utilities/sc_test_utils.h
+++ b/unit-test/utilities/sc_test_utils.h
@@ -72,6 +72,7 @@ typedef union
     SC_EnableRtsCmd_t            EnableRtsCmd;
     SC_JumpAtsCmd_t              JumpAtsCmd;
     SC_ContinueAtsOnFailureCmd_t ContinueAtsOnFailureCmd;
+    SC_ContinueRtsOnFailureCmd_t ContinueRtsOnFailureCmd;
     SC_AppendAtsCmd_t            AppendAtsCmd;
     SC_ManageTableCmd_t          ManageTableCmd;
     SC_StartRtsGrpCmd_t          StartRtsGrpCmd;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
  - Fixes #11 
    - Adds configurable continue-on-checksum-failure capability for RTS tables (like we have already for ATS tables)

**Expected behavior changes**
  - When an RTS command fails checksum validation:
    - If `ContinueRtsOnFailureFlag` is `FALSE`: The RTS is aborted (calls `SC_KillRts`) and event `SC_RTS_CHKSUM_ERR_EID` is sent
    - If `ContinueRtsOnFailureFlag` is `TRUE`: RTS continues with the next command (calls `SC_GetNextRtsCommand`), and event `SC_RTS_CHKSUM_CONT_EID` is sent
  - Default behavior is to continue RTS execution on checksum failure (set in the config via `SC_CONT_ON_RTS_FAILURE_START`) - same as the default for ATS

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt