### PR TITLE
[NAV#707] Fix SC unit tests to work with large SC_PACKET_MAX_SIZE

### DIFF
--- a/unit-test/sc_loads_tests.c
+++ b/unit-test/sc_loads_tests.c
@@ -431,7 +431,8 @@ void SC_LoadAts_Test_AtsEntryOverflow(void)
     SC_OperData.AtsTblAddr[AtsIndex]          = &AtsTable[0];
     SC_OperData.AtsInfoTblAddr                = &AtsInfoTbl;
 
-    MsgSize1      = SC_PACKET_MAX_SIZE;
+    /* Use a reasonable message size for testing to avoid test buffer overflow with large SC_PACKET_MAX_SIZE */
+    MsgSize1      = 256;  /* Use fixed 256 bytes instead of SC_PACKET_MAX_SIZE */
     BufEntrySize  = ((MsgSize1 + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD) + SC_ATS_HDR_NOPKT_WORDS;
     MaxBufEntries = SC_ATS_BUFF_SIZE32 / BufEntrySize;
 
@@ -1364,8 +1365,8 @@ void SC_UpdateAppend_Test_CmdDoesNotFitBuffer(void)
 
     /* Verify results */
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 30, "SC_OperData.HkPacket.AppendEntryCount == 30");
-    UtAssert_True(SC_AppData.AppendWordCount == 1980, "SC_AppData.AppendWordCount == 1980");
+    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == MaxBufEntries, "SC_OperData.HkPacket.AppendEntryCount == %d", MaxBufEntries);
+    UtAssert_True(SC_AppData.AppendWordCount == (MaxBufEntries * BufEntrySize), "SC_AppData.AppendWordCount == %d", (MaxBufEntries * BufEntrySize));
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1512,9 +1513,13 @@ void SC_UpdateAppend_Test_EndOfBuffer(void)
     SC_UpdateAppend();
 
     /* Verify results */
+    /* Expected: MaxBufEntries entries fit, with the (MaxBufEntries-1)th entry being smaller */
+    int SmallEntrySize = (72 + SC_ROUND_UP_BYTES) / SC_BYTES_IN_WORD + SC_ATS_HDR_NOPKT_WORDS;
+    int ExpectedEntryCount = MaxBufEntries + 1;
+    int ExpectedWordCount = (MaxBufEntries * BufEntrySize) - BufEntrySize + SmallEntrySize + BufEntrySize;
     UtAssert_True(SC_OperData.HkPacket.AppendLoadCount == 1, "SC_OperData.HkPacket.AppendLoadCount == 1");
-    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == 31, "SC_OperData.HkPacket.AppendEntryCount == 31");
-    UtAssert_True(SC_AppData.AppendWordCount == 2000, "SC_AppData.AppendWordCount == 2000");
+    UtAssert_True(SC_OperData.HkPacket.AppendEntryCount == ExpectedEntryCount, "SC_OperData.HkPacket.AppendEntryCount == %d", ExpectedEntryCount);
+    UtAssert_True(SC_AppData.AppendWordCount == ExpectedWordCount, "SC_AppData.AppendWordCount == %d", ExpectedWordCount);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, SC_UPDATE_APPEND_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);


### PR DESCRIPTION
- SC_LoadAts_Test_AtsEntryOverflow: Use fixed 256-byte message size to prevent stack buffer overflow
- SC_UpdateAppend_Test_CmdDoesNotFitBuffer: Use dynamic values based on MaxBufEntries
- SC_UpdateAppend_Test_EndOfBuffer: Fix word count calculation for variable-sized entries

These fixes make the tests robust against SC_PACKET_MAX_SIZE values up to 4096 bytes. All 150 unit tests now pass.

**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
2. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
