### PR TITLE
Fix #174, Remove Dead Functions

### DIFF
--- a/unit-test/sc_state_tests.c
+++ b/unit-test/sc_state_tests.c
@@ -41,20 +41,6 @@
 /*
  * Function Definitions
  */
-uint8 SC_STATE_TEST_GetTotalMsgLengthHook_RunCount;
-int32 SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook(void                   *UserObj,
-                                                 int32                   StubRetcode,
-                                                 uint32                  CallCount,
-                                                 const UT_StubContext_t *Context)
-{
-    SC_STATE_TEST_GetTotalMsgLengthHook_RunCount += 1;
-
-    if (SC_STATE_TEST_GetTotalMsgLengthHook_RunCount == 1)
-        return SC_PACKET_MAX_SIZE;
-    else
-        return SC_PACKET_MAX_SIZE + 100;
-}
-
 void SC_GetNextRtsTime_Test_Nominal(void)
 {
     SC_RtsIndex_t      RtsIndex = SC_RTS_IDX_C(0);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #174

**Testing performed**
Ran the native_std commands which includes prep, install, runtest, and lcov. Compared these lcov results against the unchanged cFS bundle and found no changes. Ran the old build commands with unit tests enabled to ensure that the internal static code analysis tool no longer flags these functions. Also ran the bundle with -Wunused flags which only flagged unrelated macros.

**Expected behavior changes**
Removes SC_STATE_TEST_CFE_SB_GetTotalMsgLengthHook

**System(s) tested on**
RedHat, cFS dev

**Additional context**
Lcov bundle results using native_std:
```
Overall coverage rate:
  lines......: 99.2% (30304 of 30537 lines)
  functions..: 99.2% (2428 of 2447 functions)
  branches...: no data found
```
Lcov bundle results using the old build commands:
```
Overall coverage rate:
  lines......: 99.2% (30167 of 30396 lines)
  functions..: 99.2% (2417 of 2436 functions)
  branches...: 98.7% (12931 of 13095 branches)
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
