### PR TITLE
Fix nasa/sc#176, Replaced zero with NULL in #define SC_MEMBER_SIZE.

### DIFF
--- a/fsw/tables/sc_ats1.c
+++ b/fsw/tables/sc_ats1.c
@@ -94,7 +94,7 @@ typedef union
 } SC_AtsTable1_t;
 
 /* Helper macro to get size of structure elements */
-#define SC_MEMBER_SIZE(member) (sizeof(((SC_AtsStruct1_t *)0)->member))
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_AtsStruct1_t *)NULL)->member))
 
 /* Used designated intializers to be verbose, modify as needed/desired */
 SC_AtsTable1_t SC_Ats1 = {

--- a/fsw/tables/sc_rts001.c
+++ b/fsw/tables/sc_rts001.c
@@ -72,7 +72,7 @@ typedef union
 } SC_RtsTable001_t;
 
 /* Helper macro to get size of structure elements */
-#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct001_t *)0)->member))
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct001_t *)NULL)->member))
 
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable001_t SC_Rts001 = {

--- a/fsw/tables/sc_rts002.c
+++ b/fsw/tables/sc_rts002.c
@@ -66,7 +66,7 @@ typedef union
 } SC_RtsTable002_t;
 
 /* Helper macro to get size of structure elements */
-#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct002_t *)0)->member))
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct002_t *)NULL)->member))
 
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable002_t SC_Rts002 = {

--- a/fsw/tables/sc_rts003.c
+++ b/fsw/tables/sc_rts003.c
@@ -66,7 +66,7 @@ typedef union
 } SC_RtsTable003_t;
 
 /* Helper macro to get size of structure elements */
-#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct003_t *)0)->member))
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct003_t *)NULL)->member))
 
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable003_t SC_Rts003 = {

--- a/fsw/tables/sc_rts004.c
+++ b/fsw/tables/sc_rts004.c
@@ -66,7 +66,7 @@ typedef union
 } SC_RtsTable004_t;
 
 /* Helper macro to get size of structure elements */
-#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct004_t *)0)->member))
+#define SC_MEMBER_SIZE(member) (sizeof(((SC_RtsStruct004_t *)NULL)->member))
 
 /* Used designated initializers to be verbose, modify as needed/desired */
 SC_RtsTable004_t SC_Rts004 = {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/SC/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes https://github.com/nasa/SC/issues/176 - Replaced zero with NULL in #define SC_MEMBER_SIZE.

**Testing performed**
Ran the Axle static code analysis tool and it no longer reported any findings in `sc_ats1.c`, `sc_rts001.c`, `sc_rts002.c`, `sc_rts003.c`, and `sc_rts004.c` when I ran the `literal-zero-used-as-null-pointer` query.

**Expected behavior changes**
 No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Linux 9.8

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang / NASA GSFC
